### PR TITLE
Update spk CMD --help to include description of command

### DIFF
--- a/spk/cli/_cmd_bake.py
+++ b/spk/cli/_cmd_bake.py
@@ -22,7 +22,9 @@ def register(
     sub_parsers: argparse._SubParsersAction, **parser_args: Any
 ) -> argparse.ArgumentParser:
 
-    bake_cmd = sub_parsers.add_parser("bake", help=_bake.__doc__, **parser_args)
+    bake_cmd = sub_parsers.add_parser(
+        "bake", help=_bake.__doc__, description=_bake.__doc__, **parser_args
+    )
     bake_cmd.add_argument(
         "package",
         metavar="PKG",

--- a/spk/cli/_cmd_build.py
+++ b/spk/cli/_cmd_build.py
@@ -18,7 +18,9 @@ def register(
     sub_parsers: argparse._SubParsersAction, **parser_args: Any
 ) -> argparse.ArgumentParser:
 
-    build_cmd = sub_parsers.add_parser("build", help=_build.__doc__, **parser_args)
+    build_cmd = sub_parsers.add_parser(
+        "build", help=_build.__doc__, description=_build.__doc__, **parser_args
+    )
     build_cmd.add_argument(
         "--interactive",
         "-i",

--- a/spk/cli/_cmd_convert.py
+++ b/spk/cli/_cmd_convert.py
@@ -21,7 +21,7 @@ def register(
 ) -> argparse.ArgumentParser:
 
     convert_cmd = sub_parsers.add_parser(
-        "convert", help=_convert.__doc__, **parser_args
+        "convert", help=_convert.__doc__, description=_convert.__doc__, **parser_args
     )
 
     sub_parsers = convert_cmd.add_subparsers(dest="converter")

--- a/spk/cli/_cmd_deprecate.py
+++ b/spk/cli/_cmd_deprecate.py
@@ -21,7 +21,10 @@ def register(
 ) -> argparse.ArgumentParser:
 
     deprecate_cmd = sub_parsers.add_parser(
-        "deprecate", help=_deprecate.__doc__, **parser_args
+        "deprecate",
+        help=_deprecate.__doc__,
+        description=_deprecate.__doc__,
+        **parser_args,
     )
     deprecate_cmd.add_argument(
         "packages", metavar="PKG", nargs="+", help="The packages to deprecate"

--- a/spk/cli/_cmd_env.py
+++ b/spk/cli/_cmd_env.py
@@ -22,7 +22,11 @@ def register(
 ) -> argparse.ArgumentParser:
 
     env_cmd = sub_parsers.add_parser(
-        "env", aliases=["run"], help=_env.__doc__, **parser_args
+        "env",
+        aliases=["run"],
+        help=_env.__doc__,
+        description=_env.__doc__,
+        **parser_args
     )
     env_cmd.add_argument(
         "args",

--- a/spk/cli/_cmd_explain.py
+++ b/spk/cli/_cmd_explain.py
@@ -20,7 +20,7 @@ def register(
 ) -> argparse.ArgumentParser:
 
     explain_cmd = sub_parsers.add_parser(
-        "explain", help=_explain.__doc__, **parser_args
+        "explain", help=_explain.__doc__, description=_explain.__doc__, **parser_args
     )
     _flags.add_solver_flags(explain_cmd)
     _flags.add_request_flags(explain_cmd)

--- a/spk/cli/_cmd_export.py
+++ b/spk/cli/_cmd_export.py
@@ -19,7 +19,9 @@ def register(
     sub_parsers: argparse._SubParsersAction, **parser_args: Any
 ) -> argparse.ArgumentParser:
 
-    export_cmd = sub_parsers.add_parser("export", help=_export.__doc__, **parser_args)
+    export_cmd = sub_parsers.add_parser(
+        "export", help=_export.__doc__, description=_export.__doc__, **parser_args
+    )
     export_cmd.add_argument(
         "packages", metavar="PKG", nargs="+", help="The packages to export"
     )

--- a/spk/cli/_cmd_import.py
+++ b/spk/cli/_cmd_import.py
@@ -18,7 +18,9 @@ def register(
     sub_parsers: argparse._SubParsersAction, **parser_args: Any
 ) -> argparse.ArgumentParser:
 
-    import_cmd = sub_parsers.add_parser("import", help=_import.__doc__, **parser_args)
+    import_cmd = sub_parsers.add_parser(
+        "import", help=_import.__doc__, description=_import.__doc__, **parser_args
+    )
 
     import_cmd.add_argument(
         "packages", metavar="FILE|NAME", nargs="+", help="The packages to import"

--- a/spk/cli/_cmd_install.py
+++ b/spk/cli/_cmd_install.py
@@ -23,7 +23,11 @@ def register(
 ) -> argparse.ArgumentParser:
 
     install_cmd = sub_parsers.add_parser(
-        "install", aliases=["i"], help=_install.__doc__, **parser_args
+        "install",
+        aliases=["i"],
+        help=_install.__doc__,
+        description=_install.__doc__,
+        **parser_args,
     )
     install_cmd.add_argument(
         "packages", metavar="PKG", nargs="+", help="The packages to install"

--- a/spk/cli/_cmd_ls.py
+++ b/spk/cli/_cmd_ls.py
@@ -21,7 +21,7 @@ def register(
 ) -> argparse.ArgumentParser:
 
     ls_cmd = sub_parsers.add_parser(
-        "ls", aliases=["list"], help=_ls.__doc__, **parser_args
+        "ls", aliases=["list"], help=_ls.__doc__, description=_ls.__doc__, **parser_args
     )
     ls_cmd.add_argument(
         "package",

--- a/spk/cli/_cmd_make_binary.py
+++ b/spk/cli/_cmd_make_binary.py
@@ -22,6 +22,7 @@ def register(
         "make-binary",
         aliases=["mkbinary", "mkbin", "mkb"],
         help=_make_binary.__doc__,
+        description=_make_binary.__doc__,
         **parser_args
     )
     mkb_cmd.add_argument(

--- a/spk/cli/_cmd_make_source.py
+++ b/spk/cli/_cmd_make_source.py
@@ -22,6 +22,7 @@ def register(
         "make-source",
         aliases=["mksource", "mksrc", "mks"],
         help=_make_source.__doc__,
+        description=_make_source.__doc__,
         **parser_args,
     )
     make_source_cmd.add_argument(

--- a/spk/cli/_cmd_new.py
+++ b/spk/cli/_cmd_new.py
@@ -16,7 +16,9 @@ def register(
     sub_parsers: argparse._SubParsersAction, **parser_args: Any
 ) -> argparse.ArgumentParser:
 
-    new_cmd = sub_parsers.add_parser("new", help=_new.__doc__, **parser_args)
+    new_cmd = sub_parsers.add_parser(
+        "new", help=_new.__doc__, description=_new.__doc__, **parser_args
+    )
     new_cmd.add_argument(
         "name", metavar="NAME", nargs=1, help="The name of the new package"
     )

--- a/spk/cli/_cmd_publish.py
+++ b/spk/cli/_cmd_publish.py
@@ -17,7 +17,7 @@ def register(
 ) -> argparse.ArgumentParser:
 
     publish_cmd = sub_parsers.add_parser(
-        "publish", help=_publish.__doc__, **parser_args
+        "publish", help=_publish.__doc__, description=_publish.__doc__, **parser_args
     )
     publish_cmd.add_argument(
         "packages", metavar="PKG", nargs="+", help="The local package to publish"

--- a/spk/cli/_cmd_remove.py
+++ b/spk/cli/_cmd_remove.py
@@ -21,7 +21,11 @@ def register(
 ) -> argparse.ArgumentParser:
 
     remove_cmd = sub_parsers.add_parser(
-        "remove", aliases=["rm"], help=_remove.__doc__, **parser_args
+        "remove",
+        aliases=["rm"],
+        help=_remove.__doc__,
+        description=_remove.__doc__,
+        **parser_args,
     )
     remove_cmd.add_argument(
         "--yes", action="store_true", help="Do not ask for confirmations (dangerous!)"

--- a/spk/cli/_cmd_render.py
+++ b/spk/cli/_cmd_render.py
@@ -22,7 +22,9 @@ def register(
     sub_parsers: argparse._SubParsersAction, **parser_args: Any
 ) -> argparse.ArgumentParser:
 
-    render_cmd = sub_parsers.add_parser("render", help=_render.__doc__, **parser_args)
+    render_cmd = sub_parsers.add_parser(
+        "render", help=_render.__doc__, description=_render.__doc__, **parser_args
+    )
     render_cmd.add_argument(
         "packages", metavar="PKG", nargs="+", help="The packages to resolve and render"
     )

--- a/spk/cli/_cmd_search.py
+++ b/spk/cli/_cmd_search.py
@@ -19,7 +19,9 @@ def register(
     sub_parsers: argparse._SubParsersAction, **parser_args: Any
 ) -> argparse.ArgumentParser:
 
-    search_cmd = sub_parsers.add_parser("search", help=_search.__doc__, **parser_args)
+    search_cmd = sub_parsers.add_parser(
+        "search", help=_search.__doc__, description=_search.__doc__, **parser_args
+    )
     _flags.add_repo_flags(search_cmd)
     search_cmd.add_argument("term", metavar="TERM", help="The search term / substring")
     search_cmd.set_defaults(func=_search)

--- a/spk/cli/_cmd_test.py
+++ b/spk/cli/_cmd_test.py
@@ -19,7 +19,9 @@ def register(
     sub_parsers: argparse._SubParsersAction, **parser_args: Any
 ) -> argparse.ArgumentParser:
 
-    test_cmd = sub_parsers.add_parser("test", help=_test.__doc__, **parser_args)
+    test_cmd = sub_parsers.add_parser(
+        "test", help=_test.__doc__, description=_test.__doc__, **parser_args
+    )
     test_cmd.add_argument(
         "--here",
         action="store_true",

--- a/spk/cli/_cmd_version.py
+++ b/spk/cli/_cmd_version.py
@@ -13,7 +13,7 @@ def register(
 ) -> argparse.ArgumentParser:
 
     version_cmd = sub_parsers.add_parser(
-        "version", help=_version.__doc__, **parser_args
+        "version", help=_version.__doc__, description=_version.__doc__, **parser_args
     )
     version_cmd.set_defaults(func=_version)
     return version_cmd

--- a/spk/cli/_cmd_view.py
+++ b/spk/cli/_cmd_view.py
@@ -22,7 +22,11 @@ def register(
 ) -> argparse.ArgumentParser:
 
     view_cmd = sub_parsers.add_parser(
-        "view", aliases=["info"], help=_view.__doc__, **parser_args
+        "view",
+        aliases=["info"],
+        help=_view.__doc__,
+        description=_view.__doc__,
+        **parser_args,
     )
     view_cmd.add_argument(
         "package",

--- a/spk/cli/_run.py
+++ b/spk/cli/_run.py
@@ -11,7 +11,13 @@ from colorama import Fore
 
 import spk
 
-from ._args import parse_args, configure_logging, configure_sentry, configure_spops, spops
+from ._args import (
+    parse_args,
+    configure_logging,
+    configure_sentry,
+    configure_spops,
+    spops,
+)
 
 
 def main() -> None:


### PR DESCRIPTION
Re-uses the same help messages that are already there, but also makes them show up in the `spk CMD --help` output as well

Closes #13 