### PR TITLE
Add package specs for imath, openexr, opencolorio, pybind11

### DIFF
--- a/packages/aswf/imath.spk.yaml
+++ b/packages/aswf/imath.spk.yaml
@@ -1,0 +1,58 @@
+pkg: imath/3.0.1
+
+sources:
+  # This idiom can work with any of (a) a local clone, (b) a git submodule,
+  # or (c) nothing (does a fresh clone from GitHub).
+  - path: ./
+  - script:
+    - if [ ! -d Imath ] ; then git clone https://github.com/AcademySoftwareFoundation/Imath -b v3.0.1 ; fi
+
+
+build:
+  options:
+    - var: arch
+    - var: os
+    - var: centos
+    - pkg: gcc/6.3
+    - pkg: python/3.7
+    - pkg: numpy
+    - pkg: cmake/^3.13
+    - pkg: boost/1.70
+  variants:
+    - { gcc: 6.3, python: 2.7, boost: 1.70 }
+    - { gcc: 6.3, python: 3.7, boost: 1.70 }
+    - { gcc: 9.3, python: 2.7, boost: 1.70 }
+    - { gcc: 9.3, python: 3.7, boost: 1.70 }
+  script:
+    - cmake -S Imath -B build -G Ninja
+        -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_PREFIX_PATH=/spfs
+        -DCMAKE_INSTALL_PREFIX=/spfs
+        -DPYTHON=ON
+        -DUSE_PYTHON${SPK_PKG_python_VERSION_MAJOR}=ON
+    - cmake --build build --target install
+
+install:
+  requirements:
+    - pkg: gcc
+      fromBuildEnv: x.x
+    - pkg: boost
+      fromBuildEnv: x.x
+    - pkg: python
+      fromBuildEnv: x.x
+      include: IfAlreadyPresent
+    - pkg: numpy
+      include: IfAlreadyPresent
+
+tests:
+  - stage: build
+    script:
+      - cmake -S Imath -B build -G Ninja
+          -DCMAKE_BUILD_TYPE=Release
+          -DCMAKE_PREFIX_PATH=/spfs
+          -DCMAKE_INSTALL_PREFIX=/spfs
+          -DPYTHON=ON
+          -DUSE_PYTHON${SPK_PKG_python_VERSION_MAJOR}=ON
+      - cmake --build build
+      - cd build
+      - ctest

--- a/packages/aswf/opencolorio.spk.yaml
+++ b/packages/aswf/opencolorio.spk.yaml
@@ -1,0 +1,45 @@
+pkg: opencolorio/2.0.0
+
+sources:
+  # This idiom can work with any of (a) a local clone, (b) a git submodule,
+  # or (c) nothing (does a fresh clone from GitHub).
+  - path: ./
+  - script:
+    - if [ ! -d OpenColorIO ] ; then git clone https://github.com/AcademySoftwareFoundation/OpenColorIO -b v2.0.0 ; fi
+
+
+build:
+  options:
+    - var: arch
+    - var: os
+    - var: centos
+    - pkg: gcc/6.3
+    - pkg: python/3.7
+    - pkg: pybind11/2.6.2
+    - pkg: cmake/^3.13
+
+  variants:
+    - { gcc: 6.3, python: 2.7 }
+    - { gcc: 6.3, python: 3.7 }
+    - { gcc: 9.3, python: 2.7 }
+    - { gcc: 9.3, python: 3.7 }
+
+  script:
+    - cmake -S OpenColorIO -B build -G Ninja
+        -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_PREFIX_PATH=/spfs
+        -DCMAKE_INSTALL_PREFIX=/spfs
+        -DOCIO_BUILD_TESTS=OFF
+        -DPYBIND11_PYTHON_VERSION="${SPK_OPT_python}" 
+    - cmake --build build --target install
+
+install:
+  requirements:
+    - pkg: gcc
+      fromBuildEnv: x.x
+    - pkg: python
+      fromBuildEnv: x.x
+      # If python is already in the environment/resolve then we
+      # we require it to be compatible with what we built with.
+      # But no python at all is also okay.
+      include: IfAlreadyPresent

--- a/packages/aswf/openexr.spk.yaml
+++ b/packages/aswf/openexr.spk.yaml
@@ -1,0 +1,47 @@
+pkg: openexr/3.0.1
+
+sources:
+  # This idiom can work with any of (a) a local clone, (b) a git submodule,
+  # or (c) nothing (does a fresh clone from GitHub).
+  - path: ./
+  - script:
+    - if [ ! -d openexr ] ; then git clone https://github.com/AcademySoftwareFoundation/openexr -b v3.0.1 ; fi
+
+
+build:
+  options:
+    - var: arch
+    - var: os
+    - var: centos
+    - pkg: gcc/6.3
+    - pkg: cmake/^3.13
+    - pkg: imath/3.0.1
+
+  variants:
+    - { gcc: 6.3 }
+    - { gcc: 9.3 }
+
+  script:
+    - cmake -S openexr -B build -G Ninja
+        -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_PREFIX_PATH=/spfs
+        -DCMAKE_INSTALL_PREFIX=/spfs
+    - cmake --build build --target install
+
+install:
+  requirements:
+    - pkg: gcc
+      fromBuildEnv: x.x
+    - pkg: imath
+      fromBuildEnv: x.x
+
+tests:
+  - stage: build
+    script:
+      - cmake -S openexr -B build -G Ninja
+          -DCMAKE_BUILD_TYPE=Release
+          -DCMAKE_PREFIX_PATH=/spfs
+          -DCMAKE_INSTALL_PREFIX=/spfs
+      - cmake --build build
+      - cd build
+      - ctest

--- a/packages/python/pybind11.spk.yaml
+++ b/packages/python/pybind11.spk.yaml
@@ -1,0 +1,27 @@
+pkg: pybind11/2.6.2
+
+sources:
+  # This idiom can work with any of (a) a local clone, (b) a git submodule,
+  # or (c) nothing (does a fresh clone from GitHub).
+  - path: ./
+  - script:
+    - if [ ! -d pybind11 ] ; then git clone https://github.com/pybind11/pybind11 -b v2.6.2 ; fi
+
+build:
+  options:
+    - var: arch
+    - var: os
+    - var: centos
+    - pkg: cmake
+    - pkg: python/3.7
+  variants:
+    - { python: 2.7 }
+    - { python: 3.7 }
+  script:
+    - cmake -S pybind11 -B build
+        -DCMAKE_PREFIX_PATH=/spfs
+        -DCMAKE_INSTALL_PREFIX=/spfs
+        -DCMAKE_MODULE_PATH=$PWD/pybind11
+        -DPYBIND11_PYTHON_VERSION="${SPK_OPT_python}"
+        -DPYBIND11_TEST=OFF
+    - cmake --build build --target install


### PR DESCRIPTION
Example package specs for some VFX things.

These should work for others. Though the imath one depends on boost (for the python bindings), and I think we haven't posted a boost package spec yet.

Signed-off-by: Larry Gritz <lg@imageworks.com>