### PR TITLE
Fix: src.exclude to src.filter

### DIFF
--- a/spk/api/_source_spec.py
+++ b/spk/api/_source_spec.py
@@ -104,7 +104,7 @@ class LocalSource(SourceSpec):
             ), "LocalSource.exclude must be a list of strings"
 
         if "filter" in data:
-            src.exclude = data.pop("filter")
+            src.filter = data.pop("filter")
             assert isinstance(
                 src.filter, list
             ), "LocalSource.filter must be a list of strings"


### PR DESCRIPTION
Fixing storage variable used for filters
Signed-off-by: Dan Sheerin <dsheerin@imageworks.com>