### PR TITLE
Make filename absolute path in export_package

### DIFF
--- a/spk/storage/_archive.py
+++ b/spk/storage/_archive.py
@@ -20,6 +20,11 @@ _LOGGER = structlog.get_logger("spk.storage")
 
 
 def export_package(pkg: Union[str, api.Ident], filename: str) -> None:
+
+    # Make filename absolute as spfs::runtime::makedirs_with_perms does not handle
+    # relative paths properly.
+    filename = os.path.abspath(filename)
+
     if not isinstance(pkg, api.Ident):
         pkg = api.parse_ident(pkg)
 


### PR DESCRIPTION
Running `make packages` results in the following error for the `spk export stdfs/stdfs.spk.yaml stdfs/stdfs.spk` operation (seen in https://github.com/imageworks/spfs/issues/16):
```
Permission denied (os error 13)
```
After some investigation, it turns out that `spfs::runtime::makedirs_with_perms`, called through `TarRepository::create`, during the export operation does not handle relative paths properly.  Specifically in this case, when "stdfs" is passed into `makedirs_with_perms`, it tries to create a "/stdfs" directory.

The proposed solution is to simply absolutify `filename` in the `export_package` python call.

As a side - would it also make sense for `makedirs_with_perms` to handle relative paths gracefully?