### PR TITLE
Example package spec and build script for LLVM+Clang 12

### DIFF
--- a/packages/llvm/build.sh
+++ b/packages/llvm/build.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+# Note: This script should build for either Rez or spk or neither, it tries
+# to decide based on the presence of the Rez or Spk env variables.
+
+# Terminate the script on error
+set -e
+
+echo "Running custom build script for LLVM"
+echo "Environment contains:"
+env | sort
+
+if [[ "${REZ_BUILD_ENV}" != "" ]] ; then
+    BUILD_SCHEME=rez
+    INSTALL_PREFIX=${REZ_BUILD_INSTALL_PATH}
+    SOURCE_DIR="${REZ_BUILD_SOURCE_PATH}/llvm-project/llvm"
+    BUILD_DIR=.
+elif [[ "${SPK_PKG_NAME}" != "" ]] ; then
+    BUILD_SCHEME=spk
+    INSTALL_PREFIX=/spfs
+    SOURCE_DIR="./llvm-project/llvm"
+    BUILD_DIR=build
+else
+    BUILD_SCHEME=none
+    : ${INSTALL_PREFIX:=_dist}
+    SOURCE_DIR=./llvm-project/llvm
+    BUILD_DIR=build
+    echo "Build type doesn't seem to be either spk or rez"
+    # exit 1
+fi
+echo "Building scheme: ${BUILD_SCHEME}"
+
+# SPI magic: build with an older clang in a known location. If this is not
+# found (for example, at other sites), it will just fall back on using the
+# default gcc it finds.
+: ${CLANGHOME:=/shots/spi/home/software/packages/llvm/11.0.0/gcc-6.3}
+if [ -d $CLANGHOME ] ; then
+    BUILD_WITH_CLANG_FLAGS+=" -DCMAKE_C_COMPILER=${CLANGHOME}/bin/clang"
+    BUILD_WITH_CLANG_FLAGS+=" -DCMAKE_CXX_COMPILER=${CLANGHOME}/bin/clang++"
+    BUILD_WITH_CLANG_FLAGS+=" -DLLVM_ENABLE_LLD=ON"
+fi
+
+TARGETS="host;NVPTX"
+SANATIZERS="Address;Memory;MemoryWithOrigins;Undefined;Thread;DataFlow"
+PROJECTS="clang;libcxx;libcxxabi;libunwind;compiler-rt;lld"
+
+# requires CUDA_TOOLKIT_ROOT_DIR for OpenMP+CUDA
+# Also need to be explicit about the libcuda otherwise version in /usr/lib is used.
+#
+# Comment this out -- this should be set by the 'cuda' dependency for either
+# spk or Rez.
+# export CUDA_TOOLKIT_ROOT_DIR="/shots/spi/home/lib/arnold/rhel7/cuda_11.1"
+
+# Additions for OpenMP
+PROJECTS="${PROJECTS};openmp"
+OMP_CUDA_FLAGS=" -DCUDA_TOOLKIT_ROOT_DIR=${CUDA_TOOLKIT_ROOT_DIR}"
+OMP_CUDA_FLAGS+=" -DLIBOMPTARGET_DEP_CUDA_DRIVER_LIBRARIES=${CUDA_TOOLKIT_ROOT_DIR}/targets/x86_64-linux/lib/stubs/libcuda.so"
+OMP_CUDA_FLAGS+=" -DLIBOMPTARGET_DEP_CUDA_INCLUDE_DIRS=${CUDA_TOOLKIT_ROOT_DIR}/targets/x86_64-linux/include"
+OMP_CUDA_FLAGS+=" -DLIBOMPTARGET_NVPTX_COMPUTE_CAPABILITIES=60,61,62,70,72,75,80"
+OMP_CUDA_FLAGS+=" -DCLANG_OPENMP_NVPTX_DEFAULT_ARCH=sm_61" # Default to P6000
+
+# LLDB doesn't like the swig version here, though LLDB says Swig v2+ should work
+#
+# PROJECTS="${PROJECTS};lldb"
+
+cmake -S "${SOURCE_DIR}" -B "${BUILD_DIR}"                \
+      -DCMAKE_BUILD_TYPE:STRING=Release -G Ninja          \
+      -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}"          \
+      -DCMAKE_CXX_STANDARD=14                             \
+      -DCMAKE_CXX_STANDARD_REQUIRED=ON                    \
+      -DCMAKE_CXX_EXTENSIONS=OFF                          \
+      -DGCC_INSTALL_PREFIX=/opt/rh/devtoolset-6/root/usr  \
+      -DLLVM_ENABLE_LTO=OFF                               \
+      -DLIBCLANG_BUILD_STATIC=ON                          \
+      -DLLVM_ENABLE_ASSERTIONS=OFF                        \
+      -DLLVM_ENABLE_BACKTRACES=OFF                        \
+      -DLLVM_TARGETS_TO_BUILD="${TARGETS}"                \
+      -DLLVM_ENABLE_TERMINFO=OFF                          \
+      -DLLVM_USE_INTEL_JITEVENTS=ON                       \
+      -DLLVM_APPEND_VC_REV=OFF                            \
+      -DLLVM_USE_SANITIZER="${SANITIZERS}"                \
+      -DLLVM_ENABLE_PROJECTS="${PROJECTS}"                \
+      ${BUILD_WITH_CLANG_FLAGS}                           \
+      ${OMP_CUDA_FLAGS}                                   \
+      "$@"
+
+if [[ "${REZ_BUILD_INSTALL}" -eq "1" || "${SPK_PKG_NAME}" != "" ]]; then
+    cmake --build ${BUILD_DIR} --target install
+else
+    cmake --build ${BUILD_DIR}
+fi

--- a/packages/llvm/llvm.spk.yaml
+++ b/packages/llvm/llvm.spk.yaml
@@ -1,0 +1,33 @@
+pkg: llvm/12.0.0
+
+
+sources:
+  # This idiom can work with any of (a) a local clone, (b) a git submodule,
+  # or (c) nothing (does a fresh clone from GitHub).
+  - path: ./
+    filter: [ ]
+  - script:
+    - if [ ! -d llvm-project ] ; then git clone https://github.com/llvm/llvm-project -b llvmorg-12.0.0 ; fi
+
+build:
+  options:
+    - var: arch
+    - var: os
+    - var: centos
+    - pkg: gcc/6
+    - pkg: cmake/^3.13
+    - pkg: cuda
+
+  variants:
+    - { gcc: 6.3 }
+    - { gcc: 9.3 }
+
+  script:
+    - ./build.sh
+    # The build steps are a little too complex to put inline here, so we
+    # have it in a separate script.
+
+install:
+  requirements:
+    - pkg: gcc
+      fromBuildEnv: x.x


### PR DESCRIPTION
There are a few oddities here that I'll just admit and hope for
forgiveness:

1. The build instructions are complex enough that I have a separate
build.sh instead of describing the build steps explicitly in the
spk.yaml file. (A lot of that complexity is ensuring that LLVM is
built with all the options that are needed downstream by OSL, and
in particular, OSL with Cuda/OptiX support. Much of that doesn't
necessarily happen with an LLVM build with only default choices.)

2. The build.sh file is carefully constructed to be a valid build
recipe for both spk and Rez. (That's how I needed it to be at SPI
rather than have two similar scripts that could accidentally
diverge. But eventually when we are spk only, I'll remove the extra
complexity.)

3. In the build.sh, there is one bit of SPI-only magic, where I prefer
to build llvm with a specific older version of clang, at a known file
path location. You can safely ignore that, I believe I have correctly
written the script so that if that is not found, it'll safely fall
back to building llvm+clang with the active gcc.

I'm leaving these ugly bits in, partly out of laziness, but also
partly because it's worth having people see how these things look in
the wild (and maybe when written by a beginner just trying to cobble
it all together to get work done), and for the sake of being able (for
now, at least) to preserve my ability to keep this example and my
actual internal build scripts in sync with just a simple copy back and
forth. I'm assuming that review comments as well as subsequent
refinement of these scripts over time will gradually converge on the
right set of generic scripts that we can all share, without too many
warts left from whichever facility wrote and contributed each script
first.