### PR TITLE
Preserve $HOME in _build_artifacts

### DIFF
--- a/spk/build/_binary.py
+++ b/spk/build/_binary.py
@@ -206,7 +206,7 @@ class BinaryPackageBuilder:
 
     def _build_artifacts(
         self,
-        env: MutableMapping[str, str] = None,
+        env: MutableMapping[str, str],
     ) -> None:
 
         assert self._spec is not None
@@ -227,7 +227,6 @@ class BinaryPackageBuilder:
         with open(build_options, "w+") as writer:
             json.dump(self._all_options, writer, indent="\t")
 
-        env = env or {}
         env = self._all_options.to_environment(env)
         env.update(get_package_build_env(self._spec))
         env["PREFIX"] = self._prefix

--- a/spk/build/_binary_test.py
+++ b/spk/build/_binary_test.py
@@ -20,7 +20,7 @@ def test_build_artifacts(tmpdir: py.path.local, capfd: Any, monkeypatch: Any) ->
         BinaryPackageBuilder()
         .from_spec(spec)
         .with_source(tmpdir.strpath)
-        ._build_artifacts()
+        ._build_artifacts(env=os.environ.copy())
     )
 
     _, err = capfd.readouterr()


### PR DESCRIPTION
Test suite is now failing on `test_build_artifacts` internally due to
items in gitlab-runner's .bashrc that refer to $HOME but $HOME is unset,
leading to:

    /home/gitlab-runner/.bashrc: line 35: /.cargo/env: No such file or directory

Signed-off-by: J Robert Ray <jrray@imageworks.com>