### PR TITLE
Package improvements: boost, openimageio, opencolorio, openexr, imath

### DIFF
--- a/packages/boost/boost-python.spk.yaml
+++ b/packages/boost/boost-python.spk.yaml
@@ -1,0 +1,48 @@
+pkg: boost-python/1.73.0
+  # - name: "Boost.python"
+  # - description: "Boost library for making python bindings"
+  # - url: https://www.boost.org
+  # - license: BSL-1.0
+  # - bindings: [ "C++" ]
+
+sources:
+  # This idiom can work with any of (a) a local clone, (b) a git submodule,
+  # or (c) nothing (does a fresh clone).
+  - path: ./
+    filter: [ ]
+  - script:
+    - if [ ! -d boost ] ; then git clone https://github.com/boostorg/boost --recurse-submodules -b boost-1.73.0 ; fi
+
+build:
+  options:
+    - var: arch
+    - var: os
+    - var: centos
+    - pkg: stdfs
+    - pkg: gcc/6.3
+    - pkg: python/2.7
+
+  variants:
+    - { gcc: 6.3, python: 2.7 }
+    - { gcc: 6.3, python: 3.7 }
+    - { gcc: 9.3, python: 2.7 }
+    - { gcc: 9.3, python: 3.7 }
+
+  script: |
+    cd boost
+    ./bootstrap.sh --prefix=$PREFIX \
+          --with-python=$PREFIX/bin/python \
+          --with-python-version=${SPK_OPT_python}
+    # This works around an apparent bug in the boost build system:
+    PYTHON_INCLUDE_PATH=$(python -c 'from distutils.sysconfig import get_python_inc; print(get_python_inc())')
+    sed --in-place=.bak -e "s|\(using python.*\);|\1: \"$PYTHON_INCLUDE_PATH\" ;|" project-config.jam
+    ./b2 -q -j $(nproc) --prefix=$PREFIX --with-python install
+
+install:
+  requirements:
+    - pkg: stdfs
+    - pkg: gcc
+      fromBuildEnv: x.x
+    - pkg: python
+      fromBuildEnv: x.x
+      include: IfAlreadyPresent

--- a/packages/boost/boost.spk.yaml
+++ b/packages/boost/boost.spk.yaml
@@ -1,0 +1,40 @@
+pkg: boost/1.73.0
+  # - name: Boost
+  # - description: "Portable C++ libraries"
+  # - url: https://www.boost.org
+  # - license: BSL-1.0
+  # - bindings: [ "C++" ]
+
+sources:
+  # This idiom can work with any of (a) a local clone, (b) a git submodule,
+  # or (c) nothing (does a fresh clone).
+  - path: ./
+    filter: [ ]
+  - script:
+    - if [ ! -d boost ] ; then git clone https://github.com/boostorg/boost --recurse-submodules -b boost-1.73.0 ; fi
+
+build:
+  options:
+    - var: arch
+    - var: os
+    - var: centos
+    - pkg: stdfs
+    - pkg: gcc/6.3
+
+  variants:
+    - { gcc: 6.3 }
+    - { gcc: 9.3 }
+
+  script:
+    - cd boost
+    - ./bootstrap.sh --prefix=$PREFIX
+    - ./b2 --help
+    - ./b2 -q -j $(nproc) --prefix=$PREFIX 
+          --without-python
+          install
+
+install:
+  requirements:
+    - pkg: stdfs
+    - pkg: gcc
+      fromBuildEnv: x.x

--- a/packages/imath/imath.spk.yaml
+++ b/packages/imath/imath.spk.yaml
@@ -1,4 +1,4 @@
-pkg: imath/3.0.1
+pkg: imath/3.0.4+r.2
   # - name: "Imath"
   # - description: "Basic vector, matrix, and math for 3D graphics"
   # - license: BSD-3-clause
@@ -10,7 +10,7 @@ sources:
   # or (c) nothing (does a fresh clone from GitHub).
   - path: ./
   - script:
-    - if [ ! -d Imath ] ; then git clone https://github.com/AcademySoftwareFoundation/Imath -b v3.0.1 ; fi
+    - if [ ! -d Imath ] ; then git clone https://github.com/AcademySoftwareFoundation/Imath -b v3.0.4 ; fi
 
 
 build:
@@ -20,19 +20,20 @@ build:
     - var: centos
     - pkg: stdfs
     - pkg: gcc/6.3
-    - pkg: python/3.7
+    - pkg: python/~3.7.0
     - pkg: numpy
-    - pkg: cmake/^3.13
-    - pkg: boost/1.70
+    - pkg: cmake/3.13
+    - pkg: boost-python/~1.70.0
   variants:
-    - { gcc: 6.3, python: 2.7, boost: 1.70 }
-    - { gcc: 6.3, python: 3.7, boost: 1.70 }
-    - { gcc: 9.3, python: 2.7, boost: 1.70 }
-    - { gcc: 9.3, python: 3.7, boost: 1.70 }
+    - { gcc: 6.3, python: ~2.7.0, boost-python: ~1.70.0 }
+    - { gcc: 6.3, python: ~3.7.0, boost-python: ~1.70.0 }
+    - { gcc: 9.3, python: ~2.7.0, boost-python: ~1.73.0 }
+    - { gcc: 9.3, python: ~3.7.0, boost-python: ~1.73.0 }
   script:
     - cmake -S Imath -B build -G Ninja
         -DCMAKE_BUILD_TYPE=Release
         -DCMAKE_INSTALL_PREFIX=$PREFIX
+        -DCMAKE_PREFIX_PATH=$PREFIX
         -DPYTHON=ON
         -DUSE_PYTHON${SPK_PKG_python_VERSION_MAJOR}=ON
     - cmake --build build --target install
@@ -42,7 +43,7 @@ install:
     - pkg: stdfs
     - pkg: gcc
       fromBuildEnv: x.x
-    - pkg: boost
+    - pkg: boost-python
       fromBuildEnv: x.x
     - pkg: python
       fromBuildEnv: x.x
@@ -57,6 +58,7 @@ tests:
     - cmake -S Imath -B build -G Ninja
         -DCMAKE_BUILD_TYPE=Release
         -DCMAKE_INSTALL_PREFIX=$PREFIX
+        -DCMAKE_PREFIX_PATH=$PREFIX
         -DPYTHON=ON
         -DUSE_PYTHON${SPK_PKG_python_VERSION_MAJOR}=ON
     - cmake --build build

--- a/packages/opencolorio/opencolorio-apps.spk.yaml
+++ b/packages/opencolorio/opencolorio-apps.spk.yaml
@@ -1,0 +1,62 @@
+pkg: opencolorio-apps/2.0.1
+  # - name: OpenColorIO-Apps
+  # - description: :OpenColorIO command line tools"
+  # - license: BSD-3-clause
+  # - url: https://opencolorio.org
+  # - bindings: [ "cli" ]
+
+# This package only builds the OpenColorIO command line utilities. There is
+# a separate spk package, opencolorio, that builds the libraries.
+#
+# This separation is necessary to untangle a mutual build dependency between
+# opencolorio and openimageio. The full build sequence is: (a) opencolorio,
+# (b) openimageio (which uses the opencolorio libraries), and finally, (c)
+# opencolorio-apps.
+
+sources:
+  # This idiom can work with any of (a) a local clone, (b) a git submodule,
+  # or (c) nothing (does a fresh clone).
+  - path: ./
+  - script:
+    - if [ ! -d OpenColorIO ] ; then git clone https://github.com/AcademySoftwareFoundation/OpenColorIO -b v2.0.1 ; fi
+
+
+build:
+  options:
+    - var: arch    # rebuild if the arch changes
+    - var: os      # rebuild if the os changes
+    - var: centos  # rebuild if centos version changes
+    - pkg: gcc/6.3
+    - pkg: cmake/^3.13
+    - pkg: opencolorio/=2.0.1
+    - pkg: openimageio/~2.3.5.0
+
+  variants:
+    - { gcc: 6.3 }
+    - { gcc: 9.3 }
+
+  script:
+    # Move outdated FindOpenImageIO.cmake out of the way
+    - mv -f OpenColorIO/share/cmake/modules/FindOpenImageIO.cmake OpenColorIO/share/cmake/modules/FindOpenImageIO.cmake.bak
+    - cmake -S OpenColorIO -B build -G Ninja
+        -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_CXX_STANDARD=14
+        -DCMAKE_INSTALL_PREFIX=$PREFIX
+        -DCMAKE_PREFIX_PATH=$PREFIX
+        -DOCIO_NAMESPACE=OpenColorIO_SPI
+        -DOCIO_LIBNAME_SUFFIX=_SPI
+        -DOCIO_BUILD_TESTS=OFF
+        -DOCIO_BUILD_GPU_TESTS=OFF
+        -DOCIO_BUILD_APPS=ON
+        -DOCIO_BUILD_PYTHON=OFF
+    - mv -f OpenColorIO/share/cmake/modules/FindOpenImageIO.cmake.bak OpenColorIO/share/cmake/modules/FindOpenImageIO.cmake
+    - cmake --build build --target install
+
+install:
+  requirements:
+    - pkg: gcc
+      fromBuildEnv: x.x
+    - pkg: openimageio
+      fromBuildEnv: x.x.x.x
+    - pkg: opencolorio
+      fromBuildEnv: x.x

--- a/packages/opencolorio/opencolorio.spk.yaml
+++ b/packages/opencolorio/opencolorio.spk.yaml
@@ -1,16 +1,25 @@
-pkg: opencolorio/2.0.0
+pkg: opencolorio/2.0.1
   # - name: OpenColorIO
-  # - description: Open source color management library
+  # - description: "Open source color management library"
   # - license: BSD-3-clause
   # - url: https://opencolorio.org
   # - bindings: [ "C++", "Python" ]
+
+# This package builds the OpenColorIO libraries. There is a separate spk
+# package, opencolorio-apps, that builds the applications.
+#
+# This separation is necessary to untangle a mutual build dependency between
+# opencolorio and openimageio. The full build sequence is: (a) opencolorio,
+# (b) openimageio (which uses the opencolorio libraries), and finally, (c)
+# opencolorio-apps.
 
 sources:
   # This idiom can work with any of (a) a local clone, (b) a git submodule,
   # or (c) nothing (does a fresh clone from GitHub).
   - path: ./
   - script:
-    - if [ ! -d OpenColorIO ] ; then git clone https://github.com/AcademySoftwareFoundation/OpenColorIO -b v2.0.0 ; fi
+    - if [ ! -d OpenColorIO ] ; then git clone https://github.com/AcademySoftwareFoundation/OpenColorIO -b v2.0.1 ; fi
+
 
 build:
   options:
@@ -19,22 +28,27 @@ build:
     - var: centos
     - pkg: stdfs
     - pkg: gcc/6.3
-    - pkg: python/3.7
+    - pkg: python/~3.7.0
     - pkg: pybind11/2.6.2
-    - pkg: cmake/^3.13
+    - pkg: cmake/3.13
 
   variants:
-    - { gcc: 6.3, python: 2.7 }
-    - { gcc: 6.3, python: 3.7 }
-    - { gcc: 9.3, python: 2.7 }
-    - { gcc: 9.3, python: 3.7 }
+    - { gcc: 6.3, python: ~2.7.0 }
+    - { gcc: 6.3, python: ~3.7.0 }
+    - { gcc: 9.3, python: ~2.7.0 }
+    - { gcc: 9.3, python: ~3.7.0 }
 
   script:
     - cmake -S OpenColorIO -B build -G Ninja
         -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_CXX_STANDARD=14
         -DCMAKE_INSTALL_PREFIX=$PREFIX
+        -DCMAKE_PREFIX_PATH=$PREFIX
         -DOCIO_BUILD_TESTS=OFF
-        -DPYBIND11_PYTHON_VERSION="${SPK_OPT_python}"
+        -DOCIO_BUILD_GPU_TESTS=OFF
+        -DOCIO_BUILD_APPS=OFF
+        -DOCIO_BUILD_PYTHON=ON
+        -DPYBIND11_PYTHON_VERSION="${SPK_PKG_python_VERSION_BASE}"
     - cmake --build build --target install
 
 install:

--- a/packages/openexr/openexr.spk.yaml
+++ b/packages/openexr/openexr.spk.yaml
@@ -1,4 +1,4 @@
-pkg: openexr/3.0.1
+pkg: openexr/3.0.4
   # - name: "OpenEXR"
   # - description: "Image storage format for HDR imagery"
   # - license: BSD-3-clause
@@ -10,7 +10,7 @@ sources:
   # or (c) nothing (does a fresh clone from GitHub).
   - path: ./
   - script:
-    - if [ ! -d openexr ] ; then git clone https://github.com/AcademySoftwareFoundation/openexr -b v3.0.1 ; fi
+    - if [ ! -d openexr ] ; then git clone https://github.com/AcademySoftwareFoundation/openexr -b v3.0.4 ; fi
 
 
 build:
@@ -22,7 +22,7 @@ build:
     - pkg: cmake/^3.13
     - pkg: gcc/6.3
     - pkg: zlib
-    - pkg: imath/3.0.1
+    - pkg: imath/3.0.4
 
   variants:
     - { gcc: 6.3 }

--- a/packages/openimageio/openimageio.spk.yaml
+++ b/packages/openimageio/openimageio.spk.yaml
@@ -1,0 +1,151 @@
+pkg: openimageio/2.3.5.0
+  # - description: "Library and tools for image files and processing"
+  # - url: https://openimageio.org
+  # - docs: https://openimageio.readthedocs.io
+  # - author: "Larry Gritz <lg@larrygritz.com>"
+  # - license: BSD-3-clause
+  # - bindings: [ "C++", "C", "Python", "cli" ]
+
+# If building off the master/development branch of OIIO, there is no
+# guarantee of API or ABI compatibility (except for the most minor level of
+# patches), so be stricter than usual, with "x.x.x.ab". If building from a
+# release branch, however, the usual x.x.a.b correctly reflects OIIO's
+# compatibility promises for release branches.
+#
+# Also, if using a "master" OIIO, downstream packages should require it
+# using
+#    - pkg: openimageio
+#      fromBuildEnv: x.x.x.x
+# but for "release" branches of OIIO, it's sufficient to use `x.x`.
+#
+compat: x.x.x.ab
+
+sources:
+  # This idiom can work with any of (a) a local clone, (b) a git submodule,
+  # or (c) nothing (does a fresh clone from GitHub).
+  - path: ./
+  - script:
+    - if [ ! -d oiio ] ; then git clone https://github.com/OpenImageIO/oiio -b v2.3.5.0-dev ; fi
+
+
+build:
+
+  options:
+    - var: arch
+    - var: os
+    - var: centos
+    - pkg: gcc/6.3
+    - pkg: python/~3.7.0
+    - pkg: pybind11/2.6.2
+    - pkg: cmake/^3.13
+    - pkg: boost/~1.70.0
+    - pkg: zlib
+    - pkg: libtiff/4.3
+    - pkg: imath/~3.0.0
+    - pkg: openexr/~3.0.0
+    - pkg: fmt/7.1.3
+    - pkg: opencolorio/~2.0.1
+    - pkg: giflib
+    - pkg: libpng
+    - pkg: pugixml
+    - pkg: robinmap
+    - pkg: libraw
+    - pkg: freetype
+    - pkg: libjpeg
+    - pkg: openjpeg
+    - pkg: tbb/2019
+    - pkg: openvdb/8.0
+    - pkg: libheif/1.12
+    - pkg: ffmpeg/4.2
+    # TODO:
+    # - pkg: webp
+    # - pkg: qt5
+    # - pkg: libsquish?
+    # - pkg: jpeg-turbo?
+    # optional: opencv?
+    - var: cxx/14
+      choices: [14, 17]
+    - var: debug/off
+      choices: [on, off]
+    - var: sse4/on
+      choices: [on, off]
+    - var: avx2/off
+      choices: [on, off]
+    - var: avx512f/off
+      choices: [on, off]
+
+  # variants declares the default set of variants to build and publish
+  # using the spk build and make-* commands
+  variants:
+    - { gcc: 6.3, cxx: 14, python: ~2.7.0, boost: ~1.70.0 }
+    - { gcc: 6.3, cxx: 14, python: ~3.7.0, boost: ~1.70.0 }
+    - { gcc: 9.3, cxx: 17, python: ~2.7.0, boost: ~1.73.0 }
+    - { gcc: 9.3, cxx: 17, python: ~3.7.0, boost: ~1.73.0 }
+
+  script:
+    - export SIMD_OPTS="-DUSE_SIMD=sse2"
+    - if [ "$SPK_OPT_sse4" == "on" ] ; then SIMD_OPTS+=",sse4.2" ; fi
+    - if [ "$SPK_OPT_avx2" == "on" ] ; then SIMD_OPTS+=",avx2" ; fi
+    - if [ "$SPK_OPT_avx512f" == "on" ] ; then SIMD_OPTS+=",avx512f" ; fi
+    - export CMAKE_BUILD_TYPE=Release
+    - if [ "${SPK_OPT_debug}" == "debug" ] ; then export CMAKE_BUILD_TYPE=Debug ; fi
+    - cmake -S oiio -B build -G Ninja
+        -DVERBOSE=1
+        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+        -DCMAKE_INSTALL_PREFIX=${PREFIX}
+        -DCMAKE_PREFIX_PATH=${PREFIX}
+        -DCMAKE_CXX_STANDARD=${SPK_OPT_cxx}
+        ${SIMD_OPTS}
+        -DPYBIND11_PYTHON_VERSION=${SPK_PKG_python_VERSION_BASE}
+        -DPYTHON_VERSION=${SPK_PKG_python_VERSION_BASE}
+        -DENABLE_FIELD3D=OFF
+        -DENABLE_PTEX=OFF
+        -DUSE_OPENCV=0
+        -DOpenJPEG_ROOT=$PREFIX
+        -DTBB_USE_DEBUG_BUILD=0
+        -DCMAKE_DISABLE_FIND_PACKAGE_JPEGTurbo=ON
+    - cmake --build build --target install
+
+
+install:
+  requirements:
+    - pkg: gcc
+      fromBuildEnv: x.x
+    - pkg: python
+      fromBuildEnv: x.x
+      # If python is already in the environment/resolve then we
+      # we require it to be compatible with what we built with.
+      # But no python at all is also okay.
+      include: IfAlreadyPresent
+    - pkg: boost
+      fromBuildEnv: x.x
+    - pkg: imath
+      fromBuildEnv: x.x
+    - pkg: fmt
+      fromBuildEnv: x.x
+    - pkg: openexr
+      fromBuildEnv: x.x
+    - pkg: opencolorio
+      fromBuildEnv: x.x
+    - pkg: giflib
+      fromBuildEnv: x.x
+    - pkg: libpng
+      fromBuildEnv: x.x
+    - pkg: pugixml
+      fromBuildEnv: x.x
+    - pkg: libraw
+      fromBuildEnv: x.x
+    - pkg: freetype
+      fromBuildEnv: x.x
+    - pkg: openjpeg
+      fromBuildEnv: x.x
+    - pkg: libjpeg
+      fromBuildEnv: x.x
+    - pkg: tbb
+      fromBuildEnv: x.x
+    - pkg: openvdb
+      fromBuildEnv: x.x
+    - pkg: libheif
+      fromBuildEnv: x.x
+    - pkg: ffmpeg
+      fromBuildEnv: x.x


### PR DESCRIPTION
* Upgrade openexr and imath specs to v3.0.4.
* Add boost and boost-python packages.
* Add openimageio package (this one was a doozy, lots of dependencies,
  now you can see why I'd been staging so many oddball packages).
* Upgrade opencolorio to 2.0.1.
* Change opencolorio to build just the libraries and python bindings,
  and add a new package opencolorio-apps that has the command line
  utils. This allows us to disentangle an unfortunate dependency cycle
  between OIIO and OCIO. These packages need to be built in the
  following order: opencolorio, openimageio (depends on opencolorio),
  opencolorio-apps (depends on both of the others).

None of this is perfect. It's a work in progress that will have further
refinement. But it seems to work and this reflects how I'm building these
packages for SPI at the moment.

Note: the openimageio.spk.yaml is for a "developer preview" tag based on
master. If you prefer a supported release (2.2.x), you'll need to change
this. When we remove the version from being hard-coded in the spec, this
will be a little less awkward.

Signed-off-by: Larry Gritz <lg@imageworks.com>