### PR TITLE
Update all scripts to use bash rather than sh

### DIFF
--- a/spk/build/_binary.py
+++ b/spk/build/_binary.py
@@ -236,7 +236,7 @@ class BinaryPackageBuilder:
         else:
             source_dir = os.path.abspath(self._source)
 
-        # force the base environment to be setup using sh, so that the
+        # force the base environment to be setup using bash, so that the
         # spfs startup and build environment are predictable and consistent
         # (eg in case the user's shell does not have startup scripts in
         #  the dependencies, is not supported by spfs, etc)
@@ -250,8 +250,8 @@ class BinaryPackageBuilder:
             print(" - to finalize and save the package, run `exit 0`")
             cmd = spkrs.build_interactive_shell_command()
         else:
-            os.environ["SHELL"] = "sh"
-            cmd = spkrs.build_shell_initialized_command("/bin/sh", "-ex", build_script)
+            os.environ["SHELL"] = "bash"
+            cmd = spkrs.build_shell_initialized_command("bash", "-ex", build_script)
         with deferred_signals():
             proc = subprocess.Popen(cmd, cwd=source_dir, env=env)
             proc.wait()

--- a/spk/test/_build.py
+++ b/spk/test/_build.py
@@ -114,10 +114,8 @@ class PackageBuildTester:
         with tempfile.NamedTemporaryFile("w+") as script_file:
             script_file.write(self._script)
             script_file.flush()
-            os.environ["SHELL"] = "sh"
-            cmd = spkrs.build_shell_initialized_command(
-                "/bin/sh", "-ex", script_file.name
-            )
+            os.environ["SHELL"] = "bash"
+            cmd = spkrs.build_shell_initialized_command("bash", "-ex", script_file.name)
 
             with build.deferred_signals():
                 proc = subprocess.Popen(cmd, cwd=source_dir, env=env)

--- a/spk/test/_install.py
+++ b/spk/test/_install.py
@@ -95,10 +95,8 @@ class PackageInstallTester:
         with tempfile.NamedTemporaryFile("w+") as script_file:
             script_file.write(self._script)
             script_file.flush()
-            os.environ["SHELL"] = "sh"
-            cmd = spkrs.build_shell_initialized_command(
-                "/bin/sh", "-ex", script_file.name
-            )
+            os.environ["SHELL"] = "bash"
+            cmd = spkrs.build_shell_initialized_command("bash", "-ex", script_file.name)
 
             with build.deferred_signals():
                 proc = subprocess.Popen(cmd, env=env, cwd=source_dir)

--- a/spk/test/_sources.py
+++ b/spk/test/_sources.py
@@ -97,10 +97,8 @@ class PackageSourceTester:
         with tempfile.NamedTemporaryFile("w+") as script_file:
             script_file.write(self._script)
             script_file.flush()
-            os.environ["SHELL"] = "sh"
-            cmd = spkrs.build_shell_initialized_command(
-                "/bin/sh", "-ex", script_file.name
-            )
+            os.environ["SHELL"] = "bash"
+            cmd = spkrs.build_shell_initialized_command("bash", "-ex", script_file.name)
 
             with build.deferred_signals():
                 proc = subprocess.Popen(cmd, cwd=source_dir, env=env)


### PR DESCRIPTION
sh is not conidered to be officially supported by spfs, only bash
and tcsh so spk has no business using sh rather than bash. This was
generally okay on centos where often sh is just bash, but other system
(like ubuntu) may have something much less compatible

@justinfx I _believe_ this covers the issue you were having but it would be good to get a confirmation if you can (in case I misunderstood)