### PR TITLE
Package recipe improvements for ptex, opencolorio, openvdb

### DIFF
--- a/packages/opencolorio/opencolorio-apps.spk.yaml
+++ b/packages/opencolorio/opencolorio-apps.spk.yaml
@@ -1,6 +1,6 @@
-pkg: opencolorio-apps/2.0.1
+pkg: opencolorio-apps/2.0.1+r.1
   # - name: OpenColorIO-Apps
-  # - description: :OpenColorIO command line tools"
+  # - description: "OpenColorIO command line tools"
   # - license: BSD-3-clause
   # - url: https://opencolorio.org
   # - bindings: [ "cli" ]
@@ -18,8 +18,8 @@ sources:
   # or (c) nothing (does a fresh clone).
   - path: ./
   - script:
-    - if [ ! -d OpenColorIO ] ; then git clone https://github.com/AcademySoftwareFoundation/OpenColorIO -b v2.0.1 ; fi
-
+    - if [ ! -d OpenColorIO ] ; then git clone https://github.com/AcademySoftwareFoundation/OpenColorIO -b 12ee9db3 ; fi
+  # Note: picked a commit that is v2.0.1 plus two patches that are important.
 
 build:
   options:

--- a/packages/opencolorio/opencolorio.spk.yaml
+++ b/packages/opencolorio/opencolorio.spk.yaml
@@ -1,4 +1,4 @@
-pkg: opencolorio/2.0.1
+pkg: opencolorio/2.0.1+r.1
   # - name: OpenColorIO
   # - description: "Open source color management library"
   # - license: BSD-3-clause
@@ -18,7 +18,8 @@ sources:
   # or (c) nothing (does a fresh clone from GitHub).
   - path: ./
   - script:
-    - if [ ! -d OpenColorIO ] ; then git clone https://github.com/AcademySoftwareFoundation/OpenColorIO -b v2.0.1 ; fi
+    - if [ ! -d OpenColorIO ] ; then git clone https://github.com/AcademySoftwareFoundation/OpenColorIO -b 12ee9db3 ; fi
+  # Note: picked a commit that is v2.0.1 plus two patches that are important.
 
 
 build:
@@ -48,7 +49,8 @@ build:
         -DOCIO_BUILD_GPU_TESTS=OFF
         -DOCIO_BUILD_APPS=OFF
         -DOCIO_BUILD_PYTHON=ON
-        -DPYBIND11_PYTHON_VERSION="${SPK_PKG_python_VERSION_BASE}"
+        -DPYBIND11_PYTHON_VERSION=${SPK_PKG_python_VERSION_MAJOR}.${SPK_PKG_python_VERSION_MINOR}
+        -DOCIO_PYTHON_VERSION=${SPK_PKG_python_VERSION_MAJOR}.${SPK_PKG_python_VERSION_MINOR}
     - cmake --build build --target install
 
 install:

--- a/packages/openvdb/openvdb.spk.yaml
+++ b/packages/openvdb/openvdb.spk.yaml
@@ -1,4 +1,4 @@
-pkg: openvdb/8.0.0
+pkg: openvdb/8.0.0+r.1
   # - name: openvdb
   # - description: Hierarchical data structure for volumes
   # - license: MPL-2.0
@@ -20,23 +20,31 @@ build:
     - var: centos  # rebuild if centos version changes
     - pkg: stdfs
     - pkg: gcc/6.3
-    - pkg: python/3.7
+    - pkg: python/~3.7.0
     - pkg: cmake/^3.13
     - pkg: tbb/2019
     - pkg: blosc
     - pkg: zlib
     - pkg: jemalloc
-    - pkg: boost/1.70
+    - pkg: boost/~1.70.0
+    - pkg: boost-python/~1.70.0
     - pkg: llvm/11
     - pkg: cuda/11
+    - var: sse4/on
+      choices: [on, off]
+    - var: avx/off
+      choices: [on, off]
 
   variants:
-    - { gcc: 6.3, python: 2.7 }
-    - { gcc: 6.3, python: 3.7 }
+    - { gcc: 6.3, python: ~2.7.0 }
+    - { gcc: 6.3, python: ~3.7.0 }
     # At SPI, we don't yet have python built for gcc/9. Come back to
     # and do these builds when that has been finished.
 
   script:
+    - export SIMD_OPTS="None"
+    - if [ "$SPK_OPT_sse4" == "on" ] ; then SIMD_OPTS="SSE42" ; fi
+    - if [ "$SPK_OPT_avx" == "on" ] ; then SIMD_OPTS="AVX" ; fi
     - cmake -S openvdb -B build -G Ninja
         -DCMAKE_INSTALL_PREFIX=$PREFIX
         -DCMAKE_VISIBILITY_INLINES_HIDDEN=ON
@@ -53,8 +61,8 @@ build:
         -DOpenGL_GL_PREFERENCE=GLVND
         -DDISABLE_DEPENDENCY_VERSION_CHECKS=OFF
         -DCMAKE_INSTALL_LIBDIR=lib
-        -DUSE_EXR=OFF
         -DBlosc_ROOT=$PREFIX
+        -DOPENVDB_SIMD=${SIMD_OPTS}
     - cmake --build build --target install
     # Also build nanovdb if this is an openvdb branch that supports it
     - if [ -e openvdb/nanovdb ] ; then
@@ -69,7 +77,7 @@ build:
             -DNANOVDB_ALLOW_FETCHCONTENT=OFF
             -DCMAKE_CUDA_HOST_COMPILER=${PREFIX}/bin/clang
             -DBlosc_ROOT=$PREFIX
-            -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON
+            -DOPENVDB_SIMD=${SIMD_OPTS}
             ;
         cmake --build nanobuild --target install
         ;
@@ -89,6 +97,8 @@ install:
     - pkg: zlib
       fromBuildEnv: x.x
     - pkg: boost
+      fromBuildEnv: x.x
+    - pkg: boost-python
       fromBuildEnv: x.x
     - pkg: blosc
       fromBuildEnv: x.x

--- a/packages/ptex/ptex.spk.yaml
+++ b/packages/ptex/ptex.spk.yaml
@@ -1,0 +1,44 @@
+pkg: ptex/2.4.0
+  # - name: "Ptex"
+  # - description: "Per-face texture mapping for production rendering"
+  # - license: BSD-3-clause
+  # - url: https://ptex.us
+  # - bindings: [ "C++" ]
+
+sources:
+  # This idiom can work with any of (a) a local clone, (b) a git submodule,
+  # or (c) nothing (does a fresh clone).
+  - path: ./
+    filter: [ ]
+  - script:
+    - if [ ! -d ptex ] ; then git clone https://github.com/wdas/ptex.git -b v2.4.0 ; fi
+
+build:
+  options:
+    - pkg: stdfs # provides the default filesystem structure (bin, lib, etc)
+    - var: arch    # rebuild if the arch changes
+    - var: os      # rebuild if the os changes
+    - var: centos  # rebuild if centos version changes
+    - pkg: gcc/6.3
+    - pkg: cmake/^3.13
+    - pkg: zlib
+
+  variants:
+    - { gcc: 6.3 }
+    - { gcc: 9.3 }
+
+  script:
+    - cmake -S ptex -B build 
+        -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_INSTALL_PREFIX=$PREFIX
+        -DCMAKE_PREFIX_PATH=$PREFIX
+        -DCMAKE_CXX_STANDARD=14
+    - cmake --build build --target install
+
+install:
+  requirements:
+    - pkg: stdfs
+    - pkg: gcc
+      fromBuildEnv: x.x
+    - pkg: zlib
+      fromBuildEnv: x.x


### PR DESCRIPTION
* New package: ptex
* opencolorio: sync to a commit atop 2.0.1 that fixes a problem where
  it didn't use the right link commands to ensure that its dependent
  libraries don't leak symbols downstream, and another fix where it's
  better at selecting the right python version when multiple are
  available.
* openvdb: more specific python version selection, add build options for
  level of SIMD support.

Signed-off-by: Larry Gritz <lg@imageworks.com>