### PR TITLE
Fix VarRequest 'fromBuildEnv: true' getting lost

### DIFF
--- a/src/api/request.rs
+++ b/src/api/request.rs
@@ -627,5 +627,5 @@ impl<'de> Deserialize<'de> for PkgRequest {
 }
 
 pub(crate) fn is_false(value: &bool) -> bool {
-    *value
+    !*value
 }

--- a/src/api/request_test.rs
+++ b/src/api/request_test.rs
@@ -58,3 +58,15 @@ fn test_var_request_empty_value_roundtrip() {
         "should be able to round-trip serialize a var request with empty string value"
     );
 }
+
+#[rstest]
+fn test_var_request_pinned_roundtrip() {
+    let req = serde_yaml::from_str::<VarRequest>("{var: python.abi, fromBuildEnv: true}").unwrap();
+    let yaml = serde_yaml::to_string(&req).unwrap();
+    let res = serde_yaml::from_str::<VarRequest>(&yaml);
+    assert!(
+        res.is_ok(),
+        "should be able to round-trip serialize a var request with pin"
+    );
+    assert!(res.unwrap().pin, "should preserve pin value");
+}


### PR DESCRIPTION
`skip_serializing_if = "is_false"` was skipping this field when pin is
true, due to `fn is_false` returning the wrong answer.

Signed-off-by: J Robert Ray <jrray@imageworks.com>