### PR TITLE
Fix bug where dict-style options on the command line had to be strings

### DIFF
--- a/spk/cli/_flags.py
+++ b/spk/cli/_flags.py
@@ -110,7 +110,13 @@ def get_var_requests_from_option_flags(
         pair = pair.strip()
         if pair.startswith("{"):
             for name, value in (yaml.safe_load(pair) or {}).items():
-                yield spk.api.VarRequest(name, value)
+                assert not isinstance(
+                    value, dict
+                ), f"provided value for '{name}' must be a scalar"
+                assert not isinstance(
+                    value, list
+                ), f"provided value for '{name}' must be a scalar"
+                yield spk.api.VarRequest(name, str(value))
             continue
 
         if "=" in pair:

--- a/spk/cli/_flags_test.py
+++ b/spk/cli/_flags_test.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2021 Sony Pictures Imageworks, et al.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/imageworks/spk
+from typing import Dict, List, Type
+import pytest
+import argparse
+
+import spk
+from . import _flags
+
+
+@pytest.mark.parametrize(
+    "args,expected",
+    [
+        (["-o", "hello:world"], {"hello": "world"}),
+        (["-o", "hello=world"], {"hello": "world"}),
+        (["-o", "{hello: world}"], {"hello": "world"}),
+        (["-o", "{python: 2.7}"], {"python": "2.7"}),
+        (
+            ["-o", "{python: 2.7, python.abi: py37m}"],
+            {"python": "2.7", "python.abi": "py37m"},
+        ),
+    ],
+)
+def test_option_flags_parsing(args: List[str], expected: Dict[str, str]) -> None:
+
+    parser = argparse.ArgumentParser("tester")
+    _flags.add_option_flags(parser)
+    parsed = parser.parse_args(["--no-host"] + args)
+    opts = _flags.get_options_from_flags(parsed)
+    assert opts == spk.api.OptionMap(expected)
+
+
+@pytest.mark.parametrize(
+    "args,expected",
+    [
+        (["-o", "{hello: [world]}"], AssertionError),
+        (["-o", "{python: {v: 2.7}}"], AssertionError),
+        (["-o", "value"], ValueError),
+    ],
+)
+def test_option_flags_parsing_err(args: List[str], expected: Type[Exception]) -> None:
+    with pytest.raises(expected):
+        parser = argparse.ArgumentParser("tester")
+        _flags.add_option_flags(parser)
+        parsed = parser.parse_args(args)
+        opts = _flags.get_options_from_flags(parsed)

--- a/src/api/option_map.rs
+++ b/src/api/option_map.rs
@@ -263,6 +263,7 @@ impl pyo3::PySequenceProtocol for OptionMap {
     fn __len__(&self) -> usize {
         self.options.len()
     }
+
     fn __contains__(&self, item: &str) -> bool {
         self.options.contains_key(item)
     }

--- a/src/api/python.rs
+++ b/src/api/python.rs
@@ -655,6 +655,14 @@ impl pyo3::PyObjectProtocol for super::OptionMap {
     fn __repr__(&self) -> String {
         self.to_string()
     }
+
+    fn __richcmp__(&self, other: Self, op: pyo3::class::basic::CompareOp) -> bool {
+        use pyo3::class::basic::CompareOp;
+        match op {
+            CompareOp::Eq => self == &other,
+            _ => false,
+        }
+    }
 }
 
 #[pyproto]


### PR DESCRIPTION
In the pre-rust world python handled scalars much better, but now we must ensure
that they are proper and convert to a string before giving it to rust

Also add test to capture the current and fixed behaviour

Signed-off-by: Ryan Bottriell <ryan@bottriell.ca>