### PR TITLE
Skip Invalid Tags

### DIFF
--- a/spk/storage/_spfs.py
+++ b/spk/storage/_spfs.py
@@ -60,8 +60,10 @@ class SpFSRepository(Repository):
         for build in build_tags:
             try:
                 builds.append(pkg.with_build(build))
-            except ValueError as e:
-                _LOGGER.warning(f"invalid package tag found in spfs repository: {base}/{build}")
+            except TypeError as e:
+                _LOGGER.warning(
+                    f"invalid package tag found in spfs repository: {base}/{build}"
+                )
         return builds
 
     def force_publish_spec(self, spec: api.Spec) -> None:

--- a/spk/storage/_spfs_test.py
+++ b/spk/storage/_spfs_test.py
@@ -1,0 +1,25 @@
+import itertools
+
+import py.path
+
+import spkrs
+from ._spfs import SpFSRepository
+
+
+def test_skip_invalid_builds(tmpdir: py.path.local) -> None:
+
+    root = tmpdir.join("repo")
+    root.join("renders").ensure_dir()
+    root.join("objects").ensure_dir()
+    root.join("payloads").ensure_dir()
+    root.join("tags").ensure_dir()
+    repo = SpFSRepository(spkrs.SpFSRepository("file:" + root.strpath))
+
+    # generate some empty tag files to simply test that ones with
+    # invalid build digests are ignored when iterating
+    for kind, build in itertools.product(("spec", "pkg"), ("src", "invalid")):
+        root.join("tags", "spk", kind, "mypkg", "1.0.0", build + ".tag").ensure()
+
+    assert list(repo.list_package_builds("mypkg/1.0.0")) == [
+        spkrs.api.parse_ident("mypkg/1.0.0/src")
+    ]


### PR DESCRIPTION
Do not fail fatally when an spfs tag exists in the spk area with an invalid build digest - instead only log a warning and continue. This could be fairly noisy but I think the lru_cache will help to reduce it. Either way the warning should be fixed and it's better than failing entirely

@justinfx 

Closes #86 