### PR TITLE
Package updates: new osl and partio, touch-ups of several others

### DIFF
--- a/packages/alembic/alembic.spk.yaml
+++ b/packages/alembic/alembic.spk.yaml
@@ -1,4 +1,4 @@
-pkg: alembic/1.8.1
+pkg: alembic/1.8.2+r.3
   # - name: "Alembic"
   # - description: "Baked scene data format and library"
   # - license: BSD-3-clause
@@ -10,30 +10,50 @@ sources:
   # or (c) nothing (does a fresh clone from GitHub).
   - path: ./
   - script:
-    - if [ ! -d alembic ] ; then git clone https://github.com/alembic/alembic -b 1.8.1 ; fi
+    - if [ ! -d alembic ] ; then git clone https://github.com/alembic/alembic -b 1.8.2 ; fi
 
 build:
   options:
     - var: arch
     - var: os
     - var: centos
+    - var: python.abi
     - pkg: stdfs
     - pkg: gcc/6.3
-    - pkg: python/3.7
-    - pkg: imath/3
+    - pkg: python/~3.7.0
+    - pkg: boost-python/~1.70.0
+    - pkg: imath/~3.1.0
     - pkg: cmake/^3.13
-    - pkg: boost/1.70
   variants:
-    - { gcc: 6.3, python: 2.7, boost: 1.70 }
-    - { gcc: 6.3, python: 3.7, boost: 1.70 }
-    # TODO: add gcc 9.3 variants. Awaiting a proper spk python+gcc9 build.
+    # VFX 2019-ish, Maya 2020, Houdini 18
+    - { gcc: 6.3, python: ~2.7.0, boost-python: ~1.70.0, python.abi: "cp27mu", imath: 2.4 }
+    # VFX2020-ish, Nuke 13?
+    - { gcc: 6.3, python: ~3.7.0, boost-python: ~1.70.0, python.abi: "cp37m", imath: 2.4 }
+    # VFX 2021-ish, Maya 2022, Houdini 19
+    - { gcc: 9.3, python: ~3.7.0, boost-python: ~1.73.0, python.abi: "cp37m", imath: 2.4 }
+    # Cutting edge version: VFX Platform 2022 will look like this
+    - { gcc: 9.3, python: ~3.7.0, boost-python: ~1.73.0, python.abi: "cp37m", imath: ~3.1.0 }
+    # Not sure if any of these are needed yet, but standing by:
+    #- { gcc: 6.3, python: ~3.7.0, boost-python: ~1.70.0, python.abi: "cp37m" }
+    #- { gcc: 6.3, python: ~2.7.0, boost-python: ~1.70.0, python.abi: "cp27mu" }
+    #- { gcc: 9.3, python: ~2.7.0, boost-python: ~1.73.0, python.abi: "cp27mu" }
   script:
+    # OpenEXR 2's exported cmake config doesn't have everything we need. A
+    # little extra hinting is necessary.
+    - if [[ ${SPK_PKG_imath_VERSION_MAJOR} == 2 ]] ; then
+          CMAKE_ARGS+=" -DALEMBIC_PYILMBASE_ROOT=$PREFIX" ;
+          CMAKE_ARGS+=" -DALEMBIC_PYILMBASE_PYIMATH_LIB=$PREFIX/lib/libPyImath_Python${SPK_PKG_python_VERSION_MAJOR}_${SPK_PKG_python_VERSION_MINOR}-${SPK_PKG_imath_VERSION_MAJOR}_${SPK_PKG_imath_VERSION_MINOR}.so" ;
+          CMAKE_ARGS+=" -DALEMBIC_ILMBASE_IMATH_LIB=$PREFIX/lib/libImath-${SPK_PKG_imath_VERSION_MAJOR}_${SPK_PKG_imath_VERSION_MINOR}.so" ;
+          CMAKE_ARGS+=" -DALEMBIC_PYILMBASE_INCLUDE_DIRECTORY=$PREFIX/lib/OpenEXR" ;
+      fi
     - cmake -S alembic -B build -G Ninja
         -DCMAKE_BUILD_TYPE=Release
         -DCMAKE_INSTALL_PREFIX=$PREFIX
         -DCMAKE_PREFIX_PATH=$PREFIX
+        -DPYILMBASE_ROOT=$PREFIX
         -DUSE_PYALEMBIC=ON
         -DPYALEMBIC_PYTHON_MAJOR=${SPK_PKG_python_VERSION_MAJOR}
+        ${CMAKE_ARGS}
     - cmake --build build --target install
 
 install:
@@ -41,7 +61,7 @@ install:
     - pkg: stdfs
     - pkg: gcc
       fromBuildEnv: x.x
-    - pkg: boost
+    - pkg: boost-python
       fromBuildEnv: x.x
     - pkg: python
       fromBuildEnv: x.x
@@ -52,12 +72,19 @@ install:
 tests:
   - stage: build
     script:
+      - if [[ ${SPK_PKG_imath_VERSION_MAJOR} == 2 ]] ; then
+            CMAKE_ARGS+=" -DALEMBIC_PYILMBASE_ROOT=$PREFIX" ;
+            CMAKE_ARGS+=" -DALEMBIC_PYILMBASE_PYIMATH_LIB=$PREFIX/lib/libPyImath_Python${SPK_PKG_python_VERSION_MAJOR}_${SPK_PKG_python_VERSION_MINOR}-${SPK_PKG_imath_VERSION_MAJOR}_${SPK_PKG_imath_VERSION_MINOR}.so" ;
+            CMAKE_ARGS+=" -DALEMBIC_ILMBASE_IMATH_LIB=$PREFIX/lib/libImath-${SPK_PKG_imath_VERSION_MAJOR}_${SPK_PKG_imath_VERSION_MINOR}.so" ;
+            CMAKE_ARGS+=" -DALEMBIC_PYILMBASE_INCLUDE_DIRECTORY=$PREFIX/lib/OpenEXR" ;
+        fi
       - cmake -S alembic -B build -G Ninja
         -DCMAKE_BUILD_TYPE=Release
         -DCMAKE_INSTALL_PREFIX=$PREFIX
         -DCMAKE_PREFIX_PATH=$PREFIX
         -DUSE_PYALEMBIC=ON
         -DPYALEMBIC_PYTHON_MAJOR=${SPK_PKG_python_VERSION_MAJOR}
+        ${CMAKE_ARGS}
       - cmake --build build
       - cd build
       - ctest

--- a/packages/fmt/fmt.spk.yaml
+++ b/packages/fmt/fmt.spk.yaml
@@ -1,6 +1,6 @@
-pkg: fmt/7.1.3
+pkg: fmt/8.0.1+r.1
   # - name: fmt
-  # - description: Header-only C++ string formatting like C++20 std::format
+  # - description: "Header-only C++ string formatting like C++20 std::format"
   # - url: https://github.com/fmtlib/fmt
   # - license: MIT
   # - bindings: [ "C++" ]
@@ -12,7 +12,7 @@ sources:
   # or (c) nothing (does a fresh clone).
   - path: ./
   - script:
-    - if [ ! -d fmt ] ; then git clone https://github.com/fmtlib/fmt.git -b v7.1.3 ; fi
+    - if [ ! -d fmt ] ; then git clone https://github.com/fmtlib/fmt.git -b 8.0.1 ; fi
 
 
 build:
@@ -20,7 +20,7 @@ build:
     - var: arch    # rebuild if the arch changes
     - var: os      # rebuild if the os changes
     - var: centos  # rebuild if centos version changes
-    - pkg: gcc/6
+    - pkg: gcc/6.3
     - pkg: cmake/^3.13
 
   variants:
@@ -33,5 +33,3 @@ build:
         -DCMAKE_INSTALL_PREFIX=$PREFIX
         -DFMT_TEST=OFF
     - cmake --build build --target install
-    - exit 0
-

--- a/packages/imath/imath.spk.yaml
+++ b/packages/imath/imath.spk.yaml
@@ -1,4 +1,4 @@
-pkg: imath/3.0.4+r.2
+pkg: imath/3.1.3
   # - name: "Imath"
   # - description: "Basic vector, matrix, and math for 3D graphics"
   # - license: BSD-3-clause
@@ -10,7 +10,7 @@ sources:
   # or (c) nothing (does a fresh clone from GitHub).
   - path: ./
   - script:
-    - if [ ! -d Imath ] ; then git clone https://github.com/AcademySoftwareFoundation/Imath -b v3.0.4 ; fi
+    - if [ ! -d Imath ] ; then git clone https://github.com/AcademySoftwareFoundation/Imath -b v3.1.3 ; fi
 
 
 build:
@@ -18,17 +18,17 @@ build:
     - var: arch
     - var: os
     - var: centos
+    - var: python.abi
     - pkg: stdfs
     - pkg: gcc/6.3
     - pkg: python/~3.7.0
     - pkg: numpy
-    - pkg: cmake/3.13
+    - pkg: cmake/~3.13
     - pkg: boost-python/~1.70.0
   variants:
-    - { gcc: 6.3, python: ~2.7.0, boost-python: ~1.70.0 }
-    - { gcc: 6.3, python: ~3.7.0, boost-python: ~1.70.0 }
-    - { gcc: 9.3, python: ~2.7.0, boost-python: ~1.73.0 }
-    - { gcc: 9.3, python: ~3.7.0, boost-python: ~1.73.0 }
+    - { gcc: 6.3, python: ~2.7.0, boost-python: ~1.70.0, python.abi: "cp27mu" }
+    - { gcc: 6.3, python: ~3.7.0, boost-python: ~1.70.0, python.abi: "cp37m" }
+    - { gcc: 9.3, python: ~3.7.0, boost-python: ~1.73.0, python.abi: "cp37m" }
   script:
     - cmake -S Imath -B build -G Ninja
         -DCMAKE_BUILD_TYPE=Release
@@ -63,4 +63,4 @@ tests:
         -DUSE_PYTHON${SPK_PKG_python_VERSION_MAJOR}=ON
     - cmake --build build
     - cd build
-    - ctest
+    - ctest --output-on-failure

--- a/packages/imath/imath24.spk.yaml
+++ b/packages/imath/imath24.spk.yaml
@@ -1,0 +1,29 @@
+pkg: imath/2.4.0+r.1
+  # - name: "Imath"
+  # - description: "Basic vector, matrix, and math for 3D graphics"
+  # - license: BSD-3-clause
+  # - url: https://github.com/AcademySoftwareFoundation/Imath
+  # - bindings: [ "C++", "python" ]
+
+sources:
+  # There is no Imath 2.x, this is a dummy package.
+  - path: ./
+
+
+build:
+  options:
+    - var: arch
+    - var: os
+    - var: centos
+    - pkg: stdfs
+    - pkg: openexr/~2.4.0
+
+  script:
+    - echo 'all done'
+
+install:
+  requirements:
+    - pkg: stdfs
+    - pkg: openexr
+      fromBuildEnv: x.x
+

--- a/packages/llvm/llvm.spk.yaml
+++ b/packages/llvm/llvm.spk.yaml
@@ -1,4 +1,4 @@
-pkg: llvm/12.0.0
+pkg: llvm/12.0.1+r.1
   # - name: "LLVM+Clang"
   # - description: "LLVM compiler infrastructure and Clang compiler and tools"
   # - license: "Apache-2.0 WITH LLVM-exception"
@@ -12,7 +12,7 @@ sources:
   - path: ./
     filter: [ ]
   - script:
-    - if [ ! -d llvm-project ] ; then git clone https://github.com/llvm/llvm-project -b llvmorg-12.0.0 ; fi
+    - if [ ! -d llvm-project ] ; then git clone https://github.com/llvm/llvm-project -b llvmorg-12.0.1 ; fi
 
 build:
   options:
@@ -23,7 +23,7 @@ build:
     - pkg: gcc/6
     - pkg: cmake/^3.13
     - pkg: cuda
-    - pkg: ncurses
+    # - pkg: ncurses
 
   variants:
     - { gcc: 6.3 }
@@ -39,5 +39,5 @@ install:
     - pkg: stdfs
     - pkg: gcc
       fromBuildEnv: x.x
-    - pkg: ncurses
-      fromBuildEnv: x.x
+    # - pkg: ncurses
+    #   fromBuildEnv: x.x

--- a/packages/openexr/openexr.spk.yaml
+++ b/packages/openexr/openexr.spk.yaml
@@ -1,4 +1,4 @@
-pkg: openexr/3.0.4
+pkg: openexr/3.1.1
   # - name: "OpenEXR"
   # - description: "Image storage format for HDR imagery"
   # - license: BSD-3-clause
@@ -10,7 +10,7 @@ sources:
   # or (c) nothing (does a fresh clone from GitHub).
   - path: ./
   - script:
-    - if [ ! -d openexr ] ; then git clone https://github.com/AcademySoftwareFoundation/openexr -b v3.0.4 ; fi
+    - if [ ! -d openexr ] ; then git clone https://github.com/AcademySoftwareFoundation/openexr -b v3.1.1 ; fi
 
 
 build:
@@ -22,7 +22,7 @@ build:
     - pkg: cmake/^3.13
     - pkg: gcc/6.3
     - pkg: zlib
-    - pkg: imath/3.0.4
+    - pkg: imath/~3.1.0
 
   variants:
     - { gcc: 6.3 }

--- a/packages/openexr/openexr24.spk.yaml
+++ b/packages/openexr/openexr24.spk.yaml
@@ -26,22 +26,23 @@ sources:
 
 
 build:
-
   options:
     - var: arch
     - var: os
     - var: centos
+    - var: python.abi
     - pkg: stdfs
     - pkg: cmake/^3.13
     - pkg: gcc/6.3
     - pkg: zlib
-    - pkg: python/3.7
-    - pkg: boost/1.70
+    - pkg: python/~3.7.0
+    - pkg: boost-python/~1.70.0
 
   variants:
-    - { gcc: 6.3, python: 2.7 }
-    - { gcc: 6.3, python: 3.7 }
-    # TODO: Add gcc-9.3 after we fix the gcc9+python combinations at SPI.
+    - { gcc: 6.3, python: ~2.7.0, boost-python: ~1.70.0, python.abi: "cp27mu" }
+    - { gcc: 6.3, python: ~3.7.0, boost-python: ~1.70.0, python.abi: "cp37m" }
+    - { gcc: 9.3, python: ~2.7.0, boost-python: ~1.73.0, python.abi: "cp27mu" }
+    - { gcc: 9.3, python: ~3.7.0, boost-python: ~1.73.0, python.abi: "cp37m" }
 
   script:
     - if [ "${SPK_PKG_python_VERSION_MAJOR}" == "2" ] ; then
@@ -52,10 +53,14 @@ build:
     - cmake -S openexr -B build -G Ninja
         -DCMAKE_BUILD_TYPE=Release
         -DCMAKE_INSTALL_PREFIX=$PREFIX
+        -DCMAKE_PREFIX_PATH=$PREFIX
         -DOPENEXR_VIEWERS_ENABLE=OFF
         -DOPENEXR_BUILD_UTILS=OFF
         $pycmd
     - cmake --build build --target install
+    # In this OLD version of OpenEXR, the cmake build scripts are broken and
+    # failed to copy this header. So we do it by hand.
+    - cp build/PyIlmBase/config/PyIlmBaseConfigInternal.h $PREFIX/include/OpenEXR
 
 install:
   requirements:
@@ -64,11 +69,13 @@ install:
       fromBuildEnv: x.x
     - pkg: zlib
       fromBuildEnv: x.x
-    - pkg: boost
+    - pkg: boost-python
       fromBuildEnv: x.x
     - pkg: python
       fromBuildEnv: x.x
       include: IfAlreadyPresent
+    - { var: python.abi, fromBuildEnv: true }
+
 
 tests:
   - stage: build
@@ -76,6 +83,7 @@ tests:
       - cmake -S openexr -B build -G Ninja
           -DCMAKE_BUILD_TYPE=Release
           -DCMAKE_INSTALL_PREFIX=$PREFIX
+          -DCMAKE_PREFIX_PATH=$PREFIX
       - cmake --build build
       - cd build
       - ctest

--- a/packages/openimageio/openimageio.spk.yaml
+++ b/packages/openimageio/openimageio.spk.yaml
@@ -1,31 +1,29 @@
-pkg: openimageio/2.3.5.0
+pkg: openimageio/2.3.7.2
+  # - name: OpenImageIO
   # - description: "Library and tools for image files and processing"
-  # - url: https://openimageio.org
-  # - docs: https://openimageio.readthedocs.io
+  # - homepage: https://openimageio.readthedocs.io
   # - author: "Larry Gritz <lg@larrygritz.com>"
   # - license: BSD-3-clause
   # - bindings: [ "C++", "C", "Python", "cli" ]
 
 # If building off the master/development branch of OIIO, there is no
 # guarantee of API or ABI compatibility (except for the most minor level of
-# patches), so be stricter than usual, with "x.x.x.ab". If building from a
-# release branch, however, the usual x.x.a.b correctly reflects OIIO's
+# patches), so be stricter than usual, with "x.x.a.b". If building from a
+# release branch, however, the usual x.a.b correctly reflects OIIO's
 # compatibility promises for release branches.
 #
-# Also, if using a "master" OIIO, downstream packages should require it
-# using
+# Also, if using a "master" OIIO, downstream packages should specify it as:
 #    - pkg: openimageio
-#      fromBuildEnv: x.x.x.x
-# but for "release" branches of OIIO, it's sufficient to use `x.x`.
+#      fromBuildEnv: Binary
 #
-compat: x.x.x.ab
+compat: x.x.a.b
 
 sources:
   # This idiom can work with any of (a) a local clone, (b) a git submodule,
   # or (c) nothing (does a fresh clone from GitHub).
   - path: ./
   - script:
-    - if [ ! -d oiio ] ; then git clone https://github.com/OpenImageIO/oiio -b v2.3.5.0-dev ; fi
+    - if [ ! -d oiio ] ; then git clone https://github.com/OpenImageIO/oiio -b v2.3.7.2 ; fi
 
 
 build:
@@ -34,16 +32,18 @@ build:
     - var: arch
     - var: os
     - var: centos
+    - var: python.abi
     - pkg: gcc/6.3
     - pkg: python/~3.7.0
     - pkg: pybind11/2.6.2
+    - pkg: numpy
     - pkg: cmake/^3.13
     - pkg: boost/~1.70.0
     - pkg: zlib
     - pkg: libtiff/4.3
-    - pkg: imath/~3.0.0
-    - pkg: openexr/~3.0.0
-    - pkg: fmt/7.1.3
+    - pkg: imath/~3.1.0
+    - pkg: openexr/~3.1.0
+    - pkg: fmt/~8.0.0
     - pkg: opencolorio/~2.0.1
     - pkg: giflib
     - pkg: libpng
@@ -53,7 +53,7 @@ build:
     - pkg: freetype
     - pkg: libjpeg
     - pkg: openjpeg
-    - pkg: tbb/2019
+    - pkg: tbb/2019.9
     - pkg: openvdb/8.0
     - pkg: libheif/1.12
     - pkg: ffmpeg/4.2
@@ -63,38 +63,45 @@ build:
     # - pkg: libsquish?
     # - pkg: jpeg-turbo?
     # optional: opencv?
-    - var: cxx/14
+    - var: oiio_cxx/14
       choices: [14, 17]
-    - var: debug/off
+    - var: oiio_debug/off
       choices: [on, off]
-    - var: sse4/on
+    - var: oiio_sse4/on
       choices: [on, off]
-    - var: avx2/off
+    - var: oiio_avx2/off
       choices: [on, off]
-    - var: avx512f/off
+    - var: oiio_avx512f/off
       choices: [on, off]
 
   # variants declares the default set of variants to build and publish
   # using the spk build and make-* commands
   variants:
-    - { gcc: 6.3, cxx: 14, python: ~2.7.0, boost: ~1.70.0 }
-    - { gcc: 6.3, cxx: 14, python: ~3.7.0, boost: ~1.70.0 }
-    - { gcc: 9.3, cxx: 17, python: ~2.7.0, boost: ~1.73.0 }
-    - { gcc: 9.3, cxx: 17, python: ~3.7.0, boost: ~1.73.0 }
+    # VFX Platform 2019-ish, Maya 2020, Houdini 18
+    - { gcc: 6.3, oiio_cxx: 14, python: ~2.7.0, python.abi: "cp27mu", boost: ~1.70.0, openexr: ~2.4.3, imath: ~2.4.0 }
+    # VFX Platform 2020-ish (Nuke 13?)
+    - { gcc: 6.3, oiio_cxx: 14, python: ~3.7.0, python.abi: "cp37m", boost: ~1.70.0, openexr: ~2.4.3, imath: ~2.4.0 }
+    # VFX Platform 2021-ish, Maya 2022, Houdini 19
+    - { gcc: 9.3, oiio_cxx: 17, python: ~3.7.0, python.abi: "cp37m", boost: ~1.73.0, openexr: ~2.4.3, imath: ~2.4.0 }
+    # VFX Platform 2022-ish (including newer Imath + OpenEXR versions)
+    - { gcc: 9.3, oiio_cxx: 17, python: ~3.7.0, python.abi: "cp37m", boost: ~1.73.0, openexr: ~3.1.0, imath: ~3.1.0 }
+    # # unneeded?
+    # # - { gcc: 9.3, cxx: 17, python: ~2.7.0, boost: ~1.73.0, openexr: ~2.4.0, imath: ~2.4.0 }
 
   script:
     - export SIMD_OPTS="-DUSE_SIMD=sse2"
-    - if [ "$SPK_OPT_sse4" == "on" ] ; then SIMD_OPTS+=",sse4.2" ; fi
-    - if [ "$SPK_OPT_avx2" == "on" ] ; then SIMD_OPTS+=",avx2" ; fi
-    - if [ "$SPK_OPT_avx512f" == "on" ] ; then SIMD_OPTS+=",avx512f" ; fi
+    - if [ "$SPK_OPT_oiio_sse4" == "on" ] ; then SIMD_OPTS+=",sse4.2" ; fi
+    - if [ "$SPK_OPT_oiio_avx2" == "on" ] ; then SIMD_OPTS+=",avx2" ; fi
+    - if [ "$SPK_OPT_oiio_avx512f" == "on" ] ; then SIMD_OPTS+=",avx512f" ; fi
     - export CMAKE_BUILD_TYPE=Release
-    - if [ "${SPK_OPT_debug}" == "debug" ] ; then export CMAKE_BUILD_TYPE=Debug ; fi
+    - if [ "${SPK_OPT_oiio_debug}" == "debug" ] ; then export CMAKE_BUILD_TYPE=Debug ; fi
+    - export CI=1
     - cmake -S oiio -B build -G Ninja
         -DVERBOSE=1
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
         -DCMAKE_INSTALL_PREFIX=${PREFIX}
         -DCMAKE_PREFIX_PATH=${PREFIX}
-        -DCMAKE_CXX_STANDARD=${SPK_OPT_cxx}
+        -DCMAKE_CXX_STANDARD=${SPK_OPT_oiio_cxx}
         ${SIMD_OPTS}
         -DPYBIND11_PYTHON_VERSION=${SPK_PKG_python_VERSION_BASE}
         -DPYTHON_VERSION=${SPK_PKG_python_VERSION_BASE}
@@ -110,42 +117,49 @@ build:
 install:
   requirements:
     - pkg: gcc
-      fromBuildEnv: x.x
+      fromBuildEnv: Binary
     - pkg: python
-      fromBuildEnv: x.x
+      fromBuildEnv: Binary
       # If python is already in the environment/resolve then we
       # we require it to be compatible with what we built with.
       # But no python at all is also okay.
       include: IfAlreadyPresent
+    - { var: python.abi, fromBuildEnv: true }
+    - pkg: numpy
+      fromBuildEnv: Binary
     - pkg: boost
-      fromBuildEnv: x.x
-    - pkg: imath
-      fromBuildEnv: x.x
+      fromBuildEnv: Binary
     - pkg: fmt
-      fromBuildEnv: x.x
+      fromBuildEnv: Binary
+    - pkg: imath
+      fromBuildEnv: Binary
     - pkg: openexr
-      fromBuildEnv: x.x
+      fromBuildEnv: Binary
     - pkg: opencolorio
-      fromBuildEnv: x.x
+      fromBuildEnv: Binary
+    - pkg: libtiff
+      fromBuildEnv: Binary
     - pkg: giflib
-      fromBuildEnv: x.x
+      fromBuildEnv: Binary
     - pkg: libpng
-      fromBuildEnv: x.x
+      fromBuildEnv: Binary
     - pkg: pugixml
-      fromBuildEnv: x.x
+      fromBuildEnv: Binary
     - pkg: libraw
-      fromBuildEnv: x.x
+      fromBuildEnv: Binary
     - pkg: freetype
-      fromBuildEnv: x.x
+      fromBuildEnv: Binary
     - pkg: openjpeg
-      fromBuildEnv: x.x
+      fromBuildEnv: Binary
     - pkg: libjpeg
-      fromBuildEnv: x.x
+      fromBuildEnv: Binary
     - pkg: tbb
-      fromBuildEnv: x.x
+      fromBuildEnv: Binary
     - pkg: openvdb
-      fromBuildEnv: x.x
+      fromBuildEnv: Binary
     - pkg: libheif
-      fromBuildEnv: x.x
+      fromBuildEnv: Binary
     - pkg: ffmpeg
-      fromBuildEnv: x.x
+      fromBuildEnv: Binary
+    - pkg: zlib
+      fromBuildEnv: Binary

--- a/packages/osl/osl.spk.yaml
+++ b/packages/osl/osl.spk.yaml
@@ -1,0 +1,139 @@
+pkg: osl/1.11.15.0
+  # - name: "Open Shading Language"
+  # - description: "Shading language for modern physically based renderers"
+  # - url: https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+  # - author: "Larry Gritz <lg@larrygritz.com>"
+  # - license: BSD-3-clause
+  # - bindings: [ "C++", "Python", "cli" ]
+
+# If building off the master/development branch of OSL, there is no
+# guarantee of API or ABI compatibility (except for the most minor level of
+# patches), so be stricter than usual, with "x.x.a.b". If building from a
+# release branch, however, the usual x.a.b correctly reflects OSL's
+# compatibility promises for release branches.
+#
+# Downstream packages should require
+#    - pkg: osl
+#      fromBuildEnv: Binary
+#
+compat: x.x.a.b
+
+sources:
+  # This idiom can work with any of (a) a local clone, (b) a git submodule,
+  # or (c) nothing (does a fresh clone from GitHub).
+  - path: ./
+  - script:
+    - if [ ! -d OpenShadingLanguage ] ; then git clone https://github.com/AcademySoftwareFoundation/OpenShadingLanguage -b v1.11.15.0 ; fi
+
+
+build:
+
+  options:
+    - var: arch
+    - var: os
+    - var: centos
+    - var: python.abi
+    - pkg: cmake/^3.13
+    - pkg: gcc/~6.3.0
+    - pkg: llvm/~12.0.1
+    - pkg: openimageio/~2.3.7
+    - pkg: python/~3.7.0
+    - pkg: pybind11/2.6.2
+    - pkg: boost/~1.70.0
+    - pkg: imath/~3.1.2
+    - pkg: pugixml
+    - pkg: zlib
+    - pkg: cuda/~11.3
+    - pkg: optix/~7.3
+    - pkg: partio/~1.11.0
+    - var: cxx/14
+      choices: [14, 17]
+    - var: debug/off
+      choices: [on, off]
+    - var: sse4/on
+      choices: [on, off]
+    - var: avx2/off
+      choices: [on, off]
+    - var: avx512f/off
+      choices: [on, off]
+    - var: osloptix/on
+      choices: [on, off]
+    - var: oslbatch
+    - var: oslcudatarget/sm_61
+
+  # variants declares the default set of variants to build and publish
+  # using the spk build and make-* commands
+  variants:
+    # VFX Platform 2019-ish, Maya 2020, Houdini 18
+    - { gcc: ~6.3.0, cxx: 14, python: ~2.7.0, python.abi: "cp27mu", boost: ~1.70.0, openexr: ~2.4.3, imath: ~2.4.0 }
+    # VFX Platform 2020-ish (Nuke 13?)
+    - { gcc: 6.3, cxx: 14, python: ~3.7.0, python.abi: "cp37m", boost: ~1.70.0, openexr: ~2.4.3, imath: ~2.4.0 }
+    # VFX Platform 2021-ish, Maya 2022, Houdini 19
+    - { gcc: 9.3, cxx: 17, python: ~3.7.0, python.abi: "cp37m", boost: ~1.73.0, openexr: ~2.4.3, imath: ~2.4.0 }
+    # VFX Platform 2022-ish (including newer Imath + OpenEXR versions)
+    - { gcc: 9.3, cxx: 17, python: ~3.7.0, python.abi: "cp37m", boost: ~1.73.0, openexr: ~3.1.0, imath: ~3.1.2 }
+
+  script:
+    - env | sort
+    - export SIMD_OPTS="-DUSE_SIMD=sse2"
+    - if [ "$SPK_OPT_sse4" == "on" ] ; then SIMD_OPTS+=",sse4.2" ; fi
+    - if [ "$SPK_OPT_avx2" == "on" ] ; then SIMD_OPTS+=",avx2" ; fi
+    - if [ "$SPK_OPT_avx512f" == "on" ] ; then SIMD_OPTS+=",avx512f" ; fi
+    - export CMAKE_BUILD_TYPE=Release
+    - if [ "${SPK_OPT_debug}" == "debug" ] ; then export CMAKE_BUILD_TYPE=Debug ; fi
+    - export CI=1
+    - cmake -S OpenShadingLanguage -B build -G Ninja
+        -DVERBOSE=1
+        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+        -DCMAKE_INSTALL_PREFIX=${PREFIX}
+        -DCMAKE_PREFIX_PATH=${PREFIX}
+        -DCMAKE_CXX_STANDARD=${SPK_OPT_cxx}
+        ${SIMD_OPTS}
+        -DUSE_BATCHED=${SPK_OPT_batch}
+        -DUSE_OPTIX=${SPK_OPT_osloptix}
+        -DPYBIND11_PYTHON_VERSION=${SPK_PKG_python_VERSION_BASE}
+        -DPYTHON_VERSION=${SPK_PKG_python_VERSION_BASE}
+        -DOSL_SITE:STRING=spi
+        -DTBB_USE_DEBUG_BUILD=0
+        -DCUDA_TOOLKIT_ROOT_DIR=${CUDA_ROOT}
+        -DCUDA_TARGET_ARCH=${SPK_OPT_oslcudatarget}
+        -DEXTRA_CPP_ARGS:STRING=-DOSL_SPI=1
+        -DOSL_EXTRA_NVCC_ARGS="--compiler-bindir=/opt/rh/devtoolset-6/root/bin/gcc"
+    # Note: We reference devtoolset-6 here because we compile the code into
+    # PTX in C++14 mode, due to limitations of nvcc.
+    - cmake --build build --target install
+
+
+install:
+  requirements:
+    - pkg: gcc
+      fromBuildEnv: Binary
+    - pkg: python
+      fromBuildEnv: Binary
+      # If python is already in the environment/resolve then we
+      # we require it to be compatible with what we built with.
+      # But no python at all is also okay.
+      include: IfAlreadyPresent
+    - { var: python.abi, fromBuildEnv: true }
+    - pkg: openimageio
+      fromBuildEnv: Binary
+    - pkg: llvm
+      fromBuildEnv: Binary
+    - pkg: boost
+      fromBuildEnv: Binary
+    - pkg: imath
+      fromBuildEnv: Binary
+    - pkg: openexr
+      fromBuildEnv: Binary
+    - pkg: fmt
+      fromBuildEnv: Binary
+    - pkg: pugixml
+      fromBuildEnv: Binary
+    - pkg: zlib
+      fromBuildEnv: Binary
+    - pkg: cuda
+      fromBuildEnv: Binary
+    - pkg: optix
+      fromBuildEnv: Binary
+    - pkg: partio
+      fromBuildEnv: x.x

--- a/packages/partio/partio.spk.yaml
+++ b/packages/partio/partio.spk.yaml
@@ -1,0 +1,77 @@
+pkg: partio/1.14.0
+  # - name: "partio"
+  # - description: "Read/write/manipulate common particle formats"
+  # - license: BSD-3-clause
+  # - url: https://partio.us
+  # - bindings: [ "C++" ]
+
+sources:
+  # This idiom can work with any of (a) a local clone, (b) a git submodule,
+  # or (c) nothing (does a fresh clone).
+  - path: ./
+    filter: [ ]
+    subdir: partio
+  - script:
+    - if [ ! -d partio ] ; then git clone https://github.com/wdas/partio.git -b v1.14.0 ; fi
+
+build:
+  options:
+    - pkg: stdfs # provides the default filesystem structure (bin, lib, etc)
+    - var: arch    # rebuild if the arch changes
+    - var: os      # rebuild if the os changes
+    - var: centos  # rebuild if centos version changes
+    - var: python.abi
+    - pkg: gcc/6.3
+    - pkg: cmake/^3.15
+    - pkg: blosc
+    - pkg: alembic/~1.8.0
+    - pkg: tbb/2019
+    - pkg: openvdb/~8.0.0
+    - pkg: python/~2.7.0
+    - pkg: imath/~2.4.0
+
+  variants:
+    # VFX 2019-ish, Maya 2020, Houdini 18
+    - { gcc: 6.3, python: ~2.7.0, python.abi: "cp27mu", imath: 2.4 }
+    # VFX2020-ish, Nuke 13?
+    - { gcc: 6.3, python: ~3.7.0, python.abi: "cp37m", imath: 2.4 }
+    # VFX 2021-ish, Maya 2022, Houdini 19
+    - { gcc: 9.3, python: ~3.7.0, python.abi: "cp37m", imath: 2.4 }
+    # Cutting edge version: VFX Platform 2022 will look like this
+    - { gcc: 9.3, python: ~3.7.0, python.abi: "cp37m", imath: ~3.1.0 }
+
+  script:
+    - ls -l
+    - echo src
+    - ls -l partio
+    - cmake -S partio -B build 
+        -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_INSTALL_PREFIX=$PREFIX
+        -DCMAKE_PREFIX_PATH=$PREFIX
+        -DCMAKE_CXX_STANDARD=14
+        -DOpenVDB_ROOT=$PREFIX
+        -DTBB_ROOT=$PREFIX
+    - cmake --build build --target install
+
+install:
+  requirements:
+    - pkg: stdfs
+    - pkg: gcc
+      fromBuildEnv: x.x
+    - pkg: blosc
+      fromBuildEnv: x.x
+    - pkg: alembic
+      fromBuildEnv: x.x
+    - pkg: tbb
+      fromBuildEnv: x.x
+    - pkg: openvdb
+      fromBuildEnv: x.x
+    - pkg: imath
+      fromBuildEnv: x.x
+    - pkg: python
+      fromBuildEnv: x.x
+      # If python is already in the environment/resolve then we
+      # we require it to be compatible with what we built with.
+      # But no python at all is also okay.
+      include: IfAlreadyPresent
+    - { var: python.abi, fromBuildEnv: true }


### PR DESCRIPTION
* osl: New!

* partio: New!

* alembic: logic to allow it to build against either openexr 2.x
  or openexr+imath 3.x. Also make common variants.

* fmt: upgrade to 8.0.0

* imath: upgrade to 3.1.3, add python abi var, add a dummy package for
  imath 2.4.

* openexr: upgrade to 3.1.1

* openexr24: some minor updates and fixes, including compensating for a
  header that Alembic needs, that OpenEXR 2.4's build system neglected to
  install properly.

* openimageio: various fixes, including making all its "var" entries be
  oiio prefixed, because I don't trust spk to ensure that they can't
  conflict between packages.

Signed-off-by: Larry Gritz <lg@imageworks.com>