### PR TITLE
Package improvements: perl file mtime build fix

### DIFF
--- a/packages/perl/perl.spk.yaml
+++ b/packages/perl/perl.spk.yaml
@@ -17,7 +17,13 @@ build:
        -Dprefix=/spfs
        -Dvendorprefix=/spfs
        -Dusethreads
+     # The "touch" below is a workaround for the following issue:
+     #    https://github.com/Perl/perl5/issues/18252
+     # The dist/Devel-PPPort/t/01_test.t test file is read-only when building from a
+     # tarball. The Makefile attempts to write-append to this file and fails.
+     # This may not be needed in newer versions of perl.
+     - touch dist/Devel-PPPort/t/01_test.t
      - make
      - make install
      # do not keep man pages in the spk package
-     - rm -rf /spfs/man
+     - rm -rf /spfs/share/man


### PR DESCRIPTION
`dist/Devel-PPPort/t/01_test.t` is a generated file that is
built by the upstream Perl maintainer and included in the
perl source tarballs. Users should not need to regenerate this
file when building perl from a tarball.

`01_test.t` is generated by `dist/Devel-PPPort/mktest.PL`.
The Makefile will regenerate `01_test.t` when its mtime is older
than the mtime for `mktest.PL`.

If the `tar` extraction writes `mktest.PL` after `01_test.t`,
and the system clock crosses over the one-second mtime
resolution boundary in the time between when `01_test.t` and
`mktest.PL` was written, then `make` will attempt to regenerate
`01_test.t` during the build.

This is not a problem when perl is built from a `git clone`
because Git worktrees are ordinarily read-write. Building from
a tarball, though, results in a worktree whose files are
read-only `chmod 444`. `mktest.PL` will attempt to open
`01_test.t` for writing and fail.

Workaround the issue by using `touch` to update the `01_test.t`
mtime so that `make` does not try to generate it.

Related-to: https://github.com/Perl/perl5/issues/18252
Signed-off-by: David Aguilar <davvid@gmail.com>