### PR TITLE
Package improvements: update the mpc version for gcc

### DIFF
--- a/packages/gnu/gcc/gcc48.spk.yaml
+++ b/packages/gnu/gcc/gcc48.spk.yaml
@@ -17,7 +17,7 @@ build:
     - pkg: mpfr
       default: 4.1
     - pkg: mpc
-      default: 1.0
+      default: 1.1
     - pkg: autoconf
     - pkg: autogen
     - pkg: zip

--- a/packages/gnu/gcc/gcc63.spk.yaml
+++ b/packages/gnu/gcc/gcc63.spk.yaml
@@ -17,7 +17,7 @@ build:
     - pkg: mpfr
       default: 4.1
     - pkg: mpc
-      default: 1.0
+      default: 1.1
     #- pkg: autoconf
     - pkg: autogen
     - pkg: coreutils

--- a/packages/gnu/gcc/gcc93.spk.yaml
+++ b/packages/gnu/gcc/gcc93.spk.yaml
@@ -17,7 +17,7 @@ build:
     - pkg: mpfr
       default: 4.1
     - pkg: mpc
-      default: 1.0
+      default: 1.1
     - pkg: autoconf
     - pkg: autogen
     - pkg: make


### PR DESCRIPTION
The gcc packages were still referring to the older mpc 1.0. That version
does not exist but 1.1 does. Bump the version for gcc48, gcc63 and gcc93.

Signed-off-by: David Aguilar <davvid@gmail.com>