### PR TITLE
Better logging setup for the rust code

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -24,7 +24,7 @@ structlog.configure(
     logger_factory=structlog.stdlib.LoggerFactory(),
     wrapper_class=structlog.stdlib.BoundLogger,
 )
-spkrs.configure_logging(0)
+spkrs.configure_logging(2)
 
 
 @pytest.fixture

--- a/spk/cli/_args.py
+++ b/spk/cli/_args.py
@@ -140,7 +140,7 @@ def configure_spops() -> None:
 def configure_logging(args: argparse.Namespace) -> None:
 
     colorama.init()
-    spkrs.configure_logging(0)
+    spkrs.configure_logging(args.verbose)
 
     level = logging.INFO
     processors = [


### PR DESCRIPTION
Up until now, it was assumed that the only rust logging was spfs, but now as the codebase grows there is increasingly more information being logged in rust, and it was not showing up in tests or at the command line. Additionally, this changes the way that it is configured to only use the env filter, as the interplay between the two was convoluted at best. Now, we simply prepend the RUST_LOG env var with the default directives for the current verbosity level, allowing everything to be easily overridden with this variable as needed
