### PR TITLE
Fix a bug where the last solve graph could never be gotten

### DIFF
--- a/src/solve/solver.rs
+++ b/src/solve/solver.rs
@@ -302,11 +302,6 @@ impl Solver {
         state
     }
 
-    pub fn get_last_solve_graph(&self) -> Graph {
-        //self.last_graph.read().unwrap().clone()
-        todo!()
-    }
-
     pub fn reset(&mut self) {
         self.repos.clear();
         self.initial_state_builders.clear();


### PR DESCRIPTION
In the binary builder, we were relying on a method with no implementation, instead of the new rustier way to get this information. I've also updated this to avoid cloning the entire dataset unless needed because of an explicit call from python.