### PR TITLE
Update publish command to warn when nothing is published

### DIFF
--- a/spk/_publish.py
+++ b/spk/_publish.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/imageworks/spk
 
-from typing import Union
+from typing import List, Union
 
 import structlog
 
@@ -43,7 +43,7 @@ class Publisher:
         self._force = force
         return self
 
-    def publish(self, pkg: Union[str, api.Ident]) -> None:
+    def publish(self, pkg: Union[str, api.Ident]) -> List[api.Ident]:
 
         if not isinstance(pkg, api.Ident):
             pkg = api.parse_ident(pkg)
@@ -83,3 +83,5 @@ class Publisher:
                 else:
                     self._from.push_digest(digest, self._to)
             self._to.publish_package(spec, components)
+
+        return list(builds)

--- a/spk/cli/_cmd_publish.py
+++ b/spk/cli/_cmd_publish.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/imageworks/spk
 
-from typing import Any
+from typing import Any, List
 import argparse
 
 import structlog
@@ -57,8 +57,14 @@ def _publish(args: argparse.Namespace) -> None:
         .skip_source_packages(args.no_source)
     )
 
+    published: List[spk.api.Ident] = []
     for pkg in args.packages:
 
-        publisher.publish(pkg)
+        published.extend(publisher.publish(pkg))
+
+    if not published:
+        _LOGGER.warn(
+            "No packages were published, did you forget to specify a version number? (spk publish mypackage/1.0.2)"
+        )
 
     _LOGGER.info("done")


### PR DESCRIPTION
Simply adds a warning when you run the publish command but nothing was actually published (this is often because the version was not given)

Closes #197 