### PR TITLE
Fix bug where an empty variable created an unsolvable request

### DIFF
--- a/src/build/binary.rs
+++ b/src/build/binary.rs
@@ -338,7 +338,9 @@ impl BinaryPackageBuilder {
                     // no need to turn that into a requirement to
                     // find a var with an empty value.
                     if let Some(value) = opts.get(&opt.var) {
-                        requests.push(opt.to_request(Some(value)).into());
+                        if !value.is_empty() {
+                            requests.push(opt.to_request(Some(value)).into());
+                        }
                     }
                 }
             }

--- a/src/build/binary_test.rs
+++ b/src/build/binary_test.rs
@@ -29,3 +29,24 @@ fn test_split_manifest_permissions() {
     assert_eq!(run.get_path("bin").unwrap().mode, 0o754);
     assert_eq!(run.get_path("bin/runme").unwrap().mode, 0o555);
 }
+
+#[rstest]
+fn test_empty_var_option_is_not_a_request() {
+    let spec: crate::api::Spec = serde_yaml::from_str(
+        r#"{
+        pkg: mypackage/1.0.0,
+        build: {
+            options: [
+                {var: something}
+            ]
+        }
+    }"#,
+    )
+    .unwrap();
+    let builder = super::BinaryPackageBuilder::from_spec(spec);
+    let requirements = builder.get_build_requirements().unwrap();
+    assert!(
+        requirements.is_empty(),
+        "a var option with empty value should not create a solver request"
+    )
+}


### PR DESCRIPTION
Empty var option strings are supposed to be the same as no value at all, but the `BinaryPackageBuilder` was adding requests that specifically asked for an empty string, which is basically unsolvable.