### PR TITLE
Update rust linting to actually fail in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ clean: packages.clean
 .PHONY: lint lint-rust
 lint: lint-rust
 lint-rust:
-	cargo clippy
+	cargo fmt --check
+	cargo clippy -- -Dwarnings
 
 .PHONY: format
 format:

--- a/src/api/spec.rs
+++ b/src/api/spec.rs
@@ -78,7 +78,7 @@ impl Spec {
 
     /// Check if this package spec satisfies the given var request.
     pub fn satisfies_var_request(&self, request: &VarRequest) -> Compatibility {
-        let opt_required = request.package().as_deref() == Some(self.pkg.name());
+        let opt_required = request.package() == Some(self.pkg.name());
         let mut opt: Option<&Opt> = None;
         let request_name = &request.var;
         for o in self.build.options.iter() {

--- a/src/build/binary.rs
+++ b/src/build/binary.rs
@@ -533,7 +533,7 @@ fn split_manifest_by_component(
 // NOTE(rbottriell): permission changes are not properly reset by spfs
 // so we must deal with them manually for now
 pub fn reset_permissions<P: AsRef<relative_path::RelativePath>>(
-    diffs: &mut Vec<spfs::tracking::Diff>,
+    diffs: &mut [spfs::tracking::Diff],
     prefix: P,
 ) -> Result<()> {
     use spfs::tracking::DiffMode;

--- a/src/solve/solver.rs
+++ b/src/solve/solver.rs
@@ -116,8 +116,10 @@ impl Solver {
             }
         }
 
-        let mut solver = Solver::default();
-        solver.repos = self.repos.clone();
+        let mut solver = Solver {
+            repos: self.repos.clone(),
+            ..Default::default()
+        };
         solver.update_options(opts);
         solver.solve_build_environment(spec)
     }


### PR DESCRIPTION
I removed the flag that caused clippy to actually fail in CI thinking it was for python issues only, and a couple of things slipped through. We should also be validating the formatting just in case.