### PR TITLE
Make option map sortable

### DIFF
--- a/src/api/option_map.rs
+++ b/src/api/option_map.rs
@@ -71,7 +71,7 @@ pub fn host_options() -> crate::Result<OptionMap> {
 }
 
 /// A set of values for package build options.
-#[derive(Default, Clone, Hash, PartialEq, Eq, Serialize)]
+#[derive(Default, Clone, Hash, PartialEq, Eq, Serialize, Ord, PartialOrd)]
 #[serde(transparent)]
 pub struct OptionMap {
     options: BTreeMap<String, String>,


### PR DESCRIPTION
Pretty simple, the `BTreeMap` is already sortable, so we just derive for the `Ord` traits. This is really just for API usage of spk as a library.