### PR TITLE
Only go through the rpm build process for on builds of master

### DIFF
--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -2,8 +2,6 @@ name: RPM & Packages
 
 on:
   workflow_dispatch:
-  pull_request:
-    branches: [master]
   push:
     branches: [master]
 


### PR DESCRIPTION
Now that the rpm build process is basically just a rust build in release mode, there's little purpose in doing said builds for the vast majority of pull requests. This change disables it on merge requests by default, though you should still be able to trigger it manually if desired. We maintain rpm builds for every merge to master.