### PR TITLE
Enable local repo by default (always)

### DIFF
--- a/src/cli/cmd_ls.rs
+++ b/src/cli/cmd_ls.rs
@@ -41,7 +41,6 @@ impl Run for Ls {
         if repos.is_empty() {
             let local = String::from("local");
             if !self.repos.disable_repo.contains(&local) {
-                self.repos.local_repo = true;
                 repos = self.repos.get_repos(None)?;
             } else {
                 eprintln!(

--- a/src/cli/cmd_test.rs
+++ b/src/cli/cmd_test.rs
@@ -47,20 +47,12 @@ impl Run for Test {
     fn run(&mut self) -> Result<i32> {
         let _runtime = self.runtime.ensure_active_runtime()?;
         let options = self.options.get_options()?;
-        let mut repos: Vec<_> = self
+        let repos: Vec<_> = self
             .repos
             .get_repos(None)?
             .into_iter()
             .map(|(_, r)| Arc::new(r))
             .collect();
-        if !self.repos.no_local_repo && !self.repos.local_repo {
-            // when testing, the local repo is included by default
-            repos.push(Arc::new(
-                spk::HANDLE
-                    .block_on(spk::storage::local_repository())?
-                    .into(),
-            ));
-        }
         let source = if self.here { Some(".".into()) } else { None };
 
         for package in &self.packages {

--- a/src/cli/flags.rs
+++ b/src/cli/flags.rs
@@ -405,10 +405,6 @@ where
 
 #[derive(Args, Clone)]
 pub struct Repositories {
-    /// Resolve packages from the local repository
-    #[clap(short, long)]
-    pub local_repo: bool,
-
     /// Disable resolving packages from the local repository
     #[clap(long)]
     pub no_local_repo: bool,
@@ -454,7 +450,7 @@ impl Repositories {
         defaults: I,
     ) -> Result<Vec<(String, spk::storage::RepositoryHandle)>> {
         let mut repos = Vec::new();
-        if self.local_repo && !self.no_local_repo {
+        if !self.no_local_repo {
             let repo = spk::HANDLE.block_on(spk::storage::local_repository())?;
             repos.push(("local".into(), repo.into()));
         }


### PR DESCRIPTION
Since the `spk` command is mostly used by developers, and it is common to
mostly be working against the local repository, make the local repository
enabled by default. It is still possible to opt out of this with the
`--no-local-repo` flag.

Partly addresses #291.

Signed-off-by: J Robert Ray <jrray@imageworks.com>