### PR TITLE
Fix for a test that fails when the tmpdir is symlinked

### DIFF
--- a/src/build/binary_test.rs
+++ b/src/build/binary_test.rs
@@ -78,7 +78,14 @@ fn test_build_workdir(tmpdir: tempdir::TempDir) {
         .unwrap();
 
     let out = std::fs::read_to_string(out_file).unwrap();
-    assert_eq!(out.trim(), &tmpdir.path().to_string_lossy());
+    assert_eq!(
+        out.trim(),
+        &tmpdir
+            .path()
+            .canonicalize()
+            .expect("tmpdir can be canonicalized")
+            .to_string_lossy()
+    );
 }
 
 #[rstest]


### PR DESCRIPTION
This fixes a test that fails when the tmpdir used in testing is symlinked to another filesystem. 