### PR TITLE
Add counters and rates to solver stats

### DIFF
--- a/src/solve/package_iterator.rs
+++ b/src/solve/package_iterator.rs
@@ -20,6 +20,7 @@ pub trait BuildIterator: DynClone + Send + Sync + std::fmt::Debug {
     }
     fn next(&mut self) -> crate::Result<Option<(Arc<api::Spec>, PackageSource)>>;
     fn version_spec(&self) -> Option<Arc<api::Spec>>;
+    fn len(&self) -> usize;
 }
 
 dyn_clone::clone_trait_object!(BuildIterator);
@@ -246,6 +247,10 @@ impl BuildIterator for RepositoryBuildIterator {
     fn version_spec(&self) -> Option<Arc<api::Spec>> {
         self.spec.clone()
     }
+
+    fn len(&self) -> usize {
+        self.builds.len()
+    }
 }
 
 impl RepositoryBuildIterator {
@@ -284,6 +289,10 @@ impl BuildIterator for EmptyBuildIterator {
     fn version_spec(&self) -> Option<Arc<api::Spec>> {
         None
     }
+
+    fn len(&self) -> usize {
+        0
+    }
 }
 
 impl EmptyBuildIterator {
@@ -314,6 +323,10 @@ impl BuildIterator for SortedBuildIterator {
 
     fn version_spec(&self) -> Option<Arc<api::Spec>> {
         self.source.lock().unwrap().version_spec()
+    }
+
+    fn len(&self) -> usize {
+        self.builds.len()
     }
 }
 


### PR DESCRIPTION
This adds counters and rates for actions taken during a solver run.  It is built on the changes in https://github.com/imageworks/spk/pull/311 , and is another of the changes we've been using for some time.

- Data is recorded for these actions: steps taken (forward), steps back, total builds examined (considered), builds tried and discarded (skipped), incompatible versions, and incompatible builds. 
    - The step back counter is shared with, and updated by, the `StepBack` change/decision objects
    - The other counter are updated by the solver (`Solver` and `SolverRuntime`)
- The new data is added to the `format_solve_stats()` output enabled by the `--time|-t` option.

Example output, package names changed, times from a debug build, so release is faster:
```sh
# A short solve
> spk explain python/2 -t
> RESOLVE python/2.7.11/HCCWE6CD
>> RESOLVE stdfs/1.0.0/3I42H3S6
 Solver took: 0.38111904300000005 seconds
 Solver skipped 0 incompatible versions (total of 0 builds)
 Solver tried and discarded 24 package builds
 Solver considered 26 package builds in total, at 68.220 builds/sec
 Solver took 2 steps (resolves)
 Solver took 0 steps back (unresolves)
 Solver took 2 steps total, at 5.248 steps/sec
 Solver hit no problems
Installed Packages:
  python:run/=2.7.11/HCCWE6CD {arch=x86_64, centos=7, gcc=~9.3.1, os=linux, stdfs=~1.0}
  stdfs:run/=1.0.0/3I42H3S6 {}

# A longer solve
> spk explain pkg1 pkg2 -t
...
 Solver took: 5.770725539 seconds
 Solver skipped 9 incompatible versions (total of 29 builds)
 Solver tried and discarded 143 package builds
 Solver considered 214 package builds in total, at 37.084 builds/sec
 Solver took 88 steps (resolves)
 Solver took 26 steps back (unresolves)
 Solver took 114 steps total, at 19.755 steps/sec
 Solver hit these problems:
   6 times could not satisfy 'pkg1:run/Binary:203.0.0'
   6 times could not satisfy 'stdfs:run'
   4 times could not satisfy 'pkg2:run'
   1 time could not satisfy 'pkg3:run/2.4.0,3.1.0'
Installed Packages:
...
```