### PR TITLE
Add more state data output when solving with higher verbosities

### DIFF
--- a/src/solve/graph.rs
+++ b/src/solve/graph.rs
@@ -932,6 +932,10 @@ impl State {
         &self.var_requests
     }
 
+    pub fn get_resolved_packages(&self) -> &Vec<(Arc<api::Spec>, PackageSource)> {
+        &self.packages
+    }
+
     fn with_options(&self, options: Vec<(String, String)>) -> Self {
         let state_id = self.state_id.with_options(&options);
         Self {


### PR DESCRIPTION
This adds more state data output when solving with verbosity set higher than typical. This is another of the changes we've been using for some time. It was branched from the changes in https://github.com/imageworks/spk/pull/313 and this PR is against that branch, but doesn't require it.

The verbosity numbers are a little arbitrary,  just higher than people usually use. I thought about adding command line parameters or other configuration for them. But left that and used verbosity for now.

These additions help debugging large solves and comparing solver changes:
- Adds `State` `pkg_requests` and `packages` output when `verbosity > 5`
- Adds `State` `var_requests` and `options` set when `verbosity > 9`
- Adds level number into level indentation display when `verbosity > 2 and level > 5`.  This saves counting the indentation marks when comparing larger (15-150+ level) solves after solver updates and trying to isolate at what level a resolve was made.
- Adds `(IfAlreadyPresent)` to the formatted output for requests that have `IfAlreadyPresent` set.

This also adds `get_resolved_packages()` method to `State` objects.

Example output, truncated, package names changed:
```sh
# Addtional State output, IfAlreadyPresent
> spk explain -t python/3 -vvvvvvvvvvvvvvvvvvvv
...
DEBUG spk::flags: using repository repo=local
DEBUG spk::flags: using repository repo=origin
State Requests: 
State Resolved: 
State  VarReqs: ""
State  Options: {}
 ASSIGN {arch=x86_64, centos=7, distro=centos, os=linux}
 REQUEST {arch=x86_64}
 REQUEST {centos=7}
 REQUEST {distro=centos}
 REQUEST {os=linux}
 REQUEST python:run/3
State Requests: python:run/3
State Resolved: 
State  VarReqs: "arch: x86_64, centos: 7, distro: centos, os: linux"
State  Options: {arch=x86_64, centos=7, distro=centos, os=linux}
> RESOLVE python/3.9.7/MMH5SV2  (requested by command line)
. REQUEST gcc:run/6.3.0 (IfAlreadyPresent)
. REQUEST stdfs:run/*
. ASSIGN {python=~3.9.7, python.abi=cp39, python.arch=x86_64, python.bzip2=~1.0.6, python.centos=7, python.debug=off, python.gcc=~6.3.1, python.os=linux, python.pymalloc=on, python.stdfs=~1.0}
State Requests: python:run/3, gcc:run/6.3.0 (IfAlreadyPresent), stdfs:run/*
State Resolved: python/3.9.7/MMH5SV2
State  VarReqs: "arch: x86_64, centos: 7, distro: centos, os: linux"
State  Options: {arch=x86_64, centos=7, distro=centos, os=linux, python=~3.9.7, python.abi=cp39, python.arch=x86_64, python.bzip2=~1.0.6, python.centos=7, python.debug=off, python.gcc=~6.3.1, python.os=linux, python.pymalloc=on, python.stdfs=~1.0}
>> RESOLVE stdfs/1.0.0/3I42HS6  (requested by python/3.9.7/MMH5SV2)
.. ASSIGN {stdfs=~1.0}
...

# Sample of level numbers in indentation,  many lines removed
> spk explain pkg1 -vvvvvv
...
>>>>> RESOLVE pkg5/2.1.1/LHJMLET6  (requested by pkg1/1.5.6/2P6XDV64)
..... REQUEST stdfs:run/*
..... REQUEST gcc:run/Binary:6.3.1
..... ASSIGN {...}
State Requests: ...
State Resolved: ...
6 >>>> RESOLVE pkg6/5.15.2/WDJHNTOU  (requested by pkg1/1.5.6/2P6XDV64)
6 .... REQUEST pkg2/2.7.0
6 .... REQUEST pkg7:run/=5.15.2
...
10 >>>>>>> RESOLVE pkg10/2.0.8/5J2TIMCP  (requested by pkg1/1.5.6/2P6XDV64, pkg8/3.0.6/4RXZ2YZ4)
10 ....... REQUEST pkg11:run/Binary:3.6.5
10 ....... REQUEST pkg2:run/Binary:2.7.11 (IfAlreadyPresent)
...
13 >>>>>>>>>> RESOLVE pkg13/1.1.5/57EY7QWF  (requested by pkg7/5.0.3/FQHYTBTV)
...
14 !!!!!!!!!!! BLOCKED could not satisfy pkg14/...
...
106 >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> RESOLVE pkg106/1.26.4/...
106 ...................................................................................................... REQUEST pkg2:run/3.7.0
107 >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> RESOLVE pkg107/20.12.5/...
...
```
