### PR TITLE
Adds tests for PkgOpt values

### DIFF
--- a/src/api/option_test.rs
+++ b/src/api/option_test.rs
@@ -13,9 +13,9 @@ use super::{PkgOpt, VarOpt};
 #[case("{pkg: my-pkg}", "2", false)]
 #[case("{pkg: my-pkg}", "2.7", false)]
 #[case("{pkg: my-pkg}", "~2.7", false)]
-#[case("{pkg: my-pkg}", "2,<3", false)] // This should work but doesn't
-#[case("{pkg: my-pkg}", "2,3", false)] // This should work but doesn't
-#[case("{pkg: my-pkg}", "2.7,<3", false)] // This should work but doesn't
+#[case("{pkg: my-pkg}", "2,<3", false)]
+#[case("{pkg: my-pkg}", "2,3", false)]
+#[case("{pkg: my-pkg}", "2.7,<3", false)]
 #[case("{pkg: my-pkg}", "<3", false)]
 #[case("{pkg: my-pkg}", ">3", false)]
 fn test_pkg_opt_validation(#[case] spec: &str, #[case] value: &str, #[case] expect_err: bool) {


### PR DESCRIPTION
This adds more tests for PkgOpt values to show some values that used to be allowed, but that don't work anymore. I think these values should still be valid, shouldn't they?

