### PR TITLE
Remove `cargo fmt` from workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,6 @@ jobs:
       SPFS_PULL_PASSWORD: ${{ secrets.SPFS_PULL_PASSWORD }}
     steps:
       - uses: actions/checkout@v2
-      - name: Check Rust Formatting
-        run: cargo fmt -- --check
       - run: sudo apt-get install -y libcap-dev
       - name: Patch spfs Pull Auth
         run: sed -i "s|github.com|$SPFS_PULL_USERNAME:$SPFS_PULL_PASSWORD@github.com|" Cargo.toml


### PR DESCRIPTION
This formatting check is also done when `make lint-rust` runs later in the
workflow.

Signed-off-by: J Robert Ray <jrray@imageworks.com>