### PR TITLE
Enable lto when building for release

### DIFF
--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -3,7 +3,8 @@ name: RPM & Packages
 on:
   workflow_dispatch:
   push:
-    branches: [master]
+    tags:
+      - 'v*
 
 jobs:
   build:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,3 +58,7 @@ nix = "0.23.1"
 proptest = "1.0.0"
 rstest = "0.9.0"
 spk = { path = ".", features = ["test-macros"] }
+
+[profile.release]
+lto = true
+codegen-units = 1


### PR DESCRIPTION
Following suit with https://github.com/imageworks/spfs/pull/125

Change the rpm workflow to only run when a (release) tag is created.

Stats...

```
w/o lto: 28,007,832 @ 1m 53s
  w lto: 16,674,256 @ 5m 01s
```

Signed-off-by: J Robert Ray <jrray@imageworks.com>