### PR TITLE
Require non-numeric tag names

### DIFF
--- a/src/parsing/version.rs
+++ b/src/parsing/version.rs
@@ -39,7 +39,7 @@ where
 /// Parse a valid version pre- or post-tag.
 ///
 /// A valid tag is comprised of a string and a number, separated
-/// by a `.`.
+/// by a `.`. The string portion may not consist of only numbers.
 ///
 /// Examples:
 /// - `"r.0"`


### PR DESCRIPTION
This addresses #329 in a more relaxed sense that it doesn't require the tag
begin with a letter but a letter must appear somewhere in the tag.

With this change, the property test can now generate tag sets with more
than one entry. This ended up revealing a problem in the parser and was
fixed in the previous commit.

The property tests also now generate invalid `Version` instances to verify
those are detected as invalid.

Signed-off-by: J Robert Ray <jrray@imageworks.com>