### PR TITLE
Update `configure_sentry` to use `whoami`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2617,7 +2617,7 @@ dependencies = [
  "url",
  "uuid",
  "walkdir",
- "whoami",
+ "whoami 0.9.0",
 ]
 
 [[package]]
@@ -2666,6 +2666,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "whoami 1.2.1",
 ]
 
 [[package]]
@@ -3424,6 +3425,16 @@ name = "whoami"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7884773ab69074615cb8f8425d0e53f11710786158704fca70f53e71b0e05504"
+
+[[package]]
+name = "whoami"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524b58fa5a20a2fb3014dd6358b70e6579692a56ef6fce928834e488f42f65e8"
+dependencies = [
+ "wasm-bindgen",
+ "web-sys",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ tokio = { version = "1.15", features = ["rt"] }
 tracing = "0.1.25"
 tracing-subscriber = "0.2.16"
 url = "2.2"
+whoami = "1.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 nix = "0.23.1"

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -9,6 +9,9 @@ use once_cell::sync::Lazy;
 
 #[cfg(feature = "sentry")]
 pub fn configure_sentry() -> sentry::ClientInitGuard {
+    // Call this before `sentry::init` to avoid potential `SIGSEGV`.
+    let username = whoami::username();
+
     // When using the sentry feature it is expected that the DSN
     // and other configuration is provided at *compile* time.
     let guard = sentry::init((
@@ -22,14 +25,12 @@ pub fn configure_sentry() -> sentry::ClientInitGuard {
         },
     ));
 
-    if let Ok(username) = std::env::var("USER") {
-        sentry::configure_scope(|scope| {
-            scope.set_user(Some(sentry::User {
-                username: Some(username),
-                ..Default::default()
-            }))
-        });
-    }
+    sentry::configure_scope(|scope| {
+        scope.set_user(Some(sentry::User {
+            username: Some(username),
+            ..Default::default()
+        }))
+    });
 
     guard
 }


### PR DESCRIPTION
To be consistent with spfs, and to avoid a possible race condition as was
discovered in spfs.

Signed-off-by: J Robert Ray <jrray@imageworks.com>