### PR TITLE
flags: allow host options to be overridden

### DIFF
--- a/src/cli/flags.rs
+++ b/src/cli/flags.rs
@@ -218,10 +218,19 @@ impl Requests {
         I: IntoIterator<Item = S>,
         S: AsRef<str>,
     {
-        let options = options.get_options()?;
-
         let mut out = Vec::<spk::api::Request>::new();
-        for (name, value) in spk::api::host_options()?.into_iter() {
+        let var_requests = options.get_var_requests()?;
+        let mut options = match options.no_host {
+            true => spk::api::OptionMap::default(),
+            false => spk::api::host_options()?,
+        };
+        // Insert var_requests, which includes requests specified on the command-line,
+        // into the map so that they can override values provided by host_options().
+        for req in var_requests {
+            options.insert(req.var, req.value);
+        }
+
+        for (name, value) in options.iter() {
             if !value.is_empty() {
                 out.push(spk::api::VarRequest::new_with_value(name, value).into());
             }


### PR DESCRIPTION
If a package was built on one distro (centos) then we are unable
to activate it using "spk env" on rhel because the requests are
incompatible due to the "distro" field.

One option is to use the --no-host option, but it is a
heavy-hammer that strips out all host options.

A more surgical approach would be to allow single host options
to be overriden.

Currently, "spk env -o distro=centos bash/5.1" does not resolve
when running on rhel because the "distro" option is always
clobbered by the option parser.

Change the order that options are parsed so that user-specified
options on the command-line override the automatic host
options.

Closes #387
Signed-off-by: David Aguilar <davvid@gmail.com>