### PR TITLE
Adding 'migration-to-components' feature 

### DIFF
--- a/.site/spi/spk.spec
+++ b/.site/spi/spk.spec
@@ -30,7 +30,7 @@ export SPDEV_CONFIG_FILE=.site/spi/.spdev.yaml
 dev toolchain install
 source ~/.bashrc
 # Include `--all` to also build spk-launcher
-dev env -- cargo build --release --features sentry --all
+dev env -- cargo build --release --features sentry --features migration-to-components --all
 
 %install
 mkdir -p %{buildroot}/usr/local/bin

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/cli/bin.rs"
 [features]
 sentry = ["dep:sentry"]
 test-macros = []
+migration-to-components = []
 
 [dependencies]
 anyhow = "1.0.56"

--- a/src/api/component_spec.rs
+++ b/src/api/component_spec.rs
@@ -74,6 +74,32 @@ pub enum Component {
 }
 
 impl Component {
+    /// Return the default build component based on migration-to-components feature
+    #[inline]
+    pub fn default_for_build() -> Self {
+        // For sites that started using spk after component support was added
+        #[cfg(not(feature = "migration-to-components"))]
+        return Component::Build;
+
+        // For migrating to packages with components while a site has
+        // packages that were published before components were supported.
+        #[cfg(feature = "migration-to-components")]
+        return Component::All;
+    }
+
+    /// Return the default run component based on migration-to-components feature
+    #[inline]
+    pub fn default_for_run() -> Self {
+        // For sites that started using spk after component support was added
+        #[cfg(not(feature = "migration-to-components"))]
+        return Component::Run;
+
+        // For migrating to packages with components while a site has
+        // packages that were published before components were supported.
+        #[cfg(feature = "migration-to-components")]
+        return Component::All;
+    }
+
     /// Parse a component name from a string, ensuring that it's valid
     pub fn parse<S: AsRef<str>>(source: S) -> Result<Self> {
         let source = source.as_ref();

--- a/src/build/binary.rs
+++ b/src/build/binary.rs
@@ -308,7 +308,9 @@ impl<'a> BinaryPackageBuilder<'a> {
                     )?;
                     if req.pkg.components.is_empty() {
                         // inject the default component for this context if needed
-                        req.pkg.components.insert(api::Component::Build);
+                        req.pkg
+                            .components
+                            .insert(api::Component::default_for_build());
                     }
                     requests.push(req.into());
                 }

--- a/src/build/binary_test.rs
+++ b/src/build/binary_test.rs
@@ -501,9 +501,9 @@ async fn test_default_build_component() {
     let req = requirements.get(0).unwrap();
     match req {
         api::Request::Pkg(req) => {
-            assert_eq!(req.pkg.components, vec![api::Component::Build].into_iter().collect(),
-                    "a build request with no components should have the default build component injected automatically"
-                );
+            assert_eq!(req.pkg.components, vec![api::Component::default_for_build()].into_iter().collect(),
+                "a build request with no components should have the default build component injected automatically"
+            );
         }
         _ => panic!("expected pkg request"),
     }

--- a/src/cli/flags.rs
+++ b/src/cli/flags.rs
@@ -298,7 +298,9 @@ impl Requests {
             req.add_requester(spk::api::RequestedBy::CommandLine);
 
             if req.pkg.components.is_empty() {
-                req.pkg.components.insert(spk::api::Component::Run);
+                req.pkg
+                    .components
+                    .insert(spk::api::Component::default_for_run());
             }
             if req.required_compat.is_none() {
                 req.required_compat = Some(spk::api::CompatRule::API);

--- a/src/solve/graph.rs
+++ b/src/solve/graph.rs
@@ -224,7 +224,10 @@ impl<'state, 'cmpt> DecisionBuilder<'state, 'cmpt> {
         if req.pkg.components.is_empty() {
             // if no component was requested specifically,
             // then we must assume the default run component
-            req.to_mut().pkg.components.insert(api::Component::Run);
+            req.to_mut()
+                .pkg
+                .components
+                .insert(api::Component::default_for_run());
         }
 
         // Add the package that would make this request, into the request

--- a/src/solve/graph_test.rs
+++ b/src/solve/graph_test.rs
@@ -118,8 +118,11 @@ fn test_request_default_component() {
         .get_merged_request(api::PkgName::new("dependency").unwrap())
         .unwrap();
     assert!(
-        request.pkg.components.contains(&api::Component::Run),
-        "default run component should be injected when none specified"
+        request
+            .pkg
+            .components
+            .contains(&api::Component::default_for_run()),
+        "default component should be injected when none specified"
     );
 
     let build_state = DecisionBuilder::new(spec, &base)
@@ -130,7 +133,10 @@ fn test_request_default_component() {
         .get_merged_request(api::PkgName::new("dependency").unwrap())
         .unwrap();
     assert!(
-        request.pkg.components.contains(&api::Component::Run),
-        "default run component should be injected when none specified"
+        request
+            .pkg
+            .components
+            .contains(&api::Component::default_for_run()),
+        "default component should be injected when none specified"
     );
 }

--- a/src/solve/solver.rs
+++ b/src/solve/solver.rs
@@ -92,7 +92,10 @@ impl Solver {
         let request = match request {
             Request::Pkg(mut request) => {
                 if request.pkg.components.is_empty() {
-                    request.pkg.components.insert(api::Component::Run);
+                    request
+                        .pkg
+                        .components
+                        .insert(api::Component::default_for_run());
                 }
                 Change::RequestPackage(RequestPackage::new(request))
             }
@@ -426,7 +429,10 @@ impl Solver {
                 // if no components were explicitly requested in a build option,
                 // then we inject the default for this context
                 if request.pkg.components.is_empty() {
-                    request.pkg.components.insert(Component::Build);
+                    request
+                        .pkg
+                        .components
+                        .insert(Component::default_for_build());
                 }
                 self.add_request(request.into())
             }


### PR DESCRIPTION
This adds the `migration-to-components` feature to help sites that are migrating to spk with component support from repos of packages published without component support. It adds `default_for_run()` and `default_for_build()` methods to the `Component` enum to support the change.

When enabled, `migration-to-components` sets the default component to `Component::All` for solver and build env requests that do not specify components. Without this feature, those requests default to `Component::Run` and `Component::Build` respectively, and that is problematic for packages published before components were introduced because they expect all components to always be present in packages they depend on.