### PR TITLE
Bring back the ability for options to specify builds

### DIFF
--- a/src/api/build_spec_test.rs
+++ b/src/api/build_spec_test.rs
@@ -7,6 +7,18 @@ use super::BuildSpec;
 use crate::{api, opt_name, option_map};
 
 #[rstest]
+fn test_variants_may_have_a_build() {
+    let res: serde_yaml::Result<BuildSpec> = serde_yaml::from_str(
+        r#"{
+        options: [{pkg: "my-pkg"}],
+        variants: [{my-pkg: "1.0.0/QYB6QLCN"}],
+    }"#,
+    );
+
+    assert!(res.is_ok());
+}
+
+#[rstest]
 fn test_variants_must_be_unique() {
     // two variants end up resolving to the same set of options
     let res: serde_yaml::Result<BuildSpec> = serde_yaml::from_str(

--- a/src/api/option_test.rs
+++ b/src/api/option_test.rs
@@ -9,10 +9,11 @@ use super::{PkgOpt, VarOpt};
 #[case("{pkg: my-pkg}", "1", false)]
 #[case("{pkg: my-pkg}", "none", true)]
 #[case("{pkg: my-pkg}", "", false)]
+#[case("{pkg: my-pkg}", "1.0.0/QYB6QLCN", false)]
 fn test_pkg_opt_validation(#[case] spec: &str, #[case] value: &str, #[case] expect_err: bool) {
     let mut opt: PkgOpt = serde_yaml::from_str(spec).unwrap();
     let res = opt.set_value(value.to_string());
-    assert_eq!(res.is_err(), expect_err);
+    assert_eq!(res.is_err(), expect_err, "{:?}", res);
 }
 
 #[rstest]


### PR DESCRIPTION
In the event that someone decides to hard-code a specific build as a
dependency in a spec. Obviously something we discourage but it has been
necessary to overcome solver issues and builds of packages like this exist
in our repo.

Closes #386.

Signed-off-by: J Robert Ray <jrray@imageworks.com>