### PR TITLE
Fix spfs build cache for codecov workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -60,7 +60,7 @@ jobs:
         env:
           cache-name: spfs-installation
         with:
-          path: spfs/target/debug
+          path: "spfs/target/debug/spfs*"
           key: cargo-toml-${{ hashFiles('spfs/Cargo.toml') }}
       - if: steps.cache-spfs-installation.outputs.cache-hit == 'true'
         name: Restore spfs build from cache


### PR DESCRIPTION
This was trying to cache the result of a "release" build, however when
there is a cache miss, a "debug" build is built.

Signed-off-by: J Robert Ray <jrray@jrray.org>