### PR TITLE
Enable the "origin" repo during `spk test`

### DIFF
--- a/src/cli/cmd_test.rs
+++ b/src/cli/cmd_test.rs
@@ -50,9 +50,10 @@ pub struct Test {
 impl Run for Test {
     async fn run(&mut self) -> Result<i32> {
         let options = self.options.get_options()?;
+        let default_repos = ["origin".to_string()];
         let (_runtime, repos) = tokio::try_join!(
             self.runtime.ensure_active_runtime(),
-            self.repos.get_repos(None)
+            self.repos.get_repos(&default_repos)
         )?;
         let repos = repos
             .into_iter()


### PR DESCRIPTION
Otherwise, the tests can fail to find their install requirements.

Signed-off-by: J Robert Ray <jrray@imageworks.com>