### PR TITLE
Allow `Binary:1.2.3` and `=1.2.3` requests to merge

### DIFF
--- a/src/api/request_test.rs
+++ b/src/api/request_test.rs
@@ -71,6 +71,15 @@ fn test_inclusion_policy() {
 }
 
 #[rstest]
+fn test_compat_and_equals_restrict() {
+    let mut a: PkgRequest = serde_yaml::from_str("{pkg: something/Binary:1.2.3}").unwrap();
+    let b: PkgRequest = serde_yaml::from_str("{pkg: something/=1.2.3}").unwrap();
+
+    a.restrict(&b).unwrap();
+    assert_eq!(a.pkg.version.to_string(), "=1.2.3");
+}
+
+#[rstest]
 // Compatible inclusion policies are expected to merge,
 // case 1
 #[case(

--- a/src/api/version_range.rs
+++ b/src/api/version_range.rs
@@ -72,11 +72,39 @@ pub trait Ranged: Display + Clone + Into<VersionRange> {
     /// Test that the set of all valid versions in self is a superset of
     /// all valid versions in other.
     fn contains(&self, other: impl Ranged) -> Compatibility {
-        if self.get_compat_rule() > other.get_compat_rule() {
-            return Compatibility::Incompatible(format!(
-                "{self} has stronger compatibility requirements than {other}"
-            ));
-        }
+        match (self.get_compat_rule(), other.get_compat_rule()) {
+            (Some(_), None) => {
+                // Allow `Binary:1.2.3` to contain `=1.2.3` so that these two
+                // ranges can be simplified to just `=1.2.3`.
+                let other_v = match other.clone().into() {
+                    VersionRange::DoubleEquals(v) => Some(v.version),
+                    VersionRange::Equals(v) => Some(v.version),
+                    _ => None,
+                };
+
+                let contains = if let Some(other_v) = other_v {
+                    if let VersionRange::Compat(c) = self.clone().into() {
+                        c.base == other_v
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                };
+
+                if !contains {
+                    return Compatibility::Incompatible(format!(
+                        "{self} has stronger compatibility requirements than {other}"
+                    ));
+                }
+            }
+            (Some(x), Some(y)) if x > y => {
+                return Compatibility::Incompatible(format!(
+                    "{self} has stronger compatibility requirements than {other}"
+                ));
+            }
+            _ => {}
+        };
 
         let self_lower = self.greater_or_equal_to();
         let self_upper = self.less_than();
@@ -1068,11 +1096,17 @@ impl VersionFilter {
                 let (lhs_index, lhs_vr) = candidates.get(0).unwrap();
                 let (_, rhs_vr) = candidates.get(1).unwrap();
 
-                if !allow_compat_ranges_to_merge
-                    && (matches!(lhs_vr, VersionRange::Compat(_))
-                        || matches!(rhs_vr, VersionRange::Compat(_)))
-                {
-                    continue;
+                // `Binary:1.2.3` and `=1.2.3` are allowed to merge as a
+                // special case.
+                if !allow_compat_ranges_to_merge {
+                    match (lhs_vr, rhs_vr) {
+                        (VersionRange::Compat(lhs), VersionRange::Equals(rhs))
+                            if lhs.base == rhs.version => {}
+                        (VersionRange::Compat(lhs), VersionRange::DoubleEquals(rhs))
+                            if lhs.base == rhs.version => {}
+                        (_, VersionRange::Compat(_)) | (VersionRange::Compat(_), _) => continue,
+                        _ => {}
+                    };
                 }
 
                 // Note that `permutations` will give every element a chance

--- a/src/api/version_range_test.rs
+++ b/src/api/version_range_test.rs
@@ -504,6 +504,11 @@ proptest! {
 #[case("Binary:1.2.3", "1.2.3", false)] // decreasing strictness
 #[case(">1.0", "Binary:1.2.3", true)] // increasing strictness; narrowing range
 #[case(">2.0", "Binary:1.2.3", false)] // increasing strictness; widening range
+// CompatRange special case
+#[case("Binary:1.2.3", "=1.2.3", true)] // matching version
+#[case("Binary:1.2.3", "==1.2.3", true)] // matching version
+#[case("Binary:1.2.3+r.1", "=1.2.3", false)]
+#[case("Binary:1.2.4", "=1.2.3", false)]
 fn test_contains(#[case] range1: &str, #[case] range2: &str, #[case] expected: bool) {
     let a = parse_version_range(range1).unwrap();
     let b = parse_version_range(range2).unwrap();
@@ -526,6 +531,11 @@ fn test_contains(#[case] range1: &str, #[case] range2: &str, #[case] expected: b
 #[case("1.2.3,Binary:1.2.3", Some("Binary:1.2.3"))] // increasing strictness
 #[case("API:1.2.3,1.2.3", Some("API:1.2.3"))] // decreasing strictness
 #[case("Binary:1.2.3,1.2.3", Some("Binary:1.2.3"))] // decreasing strictness
+// CompatRange special case
+#[case("=1.2.3,Binary:1.2.3", Some("=1.2.3"))] // matching version
+#[case("==1.2.3,Binary:1.2.3", Some("==1.2.3"))] // matching version
+#[case("=1.2.3,Binary:1.2.3+r.1", None)]
+#[case("=1.2.3,Binary:1.2.4", None)]
 fn test_parse_version_range_simplifies(#[case] range1: &str, #[case] expected: Option<&str>) {
     let a = parse_version_range(range1).unwrap();
     match expected.map(|s| parse_version_range(s).unwrap()) {


### PR DESCRIPTION
Normally `Compat` ranges aren't allowed to merge (simplify), but there is
this special case where a `Compat` and `Equals` with matching version
numbers are fair game. The reasoning is that any build that satisfies
`=1.2.3` must also satisfy `Binary:1.2.3`, because version 1.2.3 must be
binary compatible with itself. This is not true of `>=1.2.3`.

We have big solves that contain a variety of cases that match this
situation, as in:

    'python-pyside2:all/=5.15.2,Binary:5.15.2'
    'python:all/=3.7.7,Binary:3.7.7'

Allowing these to merge will help reduce the distinct state id count.

Signed-off-by: J Robert Ray <jrray@jrray.org>