### PR TITLE
Fix `Version` ordering related to post-releases and plus_epsilon

### DIFF
--- a/src/api/version.rs
+++ b/src/api/version.rs
@@ -433,16 +433,17 @@ impl Ord for Version {
             },
         }
 
-        match self.post.cmp(&other.post) {
-            Ordering::Equal => (),
-            x => return x,
+        // Compare epsilon _before_ post release:
+        //
+        //     1.73.0 < 1.73.0+r.1 < 1.73.0+ε
+        //
+        match (self.parts.plus_epsilon, other.parts.plus_epsilon) {
+            (true, false) => return Ordering::Greater,
+            (false, true) => return Ordering::Less,
+            _ => (),
         }
 
-        match (self.parts.plus_epsilon, other.parts.plus_epsilon) {
-            (true, false) => Ordering::Greater,
-            (false, true) => Ordering::Less,
-            _ => Ordering::Equal,
-        }
+        self.post.cmp(&other.post)
     }
 }
 

--- a/src/api/version_range_test.rs
+++ b/src/api/version_range_test.rs
@@ -174,6 +174,7 @@ fn test_version_range_is_satisfied(
 #[case(">=1.0", ">=2.0", true)]
 #[case(">=1.2", "=1.1", false)]
 #[case("~1.2.0", "=1.2.1", true)]
+#[case("1.73.0+r.2", "=1.73.0", true)]
 fn test_intersects(#[case] range1: &str, #[case] range2: &str, #[case] expected: bool) {
     let a = parse_version_range(range1).unwrap();
     let b = parse_version_range(range2).unwrap();


### PR DESCRIPTION
We discovered that the version `1.73.0+r.2` could not satisfy a request for
`=1.73.0` due to this ordering bug.

`test_version_range_is_applicable` already has tests that seem to cover
this situation, but those tests were passing and weren't sufficient to
catch this bug:

    #[case("=1.0.0", "1.0.0+r.1", true)]
    #[case("==1.0.0", "1.0.0+r.1", false)]

Signed-off-by: J Robert Ray <jrray@jrray.org>