### PR TITLE
cli/flags: fix post-merge lint errors

### DIFF
--- a/src/cli/flags.rs
+++ b/src/cli/flags.rs
@@ -232,7 +232,7 @@ impl Requests {
 
         for (name, value) in options.iter() {
             if !value.is_empty() {
-                out.push(spk::api::VarRequest::new_with_value(name, value).into());
+                out.push(spk::api::VarRequest::new_with_value(name.clone(), value).into());
             }
         }
 


### PR DESCRIPTION
The OptNameBuf rework semantically conflicted with the recent updates
to allow command-line flags to override host options.

Clone the name variable to fix the build.

Related-to: #388
Signed-off-by: David Aguilar <davvid@gmail.com>