### PR TITLE
Draft: Exploring a redesign of `ValidatorT`

### DIFF
--- a/src/solve/solver.rs
+++ b/src/solve/solver.rs
@@ -357,7 +357,7 @@ impl Solver {
         source: &PackageSource,
     ) -> Result<api::Compatibility> {
         for validator in self.validators.as_ref() {
-            let compat = validator.validate(node, spec, source)?;
+            let compat = (node, validator).validate(spec, source)?;
             if !&compat {
                 return Ok(compat);
             }

--- a/src/solve/validation_test.rs
+++ b/src/solve/validation_test.rs
@@ -45,7 +45,10 @@ fn test_src_package_install_requests_are_not_considered() {
     for validator in validators {
         let msg = "Source package should be valid regardless of requirements";
         assert!(
-            validator.validate(&state, &*spec, &source).unwrap().is_ok(),
+            (&*state, validator)
+                .validate(&*spec, &source)
+                .unwrap()
+                .is_ok(),
             "{}",
             msg
         );
@@ -74,7 +77,10 @@ fn test_empty_options_can_match_anything() {
     let source = solve::PackageSource::Spec(spec.clone());
 
     assert!(
-        validator.validate(&state, &*spec, &source).unwrap().is_ok(),
+        (&*state, &validator)
+            .validate(&*spec, &source)
+            .unwrap()
+            .is_ok(),
         "empty option should not invalidate requirement"
     );
 }
@@ -104,7 +110,7 @@ fn test_qualified_var_supersedes_unqualified() {
     ));
     let source = solve::PackageSource::Spec(spec.clone());
 
-    let compat = validator.validate(&state, &*spec, &source).unwrap();
+    let compat = (&*state, &validator).validate(&*spec, &source).unwrap();
     assert!(
         compat.is_ok(),
         "qualified var requests should superseded unqualified ones, got: {}",
@@ -121,7 +127,7 @@ fn test_qualified_var_supersedes_unqualified() {
         }
     ));
     let source = solve::PackageSource::Spec(spec.clone());
-    let compat = validator.validate(&state, &*spec, &source).unwrap();
+    let compat = (&*state, &validator).validate(&*spec, &source).unwrap();
     assert!(
         !compat.is_ok(),
         "qualified var requests should superseded unqualified ones, got: {}",


### PR DESCRIPTION
This is a possible way to make it easier to have other inputs to `validate`
beyond just `&graph::State`.

Signed-off-by: J Robert Ray <jrray@jrray.org>