### PR TITLE
Check that `--variant` arg is valid

### DIFF
--- a/src/cli/cmd_make_binary.rs
+++ b/src/cli/cmd_make_binary.rs
@@ -123,7 +123,16 @@ impl Run for MakeBinary {
             let mut built = std::collections::HashSet::new();
 
             let variants_to_build = match self.variant {
-                Some(index) => spec.build.variants.iter().skip(index).take(1),
+                Some(index) if index < spec.build.variants.len() => {
+                    spec.build.variants.iter().skip(index).take(1)
+                }
+                Some(index) => {
+                    anyhow::bail!(
+                        "--variant {index} is out of range; {} variant(s) found in {}",
+                        spec.build.variants.len(),
+                        spec.pkg.format_ident(),
+                    );
+                }
                 None => spec.build.variants.iter().skip(0).take(usize::MAX),
             };
 

--- a/src/cli/cmd_test.rs
+++ b/src/cli/cmd_test.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use clap::Args;
+use spk::io::Format;
 
 use super::{flags, CommandArgs, Run};
 
@@ -103,7 +104,16 @@ impl Run for Test {
                 let mut tested = std::collections::HashSet::new();
 
                 let variants_to_test = match self.variant {
-                    Some(index) => spec.build.variants.iter().skip(index).take(1),
+                    Some(index) if index < spec.build.variants.len() => {
+                        spec.build.variants.iter().skip(index).take(1)
+                    }
+                    Some(index) => {
+                        anyhow::bail!(
+                            "--variant {index} is out of range; {} variant(s) found in {}",
+                            spec.build.variants.len(),
+                            spec.pkg.format_ident(),
+                        );
+                    }
                     None => spec.build.variants.iter().skip(0).take(usize::MAX),
                 };
 


### PR DESCRIPTION
Users are using this flag on the command line and sometimes make mistakes.
Make the command fail if an invalid variant is selected.

Signed-off-by: J Robert Ray <jrray@jrray.org>