### PR TITLE
Performance regression in `get_package`

### DIFF
--- a/src/storage/spfs.rs
+++ b/src/storage/spfs.rs
@@ -342,14 +342,7 @@ impl Repository for SPFSRepository {
         let component_tags = package.into_components();
         let mut components = HashMap::with_capacity(component_tags.len());
         for (name, tag_spec) in component_tags.into_iter() {
-            let tag = self
-                .inner
-                .resolve_tag(&tag_spec)
-                .await
-                .map_err(|err| match err {
-                    spfs::Error::UnknownReference(_) => Error::PackageNotFoundError(pkg.clone()),
-                    err => err.into(),
-                })?;
+            let tag = self.resolve_tag(pkg, &tag_spec).await?;
             components.insert(name, tag.target);
         }
         Ok(components)


### PR DESCRIPTION
The merge of the async conversion accidentally reverted `get_package` back
to not using the cached `resolve_tag`.

```
Before: Solver took 12564 steps total, at 418.754 steps/sec
 After: Solver took 82884 steps total, at 2762.796 steps/sec
```

(This steps/spec number is still much lower than it had been before async.)