### PR TITLE
Fix `spk test package@build` failing

### DIFF
--- a/src/cli/cmd_test.rs
+++ b/src/cli/cmd_test.rs
@@ -10,6 +10,10 @@ use spk::io::Format;
 
 use super::{flags, CommandArgs, Run};
 
+#[cfg(test)]
+#[path = "./cmd_test_test.rs"]
+mod cmd_test_test;
+
 /// Run package tests
 ///
 /// In order to run install tests the package must have been built already

--- a/src/cli/cmd_test_test.rs
+++ b/src/cli/cmd_test_test.rs
@@ -1,0 +1,87 @@
+// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/imageworks/spk
+
+use std::fs::File;
+use std::io::Write;
+
+use clap::Parser;
+use rstest::rstest;
+
+use spk::fixtures::*;
+
+use crate::cmd_build::Build;
+use crate::Run;
+
+use super::Test;
+
+#[derive(Parser)]
+struct BuildOpt {
+    #[clap(flatten)]
+    build: Build,
+}
+
+#[derive(Parser)]
+struct TestOpt {
+    #[clap(flatten)]
+    test: Test,
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_all_test_stages_succeed(tmpdir: tempfile::TempDir) {
+    // A var that appears in the variant list and doesn't appear in the
+    // build.options list should still affect the build hash / produce a
+    // unique build.
+    let _rt = spfs_runtime().await;
+
+    let filename = tmpdir.path().join("simple.spk.yaml");
+    {
+        let mut file = File::create(&filename).unwrap();
+        file.write_all(
+            br#"
+pkg: simple/1.0.0
+build:
+  script:
+    - "true"
+
+tests:
+  - stage: sources
+    script:
+      - "true"
+  - stage: build
+    script:
+      - "true"
+  - stage: install
+    script:
+      - "true"
+"#,
+        )
+        .unwrap();
+    }
+
+    let filename_str = filename.as_os_str().to_str().unwrap();
+
+    // Build the package so it can be tested.
+    let mut opt = BuildOpt::try_parse_from([
+        "build",
+        // Don't exec a new process to move into a new runtime, this confuses
+        // coverage testing.
+        "--no-runtime",
+        "--disable-repo=origin",
+        filename_str,
+    ])
+    .unwrap();
+    opt.build.run().await.unwrap();
+
+    let mut opt = TestOpt::try_parse_from([
+        "test",
+        // Don't exec a new process to move into a new runtime, this confuses
+        // coverage testing.
+        "--no-runtime",
+        "--disable-repo=origin",
+        filename_str,
+    ])
+    .unwrap();
+    opt.test.run().await.unwrap();
+}

--- a/src/test/build.rs
+++ b/src/test/build.rs
@@ -144,10 +144,11 @@ impl<'a> PackageBuildTester<'a> {
         rt.status.editable = true;
         rt.status.stack.clear();
 
-        let mut stack = Vec::new();
         if let BuildSource::SourcePackage(pkg) = self.source.clone() {
             let solution = self.resolve_source_package(&pkg.try_into()?).await?;
-            stack.append(&mut exec::resolve_runtime_layers(&solution).await?);
+            for layer in exec::resolve_runtime_layers(&solution).await? {
+                rt.push_digest(layer);
+            }
         }
 
         let mut solver = solve::Solver::default();


### PR DESCRIPTION
This fails with "No such file or directory" because the "src" package was
being resolved but not added to the runtime stack.

Signed-off-by: J Robert Ray <jrray@jrray.org>