### PR TITLE
Add "variant-count" alias for num-variants command

### DIFF
--- a/src/cli/bin.rs
+++ b/src/cli/bin.rs
@@ -149,7 +149,7 @@ pub enum Command {
     MakeBinary(cmd_make_binary::MakeBinary),
     MakeSource(cmd_make_source::MakeSource),
     New(cmd_new::New),
-    #[clap(hide = true)]
+    #[clap(alias = "variant-count", hide = true)]
     NumVariants(cmd_num_variants::NumVariants),
     Publish(cmd_publish::Publish),
     Remove(cmd_remove::Remove),


### PR DESCRIPTION
Our CI tooling inside SPI runs "spk variant-count". We'll migrate it to
use "spk info --variants" when we go live.

Signed-off-by: J Robert Ray <jrray@imageworks.com>