### PR TITLE
Refactor `Repository` into `Storage` and `Repository`

### DIFF
--- a/crates/spk-storage/src/storage/runtime.rs
+++ b/crates/spk-storage/src/storage/runtime.rs
@@ -15,7 +15,10 @@ use spk_schema::foundation::version::{parse_version, Version};
 use spk_schema::Ident;
 use spk_schema::SpecRecipe;
 
-use super::{repository::Storage, Repository};
+use super::{
+    repository::{PublishPolicy, Storage},
+    Repository,
+};
 use crate::{Error, Result};
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
@@ -93,7 +96,11 @@ impl Storage for RuntimeRepository {
         ))
     }
 
-    async fn publish_recipe_to_storage(&self, _spec: &Self::Recipe, _force: bool) -> Result<()> {
+    async fn publish_recipe_to_storage(
+        &self,
+        _spec: &Self::Recipe,
+        _publish_policy: PublishPolicy,
+    ) -> Result<()> {
         Err(Error::String(
             "Cannot publish to a runtime repository".into(),
         ))


### PR DESCRIPTION
Spun out of #415 and will lessen the burden of rebasing that PR, since the code relocation causes a lot of merge conflicts.

This change isn't as compelling when separated from the embed stub code, but there have been some changes added here that aren't in that other branch, specifically moving some of the invariant checks out of mem/spfs and into `Repository`.