### PR TITLE
Remove year from copyright notices

### DIFF
--- a/.site/spi/.spdev/overrides.py
+++ b/.site/spi/.spdev/overrides.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 Sony Pictures Imageworks, et al.
+# Copyright (c) Sony Pictures Imageworks, et al.
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/imageworks/spk
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-<!-- Copyright (c) 2021 Sony Pictures Imageworks, et al. -->
+<!-- Copyright (c) Sony Pictures Imageworks, et al. -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 <!-- https://github.com/imageworks/spk -->
 
@@ -33,7 +33,7 @@ process.
 
 SPK/SPFS/spawn are distributed using the [Apache-2.0 license](LICENSE.txt).
 
-SPK/SPFS/spawn are Copyright (c) 2021 Sony Pictures Imageworks, et al.
+SPK/SPFS/spawn are Copyright (c) Sony Pictures Imageworks, et al.
 
 Please note that the "et al" encompasses all the other contributors. We do
 not require transfer of copyright -- technically speaking, submitters retain
@@ -142,4 +142,3 @@ take it hard if your first try is not accepted. It happens to all of us.
 
 8. After approval, one of the senior developers (with commit approval to the
 official main repository) will merge your fixes into the master branch.
-

--- a/OPEN_SOURCE_PLAN.md
+++ b/OPEN_SOURCE_PLAN.md
@@ -1,4 +1,4 @@
-<!-- Copyright (c) 2021 Sony Pictures Imageworks, et al. -->
+<!-- Copyright (c) Sony Pictures Imageworks, et al. -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 <!-- https://github.com/imageworks/spk -->
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- Copyright (c) 2021 Sony Pictures Imageworks, et al. -->
+<!-- Copyright (c) Sony Pictures Imageworks, et al. -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 <!-- https://github.com/imageworks/spk -->
 
@@ -19,7 +19,7 @@ See the main [docs](docs/) for details on using spk, starting with the [index](d
 
 ## License
 
-SPK/SPFS/spawn are Copyright (c) 2021 Sony Pictures Imageworks, et al.
+SPK/SPFS/spawn are Copyright (c) Sony Pictures Imageworks, et al.
 All Rights Reserved.
 
 SPK/SPFS/spawn are distributed using the [Apache-2.0 license](LICENSE.txt).

--- a/crates/spfs-encoding/src/binary.rs
+++ b/crates/spfs-encoding/src/binary.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs-encoding/src/binary_test.rs
+++ b/crates/spfs-encoding/src/binary_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs-encoding/src/error.rs
+++ b/crates/spfs-encoding/src/error.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs-encoding/src/hash.rs
+++ b/crates/spfs-encoding/src/hash.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs-encoding/src/hash_test.rs
+++ b/crates/spfs-encoding/src/hash_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs-encoding/src/lib.rs
+++ b/crates/spfs-encoding/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/benches/spfs_bench.rs
+++ b/crates/spfs/benches/spfs_bench.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/bootstrap.rs
+++ b/crates/spfs/src/bootstrap.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use std::ffi::{OsStr, OsString};

--- a/crates/spfs/src/bootstrap_test.rs
+++ b/crates/spfs/src/bootstrap_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/clean.rs
+++ b/crates/spfs/src/clean.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/clean_test.rs
+++ b/crates/spfs/src/clean_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/cli/args.rs
+++ b/crates/spfs/src/cli/args.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/cli/bin.rs
+++ b/crates/spfs/src/cli/bin.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/cli/cmd_check.rs
+++ b/crates/spfs/src/cli/cmd_check.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/cli/cmd_clean.rs
+++ b/crates/spfs/src/cli/cmd_clean.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/cli/cmd_commit.rs
+++ b/crates/spfs/src/cli/cmd_commit.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/cli/cmd_config.rs
+++ b/crates/spfs/src/cli/cmd_config.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/cli/cmd_diff.rs
+++ b/crates/spfs/src/cli/cmd_diff.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/cli/cmd_edit.rs
+++ b/crates/spfs/src/cli/cmd_edit.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/cli/cmd_enter.rs
+++ b/crates/spfs/src/cli/cmd_enter.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/cli/cmd_info.rs
+++ b/crates/spfs/src/cli/cmd_info.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/cli/cmd_join.rs
+++ b/crates/spfs/src/cli/cmd_join.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/cli/cmd_layers.rs
+++ b/crates/spfs/src/cli/cmd_layers.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/cli/cmd_log.rs
+++ b/crates/spfs/src/cli/cmd_log.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/cli/cmd_ls.rs
+++ b/crates/spfs/src/cli/cmd_ls.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/cli/cmd_ls_tags.rs
+++ b/crates/spfs/src/cli/cmd_ls_tags.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/cli/cmd_migrate.rs
+++ b/crates/spfs/src/cli/cmd_migrate.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/cli/cmd_monitor.rs
+++ b/crates/spfs/src/cli/cmd_monitor.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/cli/cmd_platforms.rs
+++ b/crates/spfs/src/cli/cmd_platforms.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/cli/cmd_pull.rs
+++ b/crates/spfs/src/cli/cmd_pull.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/cli/cmd_push.rs
+++ b/crates/spfs/src/cli/cmd_push.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/cli/cmd_read.rs
+++ b/crates/spfs/src/cli/cmd_read.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/cli/cmd_render.rs
+++ b/crates/spfs/src/cli/cmd_render.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/cli/cmd_reset.rs
+++ b/crates/spfs/src/cli/cmd_reset.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/cli/cmd_run.rs
+++ b/crates/spfs/src/cli/cmd_run.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/cli/cmd_runtime.rs
+++ b/crates/spfs/src/cli/cmd_runtime.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/cli/cmd_runtime_info.rs
+++ b/crates/spfs/src/cli/cmd_runtime_info.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/cli/cmd_runtime_list.rs
+++ b/crates/spfs/src/cli/cmd_runtime_list.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/cli/cmd_runtime_remove.rs
+++ b/crates/spfs/src/cli/cmd_runtime_remove.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/cli/cmd_search.rs
+++ b/crates/spfs/src/cli/cmd_search.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/cli/cmd_server.rs
+++ b/crates/spfs/src/cli/cmd_server.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/cli/cmd_shell.rs
+++ b/crates/spfs/src/cli/cmd_shell.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/cli/cmd_tag.rs
+++ b/crates/spfs/src/cli/cmd_tag.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/cli/cmd_tags.rs
+++ b/crates/spfs/src/cli/cmd_tags.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/cli/cmd_untag.rs
+++ b/crates/spfs/src/cli/cmd_untag.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/cli/cmd_version.rs
+++ b/crates/spfs/src/cli/cmd_version.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/cli/cmd_write.rs
+++ b/crates/spfs/src/cli/cmd_write.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use std::path::PathBuf;

--- a/crates/spfs/src/commit.rs
+++ b/crates/spfs/src/commit.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/commit_test.rs
+++ b/crates/spfs/src/commit_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/config.rs
+++ b/crates/spfs/src/config.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use std::sync::{Arc, RwLock};

--- a/crates/spfs/src/config_test.rs
+++ b/crates/spfs/src/config_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/diff.rs
+++ b/crates/spfs/src/diff.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/env.rs
+++ b/crates/spfs/src/env.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/error.rs
+++ b/crates/spfs/src/error.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use std::{io, str::Utf8Error};

--- a/crates/spfs/src/fixtures.rs
+++ b/crates/spfs/src/fixtures.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/graph/blob.rs
+++ b/crates/spfs/src/graph/blob.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/graph/database.rs
+++ b/crates/spfs/src/graph/database.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/graph/entry.rs
+++ b/crates/spfs/src/graph/entry.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/graph/entry_test.rs
+++ b/crates/spfs/src/graph/entry_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/graph/layer.rs
+++ b/crates/spfs/src/graph/layer.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/graph/layer_test.rs
+++ b/crates/spfs/src/graph/layer_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/graph/manifest.rs
+++ b/crates/spfs/src/graph/manifest.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/graph/manifest_test.rs
+++ b/crates/spfs/src/graph/manifest_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/graph/mod.rs
+++ b/crates/spfs/src/graph/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/graph/object.rs
+++ b/crates/spfs/src/graph/object.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/graph/operations.rs
+++ b/crates/spfs/src/graph/operations.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/graph/platform.rs
+++ b/crates/spfs/src/graph/platform.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/graph/platform_test.rs
+++ b/crates/spfs/src/graph/platform_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/graph/tree.rs
+++ b/crates/spfs/src/graph/tree.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/graph/tree_test.rs
+++ b/crates/spfs/src/graph/tree_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/io.rs
+++ b/crates/spfs/src/io.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/lib.rs
+++ b/crates/spfs/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/ls_tags.rs
+++ b/crates/spfs/src/ls_tags.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/prelude.rs
+++ b/crates/spfs/src/prelude.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/proto/conversions.rs
+++ b/crates/spfs/src/proto/conversions.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use std::convert::{TryFrom, TryInto};

--- a/crates/spfs/src/proto/defs/database.proto
+++ b/crates/spfs/src/proto/defs/database.proto
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 syntax = "proto3";

--- a/crates/spfs/src/proto/defs/error.proto
+++ b/crates/spfs/src/proto/defs/error.proto
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 syntax = "proto3";

--- a/crates/spfs/src/proto/defs/payload.proto
+++ b/crates/spfs/src/proto/defs/payload.proto
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 syntax = "proto3";

--- a/crates/spfs/src/proto/defs/repository.proto
+++ b/crates/spfs/src/proto/defs/repository.proto
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 syntax = "proto3";

--- a/crates/spfs/src/proto/defs/tag.proto
+++ b/crates/spfs/src/proto/defs/tag.proto
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 syntax = "proto3";

--- a/crates/spfs/src/proto/defs/types.proto
+++ b/crates/spfs/src/proto/defs/types.proto
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 syntax = "proto3";

--- a/crates/spfs/src/proto/mod.rs
+++ b/crates/spfs/src/proto/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 //! Protocol Buffer message formats and conversions.

--- a/crates/spfs/src/proto/result.rs
+++ b/crates/spfs/src/proto/result.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/prune.rs
+++ b/crates/spfs/src/prune.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/prune_test.rs
+++ b/crates/spfs/src/prune_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/resolve.rs
+++ b/crates/spfs/src/resolve.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/resolve_test.rs
+++ b/crates/spfs/src/resolve_test.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use rstest::rstest;

--- a/crates/spfs/src/runtime/csh_exp.rs
+++ b/crates/spfs/src/runtime/csh_exp.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/runtime/mod.rs
+++ b/crates/spfs/src/runtime/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/runtime/overlayfs.rs
+++ b/crates/spfs/src/runtime/overlayfs.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/runtime/startup_csh.rs
+++ b/crates/spfs/src/runtime/startup_csh.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/runtime/startup_sh.rs
+++ b/crates/spfs/src/runtime/startup_sh.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/runtime/storage.rs
+++ b/crates/spfs/src/runtime/storage.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/runtime/storage_033.rs
+++ b/crates/spfs/src/runtime/storage_033.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/runtime/storage_033_test.rs
+++ b/crates/spfs/src/runtime/storage_033_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/runtime/storage_test.rs
+++ b/crates/spfs/src/runtime/storage_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/server/database.rs
+++ b/crates/spfs/src/server/database.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use std::convert::TryInto;

--- a/crates/spfs/src/server/mod.rs
+++ b/crates/spfs/src/server/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 //! Remote rpc server implementation of the spfs repository

--- a/crates/spfs/src/server/payload.rs
+++ b/crates/spfs/src/server/payload.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/server/repository.rs
+++ b/crates/spfs/src/server/repository.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/server/tag.rs
+++ b/crates/spfs/src/server/tag.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use std::convert::TryInto;

--- a/crates/spfs/src/status.rs
+++ b/crates/spfs/src/status.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/storage/blob.rs
+++ b/crates/spfs/src/storage/blob.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/storage/config.rs
+++ b/crates/spfs/src/storage/config.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use async_trait::async_trait;

--- a/crates/spfs/src/storage/database_test.rs
+++ b/crates/spfs/src/storage/database_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use rstest::rstest;

--- a/crates/spfs/src/storage/fs/database.rs
+++ b/crates/spfs/src/storage/fs/database.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/storage/fs/database_test.rs
+++ b/crates/spfs/src/storage/fs/database_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/storage/fs/hash_store.rs
+++ b/crates/spfs/src/storage/fs/hash_store.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/storage/fs/hash_store_test.rs
+++ b/crates/spfs/src/storage/fs/hash_store_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/storage/fs/layer_test.rs
+++ b/crates/spfs/src/storage/fs/layer_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/storage/fs/migrations/mod.rs
+++ b/crates/spfs/src/storage/fs/migrations/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/storage/fs/mod.rs
+++ b/crates/spfs/src/storage/fs/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/storage/fs/payloads.rs
+++ b/crates/spfs/src/storage/fs/payloads.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/storage/fs/payloads_test.rs
+++ b/crates/spfs/src/storage/fs/payloads_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/storage/fs/renderer.rs
+++ b/crates/spfs/src/storage/fs/renderer.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/storage/fs/renderer_test.rs
+++ b/crates/spfs/src/storage/fs/renderer_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/storage/fs/repository.rs
+++ b/crates/spfs/src/storage/fs/repository.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/storage/fs/tag.rs
+++ b/crates/spfs/src/storage/fs/tag.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/storage/fs/tag_test.rs
+++ b/crates/spfs/src/storage/fs/tag_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use std::os::unix::fs::MetadataExt;

--- a/crates/spfs/src/storage/layer.rs
+++ b/crates/spfs/src/storage/layer.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/storage/layer_test.rs
+++ b/crates/spfs/src/storage/layer_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/storage/manifest.rs
+++ b/crates/spfs/src/storage/manifest.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/storage/manifest_entry_test.rs
+++ b/crates/spfs/src/storage/manifest_entry_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/storage/manifest_test.rs
+++ b/crates/spfs/src/storage/manifest_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/storage/mod.rs
+++ b/crates/spfs/src/storage/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/storage/payload.rs
+++ b/crates/spfs/src/storage/payload.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/storage/payload_test.rs
+++ b/crates/spfs/src/storage/payload_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use tokio::io::AsyncReadExt;

--- a/crates/spfs/src/storage/platform.rs
+++ b/crates/spfs/src/storage/platform.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/storage/platform_test.rs
+++ b/crates/spfs/src/storage/platform_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/storage/prelude.rs
+++ b/crates/spfs/src/storage/prelude.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/storage/proxy/mod.rs
+++ b/crates/spfs/src/storage/proxy/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/storage/proxy/repository.rs
+++ b/crates/spfs/src/storage/proxy/repository.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/storage/proxy/repository_test.rs
+++ b/crates/spfs/src/storage/proxy/repository_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/storage/repository.rs
+++ b/crates/spfs/src/storage/repository.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use std::{collections::HashSet, pin::Pin};

--- a/crates/spfs/src/storage/repository_test.rs
+++ b/crates/spfs/src/storage/repository_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/storage/rpc/database.rs
+++ b/crates/spfs/src/storage/rpc/database.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/storage/rpc/mod.rs
+++ b/crates/spfs/src/storage/rpc/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 //! Storage implementation which is a client of the built-in spfs server

--- a/crates/spfs/src/storage/rpc/payload.rs
+++ b/crates/spfs/src/storage/rpc/payload.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use std::convert::TryInto;

--- a/crates/spfs/src/storage/rpc/repository.rs
+++ b/crates/spfs/src/storage/rpc/repository.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/storage/rpc/tag.rs
+++ b/crates/spfs/src/storage/rpc/tag.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/storage/tag.rs
+++ b/crates/spfs/src/storage/tag.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/storage/tag_test.rs
+++ b/crates/spfs/src/storage/tag_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use chrono::prelude::*;

--- a/crates/spfs/src/storage/tar/mod.rs
+++ b/crates/spfs/src/storage/tar/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/storage/tar/repository.rs
+++ b/crates/spfs/src/storage/tar/repository.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/sync.rs
+++ b/crates/spfs/src/sync.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/sync_test.rs
+++ b/crates/spfs/src/sync_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/tracking/diff.rs
+++ b/crates/spfs/src/tracking/diff.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/tracking/diff_test.rs
+++ b/crates/spfs/src/tracking/diff_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/tracking/entry.rs
+++ b/crates/spfs/src/tracking/entry.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/tracking/env.rs
+++ b/crates/spfs/src/tracking/env.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/tracking/env_test.rs
+++ b/crates/spfs/src/tracking/env_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/tracking/manifest.rs
+++ b/crates/spfs/src/tracking/manifest.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/tracking/manifest_test.rs
+++ b/crates/spfs/src/tracking/manifest_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/tracking/mod.rs
+++ b/crates/spfs/src/tracking/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/tracking/object.rs
+++ b/crates/spfs/src/tracking/object.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/tracking/tag.rs
+++ b/crates/spfs/src/tracking/tag.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/src/tracking/tag_test.rs
+++ b/crates/spfs/src/tracking/tag_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spfs/tests/integration/run_tests.sh
+++ b/crates/spfs/tests/integration/run_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2021 Sony Pictures Imageworks, et al.
+# Copyright (c) Sony Pictures Imageworks, et al.
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/imageworks/spk
 

--- a/crates/spfs/tests/integration/test_remount_save_changes.sh
+++ b/crates/spfs/tests/integration/test_remount_save_changes.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2021 Sony Pictures Imageworks, et al.
+# Copyright (c) Sony Pictures Imageworks, et al.
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/imageworks/spk
 

--- a/crates/spfs/tests/integration/test_run_preserves_tmpdir.sh
+++ b/crates/spfs/tests/integration/test_run_preserves_tmpdir.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2022 Sony Pictures Imageworks, et al.
+# Copyright (c) Sony Pictures Imageworks, et al.
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/imageworks/spk
 

--- a/crates/spfs/tests/integration/test_runtime_cleanup.sh
+++ b/crates/spfs/tests/integration/test_runtime_cleanup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2022 Sony Pictures Imageworks, et al.
+# Copyright (c) Sony Pictures Imageworks, et al.
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/imageworks/spk
 

--- a/crates/spfs/tests/integration/test_runtime_dir_removal.sh
+++ b/crates/spfs/tests/integration/test_runtime_dir_removal.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2021 Sony Pictures Imageworks, et al.
+# Copyright (c) Sony Pictures Imageworks, et al.
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/imageworks/spk
 

--- a/crates/spfs/tests/integration/test_runtime_file_removal.sh
+++ b/crates/spfs/tests/integration/test_runtime_file_removal.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2021 Sony Pictures Imageworks, et al.
+# Copyright (c) Sony Pictures Imageworks, et al.
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/imageworks/spk
 

--- a/crates/spfs/tests/integration/test_runtime_not_busy.sh
+++ b/crates/spfs/tests/integration/test_runtime_not_busy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2021 Sony Pictures Imageworks, et al.
+# Copyright (c) Sony Pictures Imageworks, et al.
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/imageworks/spk
 

--- a/crates/spfs/tests/integration/test_runtime_recursion.sh
+++ b/crates/spfs/tests/integration/test_runtime_recursion.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2021 Sony Pictures Imageworks, et al.
+# Copyright (c) Sony Pictures Imageworks, et al.
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/imageworks/spk
 

--- a/crates/spfs/tests/integration/test_tagging.sh
+++ b/crates/spfs/tests/integration/test_tagging.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2021 Sony Pictures Imageworks, et al.
+# Copyright (c) Sony Pictures Imageworks, et al.
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/imageworks/spk
 

--- a/crates/spk-build/src/archive_test.rs
+++ b/crates/spk-build/src/archive_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-build/src/build/binary.rs
+++ b/crates/spk-build/src/build/binary.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-build/src/build/binary_test.rs
+++ b/crates/spk-build/src/build/binary_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-build/src/build/mod.rs
+++ b/crates/spk-build/src/build/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 mod binary;

--- a/crates/spk-build/src/build/sources.rs
+++ b/crates/spk-build/src/build/sources.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-build/src/build/sources_test.rs
+++ b/crates/spk-build/src/build/sources_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use rstest::rstest;

--- a/crates/spk-build/src/error.rs
+++ b/crates/spk-build/src/error.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-build/src/lib.rs
+++ b/crates/spk-build/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-cli/cmd-build/src/cmd_build.rs
+++ b/crates/spk-cli/cmd-build/src/cmd_build.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-cli/cmd-build/src/lib.rs
+++ b/crates/spk-cli/cmd-build/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-cli/cmd-convert/src/cmd_convert.rs
+++ b/crates/spk-cli/cmd-convert/src/cmd_convert.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-cli/cmd-convert/src/lib.rs
+++ b/crates/spk-cli/cmd-convert/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-cli/cmd-env/src/cmd_env.rs
+++ b/crates/spk-cli/cmd-env/src/cmd_env.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use std::ffi::OsString;

--- a/crates/spk-cli/cmd-env/src/lib.rs
+++ b/crates/spk-cli/cmd-env/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-cli/cmd-explain/src/cmd_explain.rs
+++ b/crates/spk-cli/cmd-explain/src/cmd_explain.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-cli/cmd-explain/src/lib.rs
+++ b/crates/spk-cli/cmd-explain/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-cli/cmd-install/src/cmd_install.rs
+++ b/crates/spk-cli/cmd-install/src/cmd_install.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-cli/cmd-install/src/lib.rs
+++ b/crates/spk-cli/cmd-install/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-cli/cmd-make-binary/src/cmd_make_binary.rs
+++ b/crates/spk-cli/cmd-make-binary/src/cmd_make_binary.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-cli/cmd-make-binary/src/lib.rs
+++ b/crates/spk-cli/cmd-make-binary/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-cli/cmd-make-source/src/cmd_make_source.rs
+++ b/crates/spk-cli/cmd-make-source/src/cmd_make_source.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-cli/cmd-make-source/src/lib.rs
+++ b/crates/spk-cli/cmd-make-source/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-cli/cmd-render/src/cmd_render.rs
+++ b/crates/spk-cli/cmd-render/src/cmd_render.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use std::path::PathBuf;

--- a/crates/spk-cli/cmd-render/src/lib.rs
+++ b/crates/spk-cli/cmd-render/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-cli/cmd-repo/src/cmd_repo.rs
+++ b/crates/spk-cli/cmd-repo/src/cmd_repo.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-cli/cmd-repo/src/lib.rs
+++ b/crates/spk-cli/cmd-repo/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-cli/cmd-test/src/cmd_test.rs
+++ b/crates/spk-cli/cmd-test/src/cmd_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use std::str::FromStr;

--- a/crates/spk-cli/cmd-test/src/cmd_test_test.rs
+++ b/crates/spk-cli/cmd-test/src/cmd_test_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-cli/cmd-test/src/lib.rs
+++ b/crates/spk-cli/cmd-test/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-cli/cmd-test/src/test/build.rs
+++ b/crates/spk-cli/cmd-test/src/test/build.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
@@ -15,10 +15,10 @@ use spk_schema::foundation::ident_component::Component;
 use spk_schema::foundation::option_map::OptionMap;
 use spk_schema::foundation::spec_ops::RecipeOps;
 use spk_schema::ident::{PkgRequest, PreReleasePolicy, RangeIdent, Request, RequestedBy};
-use spk_solve::{BoxedResolverCallback, DefaultResolver, ResolverCallback, Solver};
+use spk_schema::{Ident, Recipe, SpecRecipe};
 use spk_solve::graph::Graph;
 use spk_solve::solution::Solution;
-use spk_schema::{Recipe, SpecRecipe, Ident};
+use spk_solve::{BoxedResolverCallback, DefaultResolver, ResolverCallback, Solver};
 use spk_storage::{self as storage};
 
 pub struct PackageBuildTester<'a> {

--- a/crates/spk-cli/cmd-test/src/test/install.rs
+++ b/crates/spk-cli/cmd-test/src/test/install.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
@@ -13,9 +13,9 @@ use spk_schema::foundation::ident_component::Component;
 use spk_schema::foundation::option_map::OptionMap;
 use spk_schema::foundation::spec_ops::RecipeOps;
 use spk_schema::ident::{PkgRequest, PreReleasePolicy, RangeIdent, Request, RequestedBy};
-use spk_solve::{BoxedResolverCallback, DefaultResolver, ResolverCallback, Solver};
-use spk_solve::graph::Graph;
 use spk_schema::SpecRecipe;
+use spk_solve::graph::Graph;
+use spk_solve::{BoxedResolverCallback, DefaultResolver, ResolverCallback, Solver};
 use spk_storage::{self as storage};
 
 pub struct PackageInstallTester<'a> {

--- a/crates/spk-cli/cmd-test/src/test/mod.rs
+++ b/crates/spk-cli/cmd-test/src/test/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-cli/cmd-test/src/test/sources.rs
+++ b/crates/spk-cli/cmd-test/src/test/sources.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
@@ -15,9 +15,9 @@ use spk_schema::foundation::ident_component::Component;
 use spk_schema::foundation::option_map::OptionMap;
 use spk_schema::foundation::spec_ops::RecipeOps;
 use spk_schema::ident::{PkgRequest, PreReleasePolicy, RangeIdent, Request, RequestedBy};
-use spk_solve::{BoxedResolverCallback, DefaultResolver, ResolverCallback, Solver};
-use spk_solve::graph::Graph;
 use spk_schema::SpecRecipe;
+use spk_solve::graph::Graph;
+use spk_solve::{BoxedResolverCallback, DefaultResolver, ResolverCallback, Solver};
 use spk_storage::{self as storage};
 
 pub struct PackageSourceTester<'a> {

--- a/crates/spk-cli/common/src/cli.rs
+++ b/crates/spk-cli/common/src/cli.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 //! Main entry points and utilities for command line interface and interaction.

--- a/crates/spk-cli/common/src/env.rs
+++ b/crates/spk-cli/common/src/env.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-cli/common/src/error.rs
+++ b/crates/spk-cli/common/src/error.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-cli/common/src/exec.rs
+++ b/crates/spk-cli/common/src/exec.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-cli/common/src/flags.rs
+++ b/crates/spk-cli/common/src/flags.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
@@ -15,8 +15,8 @@ use spk_schema::foundation::option_map::{host_options, OptionMap};
 use spk_schema::foundation::spec_ops::{Named, RecipeOps};
 use spk_schema::foundation::version::CompatRule;
 use spk_schema::ident::{parse_ident, Ident, PkgRequest, Request, RequestedBy, VarRequest};
-use spk_solve::{self as solve};
 use spk_schema::{Recipe, SpecTemplate, Template, TemplateExt, TestStage};
+use spk_solve::{self as solve};
 use spk_storage::{self as storage};
 
 #[cfg(test)]

--- a/crates/spk-cli/common/src/flags_test.rs
+++ b/crates/spk-cli/common/src/flags_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-cli/common/src/lib.rs
+++ b/crates/spk-cli/common/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-cli/common/src/publish.rs
+++ b/crates/spk-cli/common/src/publish.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-cli/common/src/publish_test.rs
+++ b/crates/spk-cli/common/src/publish_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-cli/group1/src/cmd_bake.rs
+++ b/crates/spk-cli/group1/src/cmd_bake.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-cli/group1/src/cmd_deprecate.rs
+++ b/crates/spk-cli/group1/src/cmd_deprecate.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use std::{io::Write, sync::Arc};

--- a/crates/spk-cli/group1/src/cmd_deprecate_test.rs
+++ b/crates/spk-cli/group1/src/cmd_deprecate_test.rs
@@ -1,11 +1,11 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
 use rstest::rstest;
 use spk_schema::ident::parse_ident;
-use spk_solve::make_repo;
 use spk_schema::Deprecate;
+use spk_solve::make_repo;
 
 use super::{change_deprecation_state, ChangeAction};
 

--- a/crates/spk-cli/group1/src/cmd_undeprecate.rs
+++ b/crates/spk-cli/group1/src/cmd_undeprecate.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-cli/group1/src/cmd_undeprecate_test.rs
+++ b/crates/spk-cli/group1/src/cmd_undeprecate_test.rs
@@ -1,11 +1,11 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
 use rstest::rstest;
 use spk_schema::ident::parse_ident;
-use spk_solve::make_repo;
 use spk_schema::Deprecate;
+use spk_solve::make_repo;
 
 use super::{change_deprecation_state, ChangeAction};
 

--- a/crates/spk-cli/group1/src/lib.rs
+++ b/crates/spk-cli/group1/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-cli/group2/src/cmd_ls.rs
+++ b/crates/spk-cli/group2/src/cmd_ls.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-cli/group2/src/cmd_ls_test.rs
+++ b/crates/spk-cli/group2/src/cmd_ls_test.rs
@@ -1,12 +1,12 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
 use clap::Parser;
 use spfs::{config::Remote, RemoteAddress};
 use spk_schema::foundation::ident_component::Component;
-use spk_solve::spec;
 use spk_schema::recipe;
+use spk_solve::spec;
 use spk_storage::fixtures::*;
 
 use super::{Ls, Output, Run};

--- a/crates/spk-cli/group2/src/cmd_new.rs
+++ b/crates/spk-cli/group2/src/cmd_new.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use anyhow::Result;

--- a/crates/spk-cli/group2/src/cmd_new_test.rs
+++ b/crates/spk-cli/group2/src/cmd_new_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-cli/group2/src/cmd_num_variants.rs
+++ b/crates/spk-cli/group2/src/cmd_num_variants.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-cli/group2/src/cmd_publish.rs
+++ b/crates/spk-cli/group2/src/cmd_publish.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use std::sync::Arc;

--- a/crates/spk-cli/group2/src/cmd_remove.rs
+++ b/crates/spk-cli/group2/src/cmd_remove.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use std::io::Write;

--- a/crates/spk-cli/group2/src/lib.rs
+++ b/crates/spk-cli/group2/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-cli/group3/src/cmd_export.rs
+++ b/crates/spk-cli/group3/src/cmd_export.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-cli/group3/src/cmd_import.rs
+++ b/crates/spk-cli/group3/src/cmd_import.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-cli/group3/src/lib.rs
+++ b/crates/spk-cli/group3/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-cli/group4/src/cmd_search.rs
+++ b/crates/spk-cli/group4/src/cmd_search.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use anyhow::Result;

--- a/crates/spk-cli/group4/src/cmd_version.rs
+++ b/crates/spk-cli/group4/src/cmd_version.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-cli/group4/src/cmd_view.rs
+++ b/crates/spk-cli/group4/src/cmd_view.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-cli/group4/src/lib.rs
+++ b/crates/spk-cli/group4/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-exec/src/error.rs
+++ b/crates/spk-exec/src/error.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-exec/src/exec.rs
+++ b/crates/spk-exec/src/exec.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-exec/src/lib.rs
+++ b/crates/spk-exec/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-launcher/src/main.rs
+++ b/crates/spk-launcher/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/foundation/src/env/env_test.rs
+++ b/crates/spk-schema/crates/foundation/src/env/env_test.rs
@@ -1,3 +1,3 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk

--- a/crates/spk-schema/crates/foundation/src/env/mod.rs
+++ b/crates/spk-schema/crates/foundation/src/env/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/foundation/src/fixtures.rs
+++ b/crates/spk-schema/crates/foundation/src/fixtures.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/foundation/src/format/error.rs
+++ b/crates/spk-schema/crates/foundation/src/format/error.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/foundation/src/format/mod.rs
+++ b/crates/spk-schema/crates/foundation/src/format/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/foundation/src/ident_build/build.rs
+++ b/crates/spk-schema/crates/foundation/src/ident_build/build.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use std::convert::TryInto;

--- a/crates/spk-schema/crates/foundation/src/ident_build/build_test.rs
+++ b/crates/spk-schema/crates/foundation/src/ident_build/build_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/foundation/src/ident_build/error.rs
+++ b/crates/spk-schema/crates/foundation/src/ident_build/error.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/foundation/src/ident_build/format.rs
+++ b/crates/spk-schema/crates/foundation/src/ident_build/format.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/foundation/src/ident_build/mod.rs
+++ b/crates/spk-schema/crates/foundation/src/ident_build/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/foundation/src/ident_build/parsing/build.rs
+++ b/crates/spk-schema/crates/foundation/src/ident_build/parsing/build.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/foundation/src/ident_build/parsing/mod.rs
+++ b/crates/spk-schema/crates/foundation/src/ident_build/parsing/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/foundation/src/ident_component/component_spec.rs
+++ b/crates/spk-schema/crates/foundation/src/ident_component/component_spec.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use std::{collections::HashSet, convert::TryFrom};

--- a/crates/spk-schema/crates/foundation/src/ident_component/component_spec_test.rs
+++ b/crates/spk-schema/crates/foundation/src/ident_component/component_spec_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use rstest::rstest;

--- a/crates/spk-schema/crates/foundation/src/ident_component/error.rs
+++ b/crates/spk-schema/crates/foundation/src/ident_component/error.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/foundation/src/ident_component/mod.rs
+++ b/crates/spk-schema/crates/foundation/src/ident_component/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/foundation/src/ident_component/parsing/component.rs
+++ b/crates/spk-schema/crates/foundation/src/ident_component/parsing/component.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/foundation/src/ident_component/parsing/mod.rs
+++ b/crates/spk-schema/crates/foundation/src/ident_component/parsing/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/foundation/src/ident_ops/metadata_path.rs
+++ b/crates/spk-schema/crates/foundation/src/ident_ops/metadata_path.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/foundation/src/ident_ops/mod.rs
+++ b/crates/spk-schema/crates/foundation/src/ident_ops/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/foundation/src/lib.rs
+++ b/crates/spk-schema/crates/foundation/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/foundation/src/name/error.rs
+++ b/crates/spk-schema/crates/foundation/src/name/error.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/foundation/src/name/mod.rs
+++ b/crates/spk-schema/crates/foundation/src/name/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/foundation/src/name/parsing/mod.rs
+++ b/crates/spk-schema/crates/foundation/src/name/parsing/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/foundation/src/name/parsing/name.rs
+++ b/crates/spk-schema/crates/foundation/src/name/parsing/name.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/foundation/src/option_map/error.rs
+++ b/crates/spk-schema/crates/foundation/src/option_map/error.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/foundation/src/option_map/format.rs
+++ b/crates/spk-schema/crates/foundation/src/option_map/format.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/foundation/src/option_map/mod.rs
+++ b/crates/spk-schema/crates/foundation/src/option_map/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use std::collections::{BTreeMap, HashMap};

--- a/crates/spk-schema/crates/foundation/src/option_map/option_map_test.rs
+++ b/crates/spk-schema/crates/foundation/src/option_map/option_map_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/foundation/src/spec_ops/component_ops.rs
+++ b/crates/spk-schema/crates/foundation/src/spec_ops/component_ops.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/foundation/src/spec_ops/error.rs
+++ b/crates/spk-schema/crates/foundation/src/spec_ops/error.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/foundation/src/spec_ops/file_matcher.rs
+++ b/crates/spk-schema/crates/foundation/src/spec_ops/file_matcher.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/foundation/src/spec_ops/file_matcher_test.rs
+++ b/crates/spk-schema/crates/foundation/src/spec_ops/file_matcher_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use rstest::rstest;

--- a/crates/spk-schema/crates/foundation/src/spec_ops/mod.rs
+++ b/crates/spk-schema/crates/foundation/src/spec_ops/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/foundation/src/spec_ops/named.rs
+++ b/crates/spk-schema/crates/foundation/src/spec_ops/named.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/foundation/src/spec_ops/package_ops.rs
+++ b/crates/spk-schema/crates/foundation/src/spec_ops/package_ops.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/foundation/src/spec_ops/recipe_ops.rs
+++ b/crates/spk-schema/crates/foundation/src/spec_ops/recipe_ops.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/foundation/src/spec_ops/versioned.rs
+++ b/crates/spk-schema/crates/foundation/src/spec_ops/versioned.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/foundation/src/version/compat.rs
+++ b/crates/spk-schema/crates/foundation/src/version/compat.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use std::cmp::{Ord, Ordering};

--- a/crates/spk-schema/crates/foundation/src/version/compat_test.rs
+++ b/crates/spk-schema/crates/foundation/src/version/compat_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/foundation/src/version/error.rs
+++ b/crates/spk-schema/crates/foundation/src/version/error.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/foundation/src/version/mod.rs
+++ b/crates/spk-schema/crates/foundation/src/version/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/foundation/src/version/parsing/mod.rs
+++ b/crates/spk-schema/crates/foundation/src/version/parsing/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/foundation/src/version/parsing/version.rs
+++ b/crates/spk-schema/crates/foundation/src/version/parsing/version.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/foundation/src/version/version_test.rs
+++ b/crates/spk-schema/crates/foundation/src/version/version_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use std::cmp::Ord;

--- a/crates/spk-schema/crates/foundation/src/version_range/error.rs
+++ b/crates/spk-schema/crates/foundation/src/version_range/error.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/foundation/src/version_range/intersection.rs
+++ b/crates/spk-schema/crates/foundation/src/version_range/intersection.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/foundation/src/version_range/mod.rs
+++ b/crates/spk-schema/crates/foundation/src/version_range/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/foundation/src/version_range/parsing/mod.rs
+++ b/crates/spk-schema/crates/foundation/src/version_range/parsing/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/foundation/src/version_range/parsing/version_range.rs
+++ b/crates/spk-schema/crates/foundation/src/version_range/parsing/version_range.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/ident/src/error.rs
+++ b/crates/spk-schema/crates/ident/src/error.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/ident/src/format.rs
+++ b/crates/spk-schema/crates/ident/src/format.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/ident/src/ident.rs
+++ b/crates/spk-schema/crates/ident/src/ident.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/ident/src/ident_test.rs
+++ b/crates/spk-schema/crates/ident/src/ident_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/ident/src/lib.rs
+++ b/crates/spk-schema/crates/ident/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/ident/src/parsing/ident.rs
+++ b/crates/spk-schema/crates/ident/src/parsing/ident.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/ident/src/parsing/mod.rs
+++ b/crates/spk-schema/crates/ident/src/parsing/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/ident/src/parsing/parsing_test.rs
+++ b/crates/spk-schema/crates/ident/src/parsing/parsing_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/ident/src/parsing/request.rs
+++ b/crates/spk-schema/crates/ident/src/parsing/request.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/ident/src/request.rs
+++ b/crates/spk-schema/crates/ident/src/request.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use std::{

--- a/crates/spk-schema/crates/ident/src/request_test.rs
+++ b/crates/spk-schema/crates/ident/src/request_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use std::collections::HashSet;

--- a/crates/spk-schema/crates/validators/src/error.rs
+++ b/crates/spk-schema/crates/validators/src/error.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/validators/src/lib.rs
+++ b/crates/spk-schema/crates/validators/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/validators/src/validators.rs
+++ b/crates/spk-schema/crates/validators/src/validators.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/crates/validators/src/validators_test.rs
+++ b/crates/spk-schema/crates/validators/src/validators_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/src/build_spec.rs
+++ b/crates/spk-schema/src/build_spec.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use std::collections::HashSet;

--- a/crates/spk-schema/src/build_spec_test.rs
+++ b/crates/spk-schema/src/build_spec_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use rstest::rstest;

--- a/crates/spk-schema/src/component_spec.rs
+++ b/crates/spk-schema/src/component_spec.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use std::convert::TryInto;

--- a/crates/spk-schema/src/component_spec_list.rs
+++ b/crates/spk-schema/src/component_spec_list.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use std::collections::{HashMap, HashSet};

--- a/crates/spk-schema/src/component_spec_list_test.rs
+++ b/crates/spk-schema/src/component_spec_list_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use rstest::rstest;

--- a/crates/spk-schema/src/component_spec_test.rs
+++ b/crates/spk-schema/src/component_spec_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use rstest::rstest;

--- a/crates/spk-schema/src/deprecate.rs
+++ b/crates/spk-schema/src/deprecate.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/src/embedded_packages_list.rs
+++ b/crates/spk-schema/src/embedded_packages_list.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use serde::{Deserialize, Serialize};

--- a/crates/spk-schema/src/embedded_packages_list_test.rs
+++ b/crates/spk-schema/src/embedded_packages_list_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use rstest::rstest;

--- a/crates/spk-schema/src/environ.rs
+++ b/crates/spk-schema/src/environ.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use serde::{Deserialize, Serialize};

--- a/crates/spk-schema/src/environ_test.rs
+++ b/crates/spk-schema/src/environ_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use rstest::rstest;

--- a/crates/spk-schema/src/error.rs
+++ b/crates/spk-schema/src/error.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/src/install_spec.rs
+++ b/crates/spk-schema/src/install_spec.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use serde::{Deserialize, Serialize};

--- a/crates/spk-schema/src/install_spec_test.rs
+++ b/crates/spk-schema/src/install_spec_test.rs
@@ -1,3 +1,3 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk

--- a/crates/spk-schema/src/lib.rs
+++ b/crates/spk-schema/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/src/meta.rs
+++ b/crates/spk-schema/src/meta.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/src/meta_test.rs
+++ b/crates/spk-schema/src/meta_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/src/option.rs
+++ b/crates/spk-schema/src/option.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use std::convert::TryFrom;

--- a/crates/spk-schema/src/option_test.rs
+++ b/crates/spk-schema/src/option_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use rstest::rstest;

--- a/crates/spk-schema/src/package.rs
+++ b/crates/spk-schema/src/package.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/src/package_test.rs
+++ b/crates/spk-schema/src/package_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/src/prelude.rs
+++ b/crates/spk-schema/src/prelude.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/src/recipe.rs
+++ b/crates/spk-schema/src/recipe.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/src/requirements_list.rs
+++ b/crates/spk-schema/src/requirements_list.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/src/requirements_list_test.rs
+++ b/crates/spk-schema/src/requirements_list_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use rstest::rstest;

--- a/crates/spk-schema/src/source_spec.rs
+++ b/crates/spk-schema/src/source_spec.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use std::collections::HashMap;

--- a/crates/spk-schema/src/source_spec_test.rs
+++ b/crates/spk-schema/src/source_spec_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use rstest::rstest;

--- a/crates/spk-schema/src/spec.rs
+++ b/crates/spk-schema/src/spec.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/src/spec_test.rs
+++ b/crates/spk-schema/src/spec_test.rs
@@ -1,3 +1,3 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk

--- a/crates/spk-schema/src/template.rs
+++ b/crates/spk-schema/src/template.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/src/test_spec.rs
+++ b/crates/spk-schema/src/test_spec.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/src/v0/mod.rs
+++ b/crates/spk-schema/src/v0/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/src/v0/spec.rs
+++ b/crates/spk-schema/src/v0/spec.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use std::collections::{HashMap, HashSet};

--- a/crates/spk-schema/src/v0/spec_test.rs
+++ b/crates/spk-schema/src/v0/spec_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/src/validation.rs
+++ b/crates/spk-schema/src/validation.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/src/validation_test.rs
+++ b/crates/spk-schema/src/validation_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-schema/src/version_range_test.rs
+++ b/crates/spk-schema/src/version_range_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use proptest::{

--- a/crates/spk-solve/crates/graph/src/error.rs
+++ b/crates/spk-solve/crates/graph/src/error.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-solve/crates/graph/src/graph.rs
+++ b/crates/spk-solve/crates/graph/src/graph.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-solve/crates/graph/src/graph_test.rs
+++ b/crates/spk-solve/crates/graph/src/graph_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use std::sync::Arc;

--- a/crates/spk-solve/crates/graph/src/lib.rs
+++ b/crates/spk-solve/crates/graph/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-solve/crates/package-iterator/src/build_key.rs
+++ b/crates/spk-solve/crates/package-iterator/src/build_key.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-solve/crates/package-iterator/src/build_key_test.rs
+++ b/crates/spk-solve/crates/package-iterator/src/build_key_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-solve/crates/package-iterator/src/error.rs
+++ b/crates/spk-solve/crates/package-iterator/src/error.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-solve/crates/package-iterator/src/lib.rs
+++ b/crates/spk-solve/crates/package-iterator/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-solve/crates/package-iterator/src/package_iterator.rs
+++ b/crates/spk-solve/crates/package-iterator/src/package_iterator.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-solve/crates/package-iterator/src/package_iterator_test.rs
+++ b/crates/spk-solve/crates/package-iterator/src/package_iterator_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-solve/crates/solution/src/error.rs
+++ b/crates/spk-solve/crates/solution/src/error.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-solve/crates/solution/src/lib.rs
+++ b/crates/spk-solve/crates/solution/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-solve/crates/solution/src/solution.rs
+++ b/crates/spk-solve/crates/solution/src/solution.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use std::{

--- a/crates/spk-solve/crates/validation/src/error.rs
+++ b/crates/spk-solve/crates/validation/src/error.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-solve/crates/validation/src/lib.rs
+++ b/crates/spk-solve/crates/validation/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-solve/crates/validation/src/validation.rs
+++ b/crates/spk-solve/crates/validation/src/validation.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-solve/crates/validation/src/validation_test.rs
+++ b/crates/spk-solve/crates/validation/src/validation_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use rstest::rstest;

--- a/crates/spk-solve/src/error.rs
+++ b/crates/spk-solve/src/error.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-solve/src/io.rs
+++ b/crates/spk-solve/src/io.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-solve/src/lib.rs
+++ b/crates/spk-solve/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-solve/src/macros.rs
+++ b/crates/spk-solve/src/macros.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-solve/src/solver.rs
+++ b/crates/spk-solve/src/solver.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use std::{

--- a/crates/spk-solve/src/solver_test.rs
+++ b/crates/spk-solve/src/solver_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use std::sync::Arc;

--- a/crates/spk-storage/src/error.rs
+++ b/crates/spk-storage/src/error.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-storage/src/fixtures.rs
+++ b/crates/spk-storage/src/fixtures.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-storage/src/lib.rs
+++ b/crates/spk-storage/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-storage/src/storage/archive.rs
+++ b/crates/spk-storage/src/storage/archive.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use std::{convert::TryFrom, path::Path};

--- a/crates/spk-storage/src/storage/handle.rs
+++ b/crates/spk-storage/src/storage/handle.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-storage/src/storage/mem.rs
+++ b/crates/spk-storage/src/storage/mem.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use std::collections::HashMap;

--- a/crates/spk-storage/src/storage/mod.rs
+++ b/crates/spk-storage/src/storage/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-storage/src/storage/repository.rs
+++ b/crates/spk-storage/src/storage/repository.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use std::{collections::HashMap, sync::Arc};

--- a/crates/spk-storage/src/storage/repository_test.rs
+++ b/crates/spk-storage/src/storage/repository_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/crates/spk-storage/src/storage/runtime.rs
+++ b/crates/spk-storage/src/storage/runtime.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use std::{

--- a/crates/spk-storage/src/storage/spfs.rs
+++ b/crates/spk-storage/src/storage/spfs.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 use std::{

--- a/crates/spk/src/cli.rs
+++ b/crates/spk/src/cli.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 //! Main entry points and utilities for command line interface and interaction.

--- a/crates/spk/src/lib.rs
+++ b/crates/spk/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sony Pictures Imageworks, et al.
+// Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 

--- a/examples/_test.py
+++ b/examples/_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Sony Pictures Imageworks, et al.
+# Copyright (c) Sony Pictures Imageworks, et al.
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/imageworks/spk
 

--- a/examples/cmake/package.py
+++ b/examples/cmake/package.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Sony Pictures Imageworks, et al.
+# Copyright (c) Sony Pictures Imageworks, et al.
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/imageworks/spk
 

--- a/examples/python/python_example/__init__.py
+++ b/examples/python/python_example/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Sony Pictures Imageworks, et al.
+# Copyright (c) Sony Pictures Imageworks, et al.
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/imageworks/spk
 

--- a/examples/python/python_example/__main__.py
+++ b/examples/python/python_example/__main__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Sony Pictures Imageworks, et al.
+# Copyright (c) Sony Pictures Imageworks, et al.
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/imageworks/spk
 

--- a/examples/python/python_example/_example_test.py
+++ b/examples/python/python_example/_example_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Sony Pictures Imageworks, et al.
+# Copyright (c) Sony Pictures Imageworks, et al.
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/imageworks/spk
 

--- a/examples/python/setup.py
+++ b/examples/python/setup.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Sony Pictures Imageworks, et al.
+# Copyright (c) Sony Pictures Imageworks, et al.
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/imageworks/spk
 

--- a/packages/spk-convert-pip/spk-convert-pip
+++ b/packages/spk-convert-pip/spk-convert-pip
@@ -1,5 +1,5 @@
 #!/spfs/bin/python3
-# Copyright (c) 2021 Sony Pictures Imageworks, et al.
+# Copyright (c) Sony Pictures Imageworks, et al.
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/imageworks/spk
 


### PR DESCRIPTION
Apparently, this has no benefit and it's a pain to update. VSCode also re-ordered the imports in a handful of files during the save-on-format, but they seem harmless so I left them.