### PR TITLE
Fix builds (sometimes) not using bash

### DIFF
--- a/crates/spfs-cli/cmd-enter/src/cmd_enter.rs
+++ b/crates/spfs-cli/cmd-enter/src/cmd_enter.rs
@@ -284,7 +284,7 @@ impl CmdEnter {
         let cmd = match self.command.take() {
             Some(exe) if !exe.is_empty() => {
                 tracing::debug!("executing runtime command");
-                spfs::build_shell_initialized_command(rt, exe, self.args.drain(..), None)?
+                spfs::build_shell_initialized_command(rt, None, exe, self.args.drain(..))?
             }
             _ => {
                 tracing::debug!("starting interactive shell environment");

--- a/crates/spfs-cli/cmd-join/src/cmd_join.rs
+++ b/crates/spfs-cli/cmd-join/src/cmd_join.rs
@@ -61,7 +61,7 @@ impl CmdJoin {
         let cmd = match self.command.take() {
             Some(exe) if !exe.is_empty() => {
                 tracing::debug!("executing runtime command");
-                spfs::build_shell_initialized_command(rt, exe, self.args.drain(..), None)?
+                spfs::build_shell_initialized_command(rt, None, exe, self.args.drain(..))?
             }
             _ => {
                 tracing::debug!("starting interactive shell environment");

--- a/crates/spfs/src/bootstrap.rs
+++ b/crates/spfs/src/bootstrap.rs
@@ -98,9 +98,9 @@ pub fn build_interactive_shell_command(
 /// If `shell` is not specified, `$SHELL` will be read from the environment.
 pub fn build_shell_initialized_command<E, A, S>(
     runtime: &runtime::Runtime,
+    shell: Option<&str>,
     command: E,
     args: A,
-    shell: Option<&str>,
 ) -> Result<Command>
 where
     E: Into<OsString>,

--- a/crates/spfs/src/bootstrap_test.rs
+++ b/crates/spfs/src/bootstrap_test.rs
@@ -84,7 +84,7 @@ async fn test_shell_initialization_startup_scripts(
         _ => {}
     }
 
-    let cmd = build_shell_initialized_command(&rt, "printenv", vec!["TEST_VALUE"], None).unwrap();
+    let cmd = build_shell_initialized_command(&rt, None, "printenv", vec!["TEST_VALUE"]).unwrap();
     let mut cmd = cmd.into_std();
     setenv(&mut cmd);
     println!("{cmd:?}");
@@ -139,7 +139,7 @@ async fn test_shell_initialization_no_startup_scripts(shell: &str, tmpdir: tempf
     }
 
     std::env::set_var("SHELL", &shell_path);
-    let cmd = build_shell_initialized_command(&rt, "echo", Option::<OsString>::None, None).unwrap();
+    let cmd = build_shell_initialized_command(&rt, None, "echo", Option::<OsString>::None).unwrap();
     let mut cmd = cmd.into_std();
     setenv(&mut cmd);
     println!("{cmd:?}");

--- a/crates/spk-build/src/build/binary.rs
+++ b/crates/spk-build/src/build/binary.rs
@@ -470,9 +470,9 @@ where
             use std::ffi::OsString;
             spfs::build_shell_initialized_command(
                 &runtime,
+                Some("bash"),
                 OsString::from("bash"),
                 &[OsString::from("-ex"), build_script.into_os_string()],
-                Some("bash"),
             )?
         };
 

--- a/crates/spk-cli/cmd-env/src/cmd_env.rs
+++ b/crates/spk-cli/cmd-env/src/cmd_env.rs
@@ -78,7 +78,7 @@ impl Run for Env {
         } else {
             let cmd = self.command.get(0).unwrap();
             let args = &self.command[1..];
-            spfs::build_shell_initialized_command(&rt, cmd, args, None)?
+            spfs::build_shell_initialized_command(&rt, None, cmd, args)?
         };
         self.run_command(command.executable, command.args)
     }

--- a/crates/spk-cli/cmd-test/src/test/tester.rs
+++ b/crates/spk-cli/cmd-test/src/test/tester.rs
@@ -46,9 +46,9 @@ pub trait Tester: Send {
             .map_err(|err| Error::FileWriteError(script_path.to_owned(), err))?;
         let cmd = spfs::build_shell_initialized_command(
             rt,
+            Some("bash"),
             OsString::from("bash"),
             &[OsString::from("-ex"), script_path.into_os_string()],
-            Some("bash"),
         )?;
         let mut cmd = cmd.into_std();
         let status = cmd


### PR DESCRIPTION
Fixes #464. Using setenv in a multi-threaded program is discouraged. I
wasn't able to reproduce the problem in a trivial package but in a complex
package I was able to get the spk build script `echo $SHELL` to print tcsh,
even though it was in fact running the build script with bash. However,
the spfs runtime environment was created with tcsh.

Signed-off-by: J Robert Ray <jrray@jrray.org>