### PR TITLE
Custom clippy configuration

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,5 @@
+# default is 3
+max-fn-params-bools = 1
+
+# default is 7
+too-many-arguments-threshold = 5

--- a/crates/parsedbuf/src/lib.rs
+++ b/crates/parsedbuf/src/lib.rs
@@ -3,6 +3,7 @@
 // https://github.com/imageworks/spk
 
 #![deny(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::fn_params_excessive_bools)]
 
 pub use paste;
 

--- a/crates/spfs-cli/cmd-clean/src/cmd_clean.rs
+++ b/crates/spfs-cli/cmd-clean/src/cmd_clean.rs
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
+#![deny(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::fn_params_excessive_bools)]
+
 use chrono::prelude::*;
 use clap::Parser;
 use colored::*;

--- a/crates/spfs-cli/cmd-enter/src/cmd_enter.rs
+++ b/crates/spfs-cli/cmd-enter/src/cmd_enter.rs
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
+#![deny(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::fn_params_excessive_bools)]
+
 use std::ffi::OsString;
 
 use clap::Parser;

--- a/crates/spfs-cli/cmd-join/src/cmd_join.rs
+++ b/crates/spfs-cli/cmd-join/src/cmd_join.rs
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
+#![deny(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::fn_params_excessive_bools)]
+
 use std::ffi::OsString;
 
 use clap::Parser;

--- a/crates/spfs-cli/cmd-monitor/src/cmd_monitor.rs
+++ b/crates/spfs-cli/cmd-monitor/src/cmd_monitor.rs
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
+#![deny(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::fn_params_excessive_bools)]
+
 use std::time::Duration;
 
 use clap::Parser;

--- a/crates/spfs-cli/common/src/lib.rs
+++ b/crates/spfs-cli/common/src/lib.rs
@@ -1,3 +1,6 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::fn_params_excessive_bools)]
+
 //! Common macros and argument structures for the spfs command line
 
 mod args;

--- a/crates/spfs-cli/main/src/bin.rs
+++ b/crates/spfs-cli/main/src/bin.rs
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
+#![deny(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::fn_params_excessive_bools)]
+
 use clap::{Parser, Subcommand};
 use spfs::Error;
 

--- a/crates/spfs-encoding/src/lib.rs
+++ b/crates/spfs-encoding/src/lib.rs
@@ -12,6 +12,7 @@
 
 #![deny(missing_docs)]
 #![deny(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::fn_params_excessive_bools)]
 
 mod binary;
 mod error;

--- a/crates/spfs/src/lib.rs
+++ b/crates/spfs/src/lib.rs
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
-//! Filesystem isolation, capture and distribution.
-
 #![deny(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::fn_params_excessive_bools)]
+
+//! Filesystem isolation, capture and distribution.
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 

--- a/crates/spfs/src/resolve_test.rs
+++ b/crates/spfs/src/resolve_test.rs
@@ -1,8 +1,9 @@
-use std::sync::Arc;
-
 // Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
+
+use std::sync::Arc;
+
 use rstest::rstest;
 
 use super::resolve_stack_to_layers;

--- a/crates/spk-build/src/lib.rs
+++ b/crates/spk-build/src/lib.rs
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
+#![deny(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::fn_params_excessive_bools)]
+
 mod build;
 mod error;
 

--- a/crates/spk-cli/cmd-build/src/lib.rs
+++ b/crates/spk-cli/cmd-build/src/lib.rs
@@ -3,5 +3,6 @@
 // https://github.com/imageworks/spk
 
 #![deny(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::fn_params_excessive_bools)]
 
 pub mod cmd_build;

--- a/crates/spk-cli/cmd-convert/src/lib.rs
+++ b/crates/spk-cli/cmd-convert/src/lib.rs
@@ -3,5 +3,6 @@
 // https://github.com/imageworks/spk
 
 #![deny(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::fn_params_excessive_bools)]
 
 pub mod cmd_convert;

--- a/crates/spk-cli/cmd-env/src/lib.rs
+++ b/crates/spk-cli/cmd-env/src/lib.rs
@@ -3,5 +3,6 @@
 // https://github.com/imageworks/spk
 
 #![deny(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::fn_params_excessive_bools)]
 
 pub mod cmd_env;

--- a/crates/spk-cli/cmd-explain/src/lib.rs
+++ b/crates/spk-cli/cmd-explain/src/lib.rs
@@ -3,5 +3,6 @@
 // https://github.com/imageworks/spk
 
 #![deny(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::fn_params_excessive_bools)]
 
 pub mod cmd_explain;

--- a/crates/spk-cli/cmd-install/src/lib.rs
+++ b/crates/spk-cli/cmd-install/src/lib.rs
@@ -3,5 +3,6 @@
 // https://github.com/imageworks/spk
 
 #![deny(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::fn_params_excessive_bools)]
 
 pub mod cmd_install;

--- a/crates/spk-cli/cmd-make-binary/src/lib.rs
+++ b/crates/spk-cli/cmd-make-binary/src/lib.rs
@@ -3,5 +3,6 @@
 // https://github.com/imageworks/spk
 
 #![deny(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::fn_params_excessive_bools)]
 
 pub mod cmd_make_binary;

--- a/crates/spk-cli/cmd-make-source/src/lib.rs
+++ b/crates/spk-cli/cmd-make-source/src/lib.rs
@@ -3,5 +3,6 @@
 // https://github.com/imageworks/spk
 
 #![deny(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::fn_params_excessive_bools)]
 
 pub mod cmd_make_source;

--- a/crates/spk-cli/cmd-render/src/cmd_render.rs
+++ b/crates/spk-cli/cmd-render/src/cmd_render.rs
@@ -1,6 +1,10 @@
 // Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
+
+#![deny(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::fn_params_excessive_bools)]
+
 use std::path::PathBuf;
 
 use anyhow::{bail, Context, Result};

--- a/crates/spk-cli/cmd-render/src/lib.rs
+++ b/crates/spk-cli/cmd-render/src/lib.rs
@@ -3,5 +3,6 @@
 // https://github.com/imageworks/spk
 
 #![deny(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::fn_params_excessive_bools)]
 
 pub mod cmd_render;

--- a/crates/spk-cli/cmd-repo/src/lib.rs
+++ b/crates/spk-cli/cmd-repo/src/lib.rs
@@ -3,5 +3,6 @@
 // https://github.com/imageworks/spk
 
 #![deny(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::fn_params_excessive_bools)]
 
 pub mod cmd_repo;

--- a/crates/spk-cli/cmd-test/src/lib.rs
+++ b/crates/spk-cli/cmd-test/src/lib.rs
@@ -3,6 +3,7 @@
 // https://github.com/imageworks/spk
 
 #![deny(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::fn_params_excessive_bools)]
 
 pub mod cmd_test;
 

--- a/crates/spk-cli/common/src/lib.rs
+++ b/crates/spk-cli/common/src/lib.rs
@@ -3,6 +3,7 @@
 // https://github.com/imageworks/spk
 
 #![deny(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::fn_params_excessive_bools)]
 
 mod cli;
 mod env;

--- a/crates/spk-cli/group1/src/lib.rs
+++ b/crates/spk-cli/group1/src/lib.rs
@@ -3,6 +3,7 @@
 // https://github.com/imageworks/spk
 
 #![deny(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::fn_params_excessive_bools)]
 
 pub mod cmd_bake;
 pub mod cmd_deprecate;

--- a/crates/spk-cli/group2/src/lib.rs
+++ b/crates/spk-cli/group2/src/lib.rs
@@ -3,6 +3,7 @@
 // https://github.com/imageworks/spk
 
 #![deny(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::fn_params_excessive_bools)]
 
 pub mod cmd_ls;
 pub mod cmd_new;

--- a/crates/spk-cli/group3/src/lib.rs
+++ b/crates/spk-cli/group3/src/lib.rs
@@ -3,6 +3,7 @@
 // https://github.com/imageworks/spk
 
 #![deny(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::fn_params_excessive_bools)]
 
 pub mod cmd_export;
 pub mod cmd_import;

--- a/crates/spk-cli/group4/src/lib.rs
+++ b/crates/spk-cli/group4/src/lib.rs
@@ -3,6 +3,7 @@
 // https://github.com/imageworks/spk
 
 #![deny(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::fn_params_excessive_bools)]
 
 pub mod cmd_lint;
 pub mod cmd_search;

--- a/crates/spk-exec/src/lib.rs
+++ b/crates/spk-exec/src/lib.rs
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
+#![deny(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::fn_params_excessive_bools)]
+
 mod error;
 mod exec;
 

--- a/crates/spk-schema/crates/foundation/src/lib.rs
+++ b/crates/spk-schema/crates/foundation/src/lib.rs
@@ -3,6 +3,7 @@
 // https://github.com/imageworks/spk
 
 #![deny(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::fn_params_excessive_bools)]
 
 pub mod env;
 pub mod fixtures;

--- a/crates/spk-schema/crates/ident/src/lib.rs
+++ b/crates/spk-schema/crates/ident/src/lib.rs
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
+#![deny(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::fn_params_excessive_bools)]
+
 mod error;
 mod format;
 mod ident;

--- a/crates/spk-schema/crates/validators/src/lib.rs
+++ b/crates/spk-schema/crates/validators/src/lib.rs
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
+#![deny(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::fn_params_excessive_bools)]
+
 mod error;
 mod validators;
 

--- a/crates/spk-schema/src/lib.rs
+++ b/crates/spk-schema/src/lib.rs
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
+#![deny(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::fn_params_excessive_bools)]
+
 mod build_spec;
 mod component_spec;
 mod component_spec_list;

--- a/crates/spk-solve/crates/graph/src/lib.rs
+++ b/crates/spk-solve/crates/graph/src/lib.rs
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
+#![deny(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::fn_params_excessive_bools)]
+
 mod error;
 mod graph;
 

--- a/crates/spk-solve/crates/package-iterator/src/build_key_test.rs
+++ b/crates/spk-solve/crates/package-iterator/src/build_key_test.rs
@@ -34,6 +34,7 @@ fn make_tag_part(pieces: Vec<&str>) -> Option<Vec<BuildKeyVersionNumberPiece>> {
 
 // For making test case results
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::fn_params_excessive_bools)]
 fn make_expanded_version_range_part(
     version: &str,
     max_digits: Vec<u32>,

--- a/crates/spk-solve/crates/package-iterator/src/lib.rs
+++ b/crates/spk-solve/crates/package-iterator/src/lib.rs
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
+#![deny(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::fn_params_excessive_bools)]
+
 mod build_key;
 mod error;
 mod package_iterator;

--- a/crates/spk-solve/crates/solution/src/lib.rs
+++ b/crates/spk-solve/crates/solution/src/lib.rs
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
+#![deny(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::fn_params_excessive_bools)]
+
 mod error;
 mod solution;
 

--- a/crates/spk-solve/crates/validation/src/lib.rs
+++ b/crates/spk-solve/crates/validation/src/lib.rs
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
+#![deny(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::fn_params_excessive_bools)]
+
 mod error;
 mod impossible_checks;
 mod validation;

--- a/crates/spk-solve/src/lib.rs
+++ b/crates/spk-solve/src/lib.rs
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
+#![deny(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::fn_params_excessive_bools)]
+
 mod error;
 mod io;
 mod macros;

--- a/crates/spk-storage/src/lib.rs
+++ b/crates/spk-storage/src/lib.rs
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
+#![deny(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::fn_params_excessive_bools)]
+
 mod error;
 pub mod fixtures;
 mod storage;

--- a/crates/spk/src/cli.rs
+++ b/crates/spk/src/cli.rs
@@ -1,6 +1,10 @@
 // Copyright (c) Sony Pictures Imageworks, et al.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
+
+#![deny(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::fn_params_excessive_bools)]
+
 //! Main entry points and utilities for command line interface and interaction.
 
 use anyhow::{Context, Result};

--- a/crates/spk/src/lib.rs
+++ b/crates/spk/src/lib.rs
@@ -3,6 +3,7 @@
 // https://github.com/imageworks/spk
 
 #![deny(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::fn_params_excessive_bools)]
 
 pub use {
     spk_build as build,


### PR DESCRIPTION
This is a step towards having some coding and style conventions for this project "in writing" that we can all discuss and agree on, focusing on two things have been a frequent point of contention in code reviews.

The use of bools in function parameters can be monitored by clippy. This is a "pedantic" check so it is not enabled by default. I put the attr in every lib.rs to enable it. Our codebase passes with this set to 1, with one exception, where the warning has been supressed. I agree with the [sentiment of the clippy lint text](https://rust-lang.github.io/rust-clippy/master/index.html#fn_params_excessive_bools), "calls to such functions [with excessive use of bools] are confusing and error prone," particularly if there are multiple consecutive bool arguments. But rather than banning bool arguments entirely, allowing a single bool argument avoids the confusing argument order problem.

The threshold for too many arguments is enabled by default, but has a default limit of 7. For our codebase, 5 is the lowest it can go without triggering any warnings. My personal preference is to not try to go lower than 5.

Interestingly, this was the #2 most ignored lint: https://github.com/rust-lang/rust-clippy/issues/7666 As noted in the comments, this is most likely due to `new` constructors for complex structs requiring many arguments.