### PR TITLE
Add defaults for all metadata fields

### DIFF
--- a/crates/spk-schema/src/meta.rs
+++ b/crates/spk-schema/src/meta.rs
@@ -11,16 +11,16 @@ mod meta_test;
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct Meta {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub homepage: Option<String>,
     #[serde(
         default = "Meta::default_license",
         skip_serializing_if = "String::is_empty"
     )]
     pub license: String,
-    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub labels: BTreeMap<String, String>,
 }
 


### PR DESCRIPTION
It should be possible to fill in just the fields that are desired rather than needing to specify all of them
