### PR TITLE
Use `--no-runtime` flag to avoid recursive runtime creation

### DIFF
--- a/crates/spk-cli/cmd-build/src/cmd_build.rs
+++ b/crates/spk-cli/cmd-build/src/cmd_build.rs
@@ -50,7 +50,9 @@ pub struct Build {
 #[async_trait::async_trait]
 impl Run for Build {
     async fn run(&mut self) -> Result<i32> {
-        self.runtime.ensure_active_runtime().await?;
+        self.runtime
+            .ensure_active_runtime(&["build", "make", "mk"])
+            .await?;
 
         // divide our packages into one for each iteration of mks/mkb
         let mut runs: Vec<_> = self.packages.iter().map(|f| vec![f.to_owned()]).collect();

--- a/crates/spk-cli/cmd-env/src/cmd_env.rs
+++ b/crates/spk-cli/cmd-env/src/cmd_env.rs
@@ -45,7 +45,10 @@ pub struct Env {
 #[async_trait::async_trait]
 impl Run for Env {
     async fn run(&mut self) -> Result<i32> {
-        let mut rt = self.runtime.ensure_active_runtime().await?;
+        let mut rt = self
+            .runtime
+            .ensure_active_runtime(&["env", "run", "shell"])
+            .await?;
 
         let (mut solver, requests) = tokio::try_join!(
             self.solver.get_solver(&self.options),

--- a/crates/spk-cli/cmd-explain/src/cmd_explain.rs
+++ b/crates/spk-cli/cmd-explain/src/cmd_explain.rs
@@ -32,7 +32,7 @@ pub struct Explain {
 #[async_trait::async_trait]
 impl Run for Explain {
     async fn run(&mut self) -> Result<i32> {
-        self.runtime.ensure_active_runtime().await?;
+        self.runtime.ensure_active_runtime(&["explain"]).await?;
 
         let (mut solver, requests) = tokio::try_join!(
             self.solver.get_solver(&self.options),

--- a/crates/spk-cli/cmd-make-binary/src/cmd_make_binary.rs
+++ b/crates/spk-cli/cmd-make-binary/src/cmd_make_binary.rs
@@ -96,7 +96,7 @@ impl Run for MakeBinary {
         let options = self.options.get_options()?;
         #[rustfmt::skip]
         let (_runtime, local, repos) = tokio::try_join!(
-            self.runtime.ensure_active_runtime(),
+            self.runtime.ensure_active_runtime(&["make-binary", "mkbinary", "mkbin", "mkb"]),
             storage::local_repository().map_ok(storage::RepositoryHandle::from).map_err(anyhow::Error::from),
             async { self.repos.get_repos_for_non_destructive_operation().await }
         )?;

--- a/crates/spk-cli/cmd-make-source/src/cmd_make_source.rs
+++ b/crates/spk-cli/cmd-make-source/src/cmd_make_source.rs
@@ -41,7 +41,10 @@ impl Run for MakeSource {
 
 impl MakeSource {
     pub async fn make_source(&mut self) -> Result<Vec<BuildIdent>> {
-        let _runtime = self.runtime.ensure_active_runtime().await?;
+        let _runtime = self
+            .runtime
+            .ensure_active_runtime(&["make-source", "mksource", "mksrc", "mks"])
+            .await?;
         let local: storage::RepositoryHandle = storage::local_repository().await?.into();
         let options = self.options.get_options()?;
 

--- a/crates/spk-cli/cmd-test/src/cmd_test.rs
+++ b/crates/spk-cli/cmd-test/src/cmd_test.rs
@@ -63,7 +63,7 @@ impl Run for Test {
     async fn run(&mut self) -> Result<i32> {
         let options = self.options.get_options()?;
         let (_runtime, repos) = tokio::try_join!(
-            self.runtime.ensure_active_runtime(),
+            self.runtime.ensure_active_runtime(&["test"]),
             self.repos.get_repos_for_non_destructive_operation()
         )?;
         let repos = repos

--- a/crates/spk-cli/group1/src/cmd_bake.rs
+++ b/crates/spk-cli/group1/src/cmd_bake.rs
@@ -77,7 +77,7 @@ impl Run for Bake {
             self.get_active_runtime_info().await?
         } else {
             let (_, layers) = tokio::try_join!(
-                self.runtime.ensure_active_runtime(),
+                self.runtime.ensure_active_runtime(&["bake"]),
                 self.get_new_solve_info()
             )?;
             layers


### PR DESCRIPTION
The use of $SPK_NO_RUNTIME would mean that any further use of nested spk
environments, intended or not, would reuse the existing runtime. Avoid that
by inserting `--no-runtime` into the args of the new command to be
executed.

Fixes #481.

There may be some better way to figure out the position more automatically,
maybe via the Clap reflection API.

Signed-off-by: J Robert Ray <jrray@jrray.org>