### PR TITLE
Update makefile for linting and testing specific crates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,11 @@ SPK_VERSION = $(shell grep Version spk.spec | cut -d ' ' -f 2)
 SPFS_VERSION = $(shell cat spfs.spec | grep Version | cut -d ' ' -f 2)
 SOURCE_ROOT := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 
+comma := ,
 cargo_features_arg = $(if $(FEATURES),--features $(FEATURES))
+cargo_packages_arg := $(if $(CRATES),-p=$(CRATES))
+cargo_packages_arg := $(subst $(comma), -p=,$(cargo_packages_arg))
+
 
 # Create a file called "config.mak" to configure variables.
 -include config.mak
@@ -33,8 +37,8 @@ clean: packages.clean
 lint: FEATURES?=server,spfs/server
 lint:
 	cargo fmt --check
-	cargo clippy --tests $(cargo_features_arg) -- -Dwarnings
-	env RUSTDOCFLAGS="-Dwarnings" cargo doc --no-deps $(cargo_features_arg)
+	cargo clippy --tests $(cargo_features_arg) $(cargo_packages_arg) -- -Dwarnings
+	env RUSTDOCFLAGS="-Dwarnings" cargo doc --no-deps $(cargo_features_arg) $(cargo_packages_arg)
 
 .PHONY: format
 format:
@@ -58,7 +62,7 @@ release:
 .PHONY: test
 test: FEATURES?=server,spfs/server
 test:
-	spfs run - -- cargo test --workspace $(cargo_features_arg)
+	spfs run - -- cargo test --workspace $(cargo_features_arg) $(cargo_packages_arg)
 
 .PHONY: converters
 converters:

--- a/README.md
+++ b/README.md
@@ -85,11 +85,18 @@ make rpms
 
 ### Testing
 
-Both projecs have a number of unit and integration tests as well as testable examples that can all be executed with `make test`. The tests for spk need to be executed under an spfs runtime in order to properly execute.
+Both projecs have a number of unit and integration tests as well as testable examples that can all be executed with `make test`. The tests for spk need to be executed under an spfs runtime in order to properly execute. We also have configured linting rules that must pass for all contributions.
+
+Our repository is broken down into a number of smaller crates for easier development, and they can be individually targeted in the makefile which can greatly reduce the time it takes for testing and linting.
 
 ```sh
 # run the unit test suite
 make test
+# check the code for lint
+make lint
+
+# only lint and test two specific crates
+make lint test CRATES=spfs-encoding,spfs-cli-common
 ```
 
 ### Bootstrapping


### PR DESCRIPTION
A small addition that has been helpful for me now that we have a great number of crates - borrowing the `FEATURES` idea.

```sh
make test CRATES=spfs-encoding
```