### PR TITLE
otio: Completed opentimelineio Created cmake/3.18 package

### DIFF
--- a/packages/cmake/cmake318.spk.yaml
+++ b/packages/cmake/cmake318.spk.yaml
@@ -1,0 +1,31 @@
+pkg: cmake/3.18.2
+api: v0/package
+
+sources:
+  # Idiom that retrieves the tar file from github if it isn't already local.
+  # Sites without direct internet access may instead want to pre-download
+  # the tar file.
+  - path: ./
+  - script:
+    - export TARFILE=cmake-3.18.2-Linux-x86_64.tar.gz
+    - if [ ! -e ./$TARFILE ] ; then wget https://github.com/Kitware/CMake/releases/download/v3.18.2/$TARFILE ; fi
+
+build:
+  options:
+  - var: arch
+  - var: os
+  script:
+    - mkdir -p build; cd build
+    - tar -xvf
+        ../cmake-3.18.2-Linux-x86_64.tar.gz
+        --strip-components=1
+        --exclude=doc
+        --exclude=Help
+    - rsync -rv ./ $PREFIX/
+
+install:
+  environment:
+    - set: CMAKE_SYSTEM_INCLUDE_PATH
+      value: /spfs/include
+    - set: CMAKE_SYSTEM_PREFIX_PATH
+      value: /spfs

--- a/packages/opentimelineio/opentimelineio.spk.yaml
+++ b/packages/opentimelineio/opentimelineio.spk.yaml
@@ -1,0 +1,47 @@
+pkg: opentimelineio/0.14.1
+
+sources: 
+  - git: https://github.com/AcademySoftwareFoundation/OpenTimelineIO.git
+    ref: v0.14.1
+
+build:
+
+  options:
+    - var: arch    # rebuild if the arch changes
+    - var: os      # rebuild if the os changes
+    - var: centos  # rebuild if centos version changes
+    
+    - pkg: python-pip
+    - pkg: python/3
+    - pkg: gcc
+    - pkg: cmake/^3.18
+  variants:
+    - {python: 3.7}
+
+  script:
+    - mkdir build
+    - cd build
+    - cmake .. -DCMAKE_INSTALL_PREFIX=/spfs 
+    - make install prefix=/spfs 
+    - python -m pip install ..[dev]
+    - cd ..  
+    - make test
+    - make coverage
+
+install:
+  requirements:
+    - pkg: python
+      fromBuildEnv: x.x
+    - pkg: gcc
+
+  componenents: 
+    - name: run
+      files: 
+        - /lib/
+        - /share/
+        - /include/
+        - /bin/
+
+tests: 
+  - stage: install
+    script: make test

--- a/packages/python/python3.spk.yaml
+++ b/packages/python/python3.spk.yaml
@@ -15,6 +15,7 @@ build:
     - pkg: binutils
     - pkg: libffi
     - pkg: openssl
+    - pkg: tcl
     - pkg: zlib/1.2
     - var: abi
       default: cp37m
@@ -97,6 +98,7 @@ install:
     - pkg: libffi
     - pkg: ncurses
     - pkg: bzip2
+    - pkg: tcl
       fromBuildEnv: Binary
     - pkg: zlib
       fromBuildEnv: Binary

--- a/packages/tcl/tcl.spk.yaml
+++ b/packages/tcl/tcl.spk.yaml
@@ -1,0 +1,24 @@
+pkg: tcl/8.6.3
+
+sources: 
+  - tar: https://sourceforge.net/projects/tcl/files/Tcl/8.6.3/tcl8.6.3-src.tar.gz/download
+
+build:
+
+  options:
+    - var: arch    # rebuild if the arch changes
+    - var: os      # rebuild if the os changes
+    - var: centos  # rebuild if centos version changes
+
+    - pkg: gcc
+    - pkg: binutils
+    - pkg: stdfs 
+  script:
+    - cd tcl8.6.3/unix
+    - ./configure --prefix=/spfs
+    - make install
+
+install:
+  requirements:
+    - pkg: gcc 
+      fromBuildEnv: x.x


### PR DESCRIPTION
Created opentimelineio package
Created tcl package
Updated python3.spk.yaml to include tcl as a requirement in order import sqlite3
cmake/3.18 is required for building otio
tcl is required for running make coverage with opentimelineio
Related-to: #39 