### PR TITLE
Overlayfs basic supported features check and default inode index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "async_once"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ce4f10ea3abcd6617873bae9f91d1c5332b4a778bd9ce34d0cd517474c1de82"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,6 +395,44 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
+
+[[package]]
+name = "cached"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5877db5d1af7fae60d06b5db9430b68056a69b3582a0be8e3691e87654aeb6"
+dependencies = [
+ "async-trait",
+ "async_once",
+ "cached_proc_macro",
+ "cached_proc_macro_types",
+ "futures",
+ "hashbrown 0.13.2",
+ "instant",
+ "lazy_static",
+ "once_cell",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "cached_proc_macro"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10ca87c81aaa3a949dbbe2b5e6c2c45dbc94ba4897e45ea31ff9ec5087be3dc"
+dependencies = [
+ "cached_proc_macro_types",
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.98",
+]
+
+[[package]]
+name = "cached_proc_macro_types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a4f925191b4367301851c6d99b09890311d74b0d43f274c0b34c86d308a3663"
 
 [[package]]
 name = "caps"
@@ -728,13 +772,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0808e1bd8671fb44a113a14e13497557533369847788fa2ae912b6ebfce9fa8"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "001d80444f28e193f30c2f293455da62dcf9a6b29918a4253152ae2b1de592cb"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 1.0.98",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b36230598a2d5de7ec1c6f51f72d8a99a9208daff41de2084d06e3fd3ea56685"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 1.0.98",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
 dependencies = [
  "cfg-if",
- "hashbrown",
+ "hashbrown 0.12.3",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -1215,6 +1294,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+
+[[package]]
 name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1348,6 +1433,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1389,7 +1480,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1918,7 +2009,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
 dependencies = [
  "dlv-list",
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -3047,6 +3138,7 @@ dependencies = [
  "async-recursion",
  "async-stream",
  "async-trait",
+ "cached",
  "caps",
  "chrono",
  "close-err",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ version = "0.36.0"
 [workspace.dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
+cached = "0.42.0"
 chrono = { version = "0.4.19", features = ["serde"] }
 clap = { version = "4.3", features = ["derive", "env"] }
 colored = "2.0.0"

--- a/crates/spfs-cli/cmd-enter/src/cmd_enter.rs
+++ b/crates/spfs-cli/cmd-enter/src/cmd_enter.rs
@@ -127,6 +127,11 @@ impl CmdEnter {
         &mut self,
         config: &spfs::Config,
     ) -> Result<Option<spfs::runtime::OwnedRuntime>> {
+        // this function will eventually be required to discover the overlayfs
+        // attributes. It can take many milliseconds to run so we prime the cache as
+        // soon as possible in a separate thread
+        std::thread::spawn(spfs::runtime::overlayfs::overlayfs_available_options_prime_cache);
+
         let mut runtime = self.load_runtime(config).await?;
 
         if self.exit.enabled {

--- a/crates/spfs/Cargo.toml
+++ b/crates/spfs/Cargo.toml
@@ -20,6 +20,7 @@ async-compression = { version = "0.3.15", features = ["tokio", "bzip2"] }
 async-trait = "0.1.52"
 async-recursion = "1.0"
 async-stream = "0.3"
+cached = { workspace = true }
 caps = "0.5.3"
 chrono = { workspace = true }
 close-err = "1.0"

--- a/crates/spfs/src/error.rs
+++ b/crates/spfs/src/error.rs
@@ -102,6 +102,10 @@ pub enum Error {
     #[error("Command, arguments or environment contained a nul byte, this is not supported")]
     CommandHasNul(#[source] std::ffi::NulError),
 
+    #[cfg(target_os = "linux")]
+    #[error("OverlayFS kernel module does not appear to be installed")]
+    OverlayFSNotInstalled,
+
     #[error("{}, and {} more errors during clean", errors.get(0).unwrap(), errors.len() - 1)]
     IncompleteClean { errors: Vec<Self> },
 }

--- a/crates/spfs/src/runtime/mod.rs
+++ b/crates/spfs/src/runtime/mod.rs
@@ -4,7 +4,7 @@
 
 //! Handles the setup and initialization of runtime environments
 
-mod overlayfs;
+pub mod overlayfs;
 mod startup_csh;
 mod startup_sh;
 mod storage;

--- a/crates/spfs/src/runtime/overlayfs.rs
+++ b/crates/spfs/src/runtime/overlayfs.rs
@@ -2,7 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
+use std::collections::HashSet;
+use std::io::{BufRead, BufReader};
 use std::os::unix::fs::MetadataExt;
+
+use crate::{Error, Result};
+
+#[cfg(test)]
+#[path = "./overlayfs_test.rs"]
+mod overlayfs_test;
 
 pub fn is_removed_entry(meta: &std::fs::Metadata) -> bool {
     // overlayfs uses character device files to denote
@@ -13,4 +21,51 @@ pub fn is_removed_entry(meta: &std::fs::Metadata) -> bool {
     }
     // - the device is always 0/0 for a whiteout file
     meta.rdev() == 0
+}
+
+/// Get the set of supported overlayfs arguments on this machine
+#[cfg(target_os = "linux")]
+#[cached::proc_macro::once(sync_writes = true)]
+pub fn overlayfs_available_options() -> HashSet<String> {
+    query_overlayfs_available_options().unwrap_or_else(|err| {
+        tracing::warn!("Failed to detect supported overlayfs params: {err}");
+        tracing::warn!(" > Falling back to the most conservative set, which is undesirable");
+        Default::default()
+    })
+}
+
+/// Read available overlayfs settings from the kernel
+fn query_overlayfs_available_options() -> Result<HashSet<String>> {
+    let output = std::process::Command::new("/sbin/modinfo")
+        .arg("overlay")
+        .output()
+        .map_err(|err| Error::process_spawn_error("/sbin/modinfo".into(), err, None))?;
+
+    if output.status.code().unwrap_or(1) != 0 {
+        return Err(Error::OverlayFSNotInstalled);
+    }
+
+    parse_modinfo_params(&mut BufReader::new(output.stdout.as_slice()))
+}
+
+/// Parses the available parameters from the output of `modinfo` for a kernel module
+#[cfg(target_os = "linux")]
+fn parse_modinfo_params<R: BufRead>(reader: &mut R) -> Result<HashSet<String>> {
+    let mut params = HashSet::new();
+    for line in reader.lines() {
+        let line = line.map_err(|err| {
+            Error::String(format!("Failed to read kernel module information: {err}"))
+        })?;
+        let param = match line.strip_prefix("parm:") {
+            Some(remainder) => remainder.trim(),
+            None => continue,
+        };
+        let name = match param.split_once(':') {
+            Some((name, _remainder)) => name,
+            None => param,
+        };
+        params.insert(name.to_owned());
+    }
+
+    Ok(params)
 }

--- a/crates/spfs/src/runtime/overlayfs_test.rs
+++ b/crates/spfs/src/runtime/overlayfs_test.rs
@@ -1,0 +1,65 @@
+// Copyright (c) Sony Pictures Imageworks, et al.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/imageworks/spk
+
+use rstest::rstest;
+
+use super::parse_modinfo_params;
+
+#[rstest]
+#[cfg(target_os = "linux")]
+fn test_parse_modinfo() {
+    const MODINFO: &str = r#"
+filename:       /lib/modules/3.10.0-1160.71.1.el7.x86_64/kernel/fs/overlayfs/overlay.ko.xz
+alias:          fs-overlay
+license:        GPL
+description:    Overlay filesystem
+author:         Miklos Szeredi <miklos@szeredi.hu>
+retpoline:      Y
+rhelversion:    7.9
+srcversion:     35816F78BA4302A3CFE3853
+depends:
+intree:         Y
+vermagic:       3.10.0-1160.71.1.el7.x86_64 SMP mod_unload modversions
+signer:         CentOS Linux kernel signing key
+sig_key:        6D:A7:C2:41:B1:C9:99:25:3F:B3:B0:36:89:C0:D1:E3:BE:27:82:E4
+sig_hashalgo:   sha256
+parm:           check_copy_up:uint
+parm:           ovl_check_copy_up:Warn on copy-up when causing process also has a R/O fd open
+parm:           redirect_max:ushort
+parm:           ovl_redirect_max:Maximum length of absolute redirect xattr value
+parm:           redirect_dir:bool
+parm:           ovl_redirect_dir_def:Default to on or off for the redirect_dir feature
+parm:           redirect_always_follow:bool
+parm:           ovl_redirect_always_follow:Follow redirects even if redirect_dir feature is turned off
+parm:           index:bool
+parm:           ovl_index_def:Default to on or off for the inodes index feature
+parm:           nfs_export:bool
+parm:           ovl_nfs_export_def:Default to on or off for the NFS export feature
+parm:           xino_auto:bool
+parm:           ovl_xino_auto_def:Auto enable xino feature
+"#;
+    let params = parse_modinfo_params(&mut std::io::BufReader::new(std::io::Cursor::new(MODINFO)))
+        .expect("modinfo parsing should not fail");
+    let mut params = params.iter().map(String::as_str).collect::<Vec<_>>();
+    params.sort();
+    assert_eq!(
+        params,
+        vec![
+            "check_copy_up",
+            "index",
+            "nfs_export",
+            "ovl_check_copy_up",
+            "ovl_index_def",
+            "ovl_nfs_export_def",
+            "ovl_redirect_always_follow",
+            "ovl_redirect_dir_def",
+            "ovl_redirect_max",
+            "ovl_xino_auto_def",
+            "redirect_always_follow",
+            "redirect_dir",
+            "redirect_max",
+            "xino_auto",
+        ]
+    );
+}


### PR DESCRIPTION
It turns out that the `metacopy=on` parameter for overlayfs does not exist in centos 7.9. From what I have found, it was introduces in the kernel version 4.18 ([pull](https://lore.kernel.org/all/20180610055326.GR30522@ZenIV.linux.org.uk/T/)) which means that the upcoming move to centos 8 and/or 9 based on the recent recommendations from the VFX reference platform will make it available. Given that, I am going to continue on this investigation to see if I can make something work which we can adopt in the future / on newer kernels.

In the meantime, I discovered the `index=on` option which I believe that we should be using as it disconnects hard links when they are copied up - eg when the same payload appears in multiple places in spfs, we don't want changes of one file to also change the other (the default behavior).

Related to #489