### PR TITLE
Remove "re-export for macros" comments

### DIFF
--- a/crates/spk-schema/src/lib.rs
+++ b/crates/spk-schema/src/lib.rs
@@ -23,7 +23,6 @@ mod test_spec;
 pub mod v0;
 mod validation;
 
-// Re-export for macros
 pub use build_spec::{BuildSpec, Script};
 pub use component_spec::ComponentSpec;
 pub use component_spec_list::ComponentSpecList;

--- a/crates/spk-solve/src/lib.rs
+++ b/crates/spk-solve/src/lib.rs
@@ -9,8 +9,6 @@ mod solver;
 
 pub use error::{Error, Result};
 pub use io::{DecisionFormatter, DecisionFormatterBuilder};
-// Re-export for macros
-pub use serde_json;
 pub use solver::{Solver, SolverRuntime};
 pub use spk_schema::foundation::ident_component::Component;
 pub use spk_schema::foundation::option_map;
@@ -20,6 +18,7 @@ pub use spk_schema::{recipe, spec, v0, Package, Recipe, Spec};
 pub use spk_solve_solution::{PackageSource, Solution};
 pub use spk_storage::RepositoryHandle;
 pub use {
+    serde_json,
     spfs,
     spk_solve_graph as graph,
     spk_solve_package_iterator as package_iterator,


### PR DESCRIPTION
These were attached to a separate grouping of imports before #500 but that
separation was lost.

Signed-off-by: J Robert Ray <jrray@jrray.org>