### PR TITLE
Add filter mode for components file filtering

### DIFF
--- a/crates/spk-build/src/build/binary.rs
+++ b/crates/spk-build/src/build/binary.rs
@@ -20,7 +20,7 @@ use spk_schema::foundation::option_map::OptionMap;
 use spk_schema::foundation::spec_ops::{ComponentOps, PackageMutOps, PackageOps};
 use spk_schema::foundation::version::VERSION_SEP;
 use spk_schema::ident::{PkgRequest, PreReleasePolicy, RangeIdent, RequestedBy};
-use spk_schema::{ComponentFilterMode, ComponentSpecList, DeprecateMut, Ident, Package};
+use spk_schema::{ComponentFileMatchMode, ComponentSpecList, DeprecateMut, Ident, Package};
 use spk_solve::graph::Graph;
 use spk_solve::solution::Solution;
 use spk_solve::{BoxedResolverCallback, DefaultResolver, ResolverCallback, Solver};
@@ -649,7 +649,7 @@ fn split_manifest_by_component(
                 .matches(&node.path.to_path("/"), node.entry.is_dir())
             {
                 let is_new_file = seen.insert(node.path.to_owned());
-                if matches!(component.filter_mode, ComponentFilterMode::Inclusive) || is_new_file {
+                if matches!(component.file_match_mode, ComponentFileMatchMode::All) || is_new_file {
                     relevant_paths.extend(path_and_parents(node.path.to_owned()));
                 }
             }

--- a/crates/spk-schema/src/component_spec.rs
+++ b/crates/spk-schema/src/component_spec.rs
@@ -15,13 +15,13 @@ mod component_spec_test;
 
 /// Control how files are filtered between components.
 #[derive(Clone, Debug, Default, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum ComponentFilterMode {
+pub enum ComponentFileMatchMode {
     /// Matching files are always included.
     #[default]
-    Inclusive,
+    All,
     /// Matching files are only included if they haven't already been matched
     /// by a previously defined component.
-    Exclusive,
+    Remaining,
 }
 
 /// Defines a named package component.
@@ -37,7 +37,7 @@ pub struct ComponentSpec {
     #[serde(default)]
     pub embedded: super::EmbeddedPackagesList,
     #[serde(default)]
-    pub filter_mode: ComponentFilterMode,
+    pub file_match_mode: ComponentFileMatchMode,
 }
 
 impl ComponentSpec {
@@ -52,7 +52,7 @@ impl ComponentSpec {
             files: Default::default(),
             requirements: Default::default(),
             embedded: Default::default(),
-            filter_mode: Default::default(),
+            file_match_mode: Default::default(),
         })
     }
 
@@ -65,7 +65,7 @@ impl ComponentSpec {
             files: FileMatcher::all(),
             requirements: Default::default(),
             embedded: Default::default(),
-            filter_mode: Default::default(),
+            file_match_mode: Default::default(),
         }
     }
 
@@ -78,7 +78,7 @@ impl ComponentSpec {
             files: FileMatcher::all(),
             requirements: Default::default(),
             embedded: Default::default(),
-            filter_mode: Default::default(),
+            file_match_mode: Default::default(),
         }
     }
 }

--- a/crates/spk-schema/src/component_spec_list.rs
+++ b/crates/spk-schema/src/component_spec_list.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use super::ComponentSpec;
 use crate::foundation::ident_component::Component;
-use crate::ComponentFilterMode;
+use crate::ComponentFileMatchMode;
 
 #[cfg(test)]
 #[path = "./component_spec_list_test.rs"]
@@ -142,7 +142,7 @@ impl<'de> Deserialize<'de> for ComponentSpecList {
                 // all referenced components must have been defined
                 // within the spec as well
                 for component in components.iter() {
-                    if matches!(component.filter_mode, ComponentFilterMode::Exclusive) {
+                    if matches!(component.file_match_mode, ComponentFileMatchMode::Remaining) {
                         using_exclusive_filter_mode = true;
                     }
 

--- a/crates/spk-schema/src/lib.rs
+++ b/crates/spk-schema/src/lib.rs
@@ -25,7 +25,7 @@ mod validation;
 
 // Re-export for macros
 pub use build_spec::{BuildSpec, Script};
-pub use component_spec::{ComponentFilterMode, ComponentSpec};
+pub use component_spec::{ComponentFileMatchMode, ComponentSpec};
 pub use component_spec_list::ComponentSpecList;
 pub use deprecate::{Deprecate, DeprecateMut};
 pub use embedded_packages_list::EmbeddedPackagesList;

--- a/crates/spk-schema/src/v0/spec.rs
+++ b/crates/spk-schema/src/v0/spec.rs
@@ -184,7 +184,7 @@ impl Spec {
             uses: Default::default(),
             requirements: Default::default(),
             embedded: Default::default(),
-            filter_mode: Default::default(),
+            file_match_mode: Default::default(),
         });
     }
 }

--- a/docs/ref/spec.md
+++ b/docs/ref/spec.md
@@ -141,21 +141,21 @@ A test spec defines one test script that should be run against the package to va
 
 The component spec defines a single component of a package. Components can be individually requested for a package. The `build` and `run` components are generated automatically unless they are defined explicitly for a package.
 
-| Field        | Type                                               | Description                                                                                                                                             |
-| ------------ | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| name         | _string_                                           | The name of this component                                                                                                                              |
-| files        | _List[string]_                                     | A list of patterns that identify which files belong to this component. Patterns follow the same syntax as gitignore files                               |
-| uses         | _List[string]_                                     | A list of other components from this package that this component uses, and are therefore also included whenever this component is included.             |
-| requirements | _List[[Request](#request)]_                        | A list of requirements that this component has. These requirements are **in addition to** any requirements defined at the `install.requirements` level. |
-| embedded     | _List[[Spec](#spec)]_                              | A list of packages that are embedded in this component                                                                                                  |
-| filter_mode  | _List[[ComponentFilterMode](#componentfiltermode)] | Control how the file filters are applied.                                                                                                               |             
+| Field            | Type                                                     | Description                                                                                                                                             |
+| ---------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| name             | _string_                                                 | The name of this component                                                                                                                              |
+| files            | _List[string]_                                           | A list of patterns that identify which files belong to this component. Patterns follow the same syntax as gitignore files                               |
+| uses             | _List[string]_                                           | A list of other components from this package that this component uses, and are therefore also included whenever this component is included.             |
+| requirements     | _List[[Request](#request)]_                              | A list of requirements that this component has. These requirements are **in addition to** any requirements defined at the `install.requirements` level. |
+| embedded         | _List[[Spec](#spec)]_                                    | A list of packages that are embedded in this component                                                                                                  |
+| file_match_mode  | _List[[ComponentFileMatchMode](#componentfilematchmode)] | Control how the file filters are applied.                                                                                                               |             
 
-#### ComponentFilterMode
+#### ComponentFileMatchMode
 
-| Value               | Description                                                                                             |
-| ------------------- | ------------------------------------------------------------------------------------------------------- |
-| Inclusive (default) | Matching files are always included                                                                      |
-| Exclusive           | Matching files are only included if they haven't already been matched by a previously defined component |
+| Value         | Description                                                                                             |
+| ------------- | ------------------------------------------------------------------------------------------------------- |
+| All (default) | Matching files are always included                                                                      |
+| Remaining     | Matching files are only included if they haven't already been matched by a previously defined component |
 
 ### EnvOp
 


### PR DESCRIPTION
In order to make it easier to divide files up into different components,
add a filter mode to enable "Exclusive" filtering, so a file is only added
to a component if it hasn't already been matched by an earlier component.

In this example pulled from the documentation:

    install:
      components:
      - name: run
        # only the compiled libraries are needed at runtime
        files: [lib/mylib*.so]
      - name: build
        # but everything else (debug symbols or static libraries, for example)
        # should be pulled in when building against this package
        files: ['*']
        filter_mode: Exclusive

As the "else" in "everything else" implies, the `build` component will
include all the files that were not previously matched by the `run`
component. Specifically, it will not contain any files matching the
pattern `lib/mylib*so`.

The default filter mode retains the original behavior.

Signed-off-by: J Robert Ray <jrray@jrray.org>