### PR TITLE
Change test additional requirements request order

### DIFF
--- a/crates/spk-cli/cmd-test/src/test/build.rs
+++ b/crates/spk-cli/cmd-test/src/test/build.rs
@@ -120,14 +120,14 @@ impl<'a> PackageBuildTester<'a> {
 
         let mut solver = Solver::default();
         solver.set_binary_only(true);
-        for request in self.additional_requirements.drain(..) {
-            solver.add_request(request)
-        }
         solver.update_options(self.options.clone());
         for repo in self.repos.iter().cloned() {
             solver.add_repository(repo);
         }
         solver.configure_for_build_environment(&self.recipe)?;
+        for request in self.additional_requirements.drain(..) {
+            solver.add_request(request)
+        }
         let mut runtime = solver.run();
         let solution = self.build_resolver.solve(&mut runtime).await;
         self.last_solve_graph = runtime.graph();

--- a/crates/spk-cli/cmd-test/src/test/install.rs
+++ b/crates/spk-cli/cmd-test/src/test/install.rs
@@ -92,9 +92,6 @@ impl<'a> PackageInstallTester<'a> {
 
         let mut solver = Solver::default();
         solver.set_binary_only(true);
-        for request in self.additional_requirements.drain(..) {
-            solver.add_request(request)
-        }
         solver.update_options(self.options.clone());
         for repo in self.repos.iter().cloned() {
             solver.add_repository(repo);
@@ -106,6 +103,9 @@ impl<'a> PackageInstallTester<'a> {
             .with_pin(None)
             .with_compat(None);
         solver.add_request(request.into());
+        for request in self.additional_requirements.drain(..) {
+            solver.add_request(request)
+        }
 
         let mut runtime = solver.run();
         let solution = self.env_resolver.solve(&mut runtime).await;

--- a/crates/spk-cli/cmd-test/src/test/sources.rs
+++ b/crates/spk-cli/cmd-test/src/test/sources.rs
@@ -96,9 +96,6 @@ impl<'a> PackageSourceTester<'a> {
 
         let mut solver = Solver::default();
         solver.set_binary_only(true);
-        for request in self.additional_requirements.drain(..) {
-            solver.add_request(request)
-        }
         solver.update_options(self.options.clone());
         for repo in self.repos.iter().cloned() {
             solver.add_repository(repo);
@@ -115,6 +112,10 @@ impl<'a> PackageSourceTester<'a> {
                 .with_pin(None)
                 .with_compat(None);
             solver.add_request(request.into());
+        }
+
+        for request in self.additional_requirements.drain(..) {
+            solver.add_request(request)
         }
 
         let mut runtime = solver.run();


### PR DESCRIPTION
Place any additional requirements added by tests to the end of the requests list, they can cause the solver to get lost if placed at the head of the list.

Signed-off-by: J Robert Ray <jrray@imageworks.com>