### PR TITLE
SPI job fix: adding rust nightly for formatting

### DIFF
--- a/.site/spi/.spdev.yaml
+++ b/.site/spi/.spdev.yaml
@@ -6,6 +6,8 @@ release_notes: |
 
 toolchain:
   - kind: Rust
+    additional_toolchains:
+      - nightly
   - kind: Shell
     variables:
       SENTRY_ENVIRONMENT: development

--- a/.site/spi/spk.spec
+++ b/.site/spi/spk.spec
@@ -13,7 +13,7 @@ BuildRequires: libcap-devel
 BuildRequires: openssl-devel
 BuildRequires: cmake3
 BuildRequires: make
-BuildRequires: spdev >= 0.27.8
+BuildRequires: spdev >= 0.28.2
 
 Requires: bash
 Obsoletes: spfs


### PR DESCRIPTION
Fix lint job failing because the nightly toolchain is not installed.
