### PR TITLE
Update spk's spfs repository caches to use DashMap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,6 +633,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+dependencies = [
+ "cfg-if",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1056,9 +1069,9 @@ checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hashbrown"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "607c8a29735385251a339424dd462993c0fed8fa09d378f259377df08c126022"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
 ]
@@ -1345,9 +1358,9 @@ checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "lock_api"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1566,9 +1579,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
 name = "oorandom"
@@ -3380,6 +3393,7 @@ version = "0.36.0"
 dependencies = [
  "async-trait",
  "colored",
+ "dashmap",
  "data-encoding",
  "enum_dispatch",
  "format_serde_error",

--- a/crates/spk-solve/src/io.rs
+++ b/crates/spk-solve/src/io.rs
@@ -896,8 +896,9 @@ impl DecisionFormatter {
                     error_freq.get_message(error.to_string())
                 );
             }
+            out.push('\n');
         } else {
-            out.push_str(" Solver hit no problems");
+            out.push_str(" Solver hit no problems\n");
         }
 
         out

--- a/crates/spk-storage/Cargo.toml
+++ b/crates/spk-storage/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.36.0"
 [dependencies]
 async-trait = "0.1"
 colored = "2.0"
+dashmap = "5.4.0"
 data-encoding = "2.3.0"
 enum_dispatch = "0.3.8"
 format_serde_error = {version = "0.3", default_features = false, features = ["serde_yaml", "colored"]}

--- a/crates/spk-storage/src/storage/repository.rs
+++ b/crates/spk-storage/src/storage/repository.rs
@@ -240,6 +240,11 @@ pub trait Repository: Storage + Sync {
 
     /// Return the set of builds for the given package name and version.
     async fn list_package_builds(&self, pkg: &Ident) -> Result<Vec<Ident>> {
+        // Note: This isn't cached. Neither get_concrete_package_builds() nor
+        // get_embedded_package_builds() are cached. But the underlying
+        // ls_tags() calls they both make are cached.
+        // TODO: could be worth caching, depending on the average
+        // builds per version.
         let concrete_builds = self.get_concrete_package_builds(pkg);
         let embedded_builds = self.get_embedded_package_builds(pkg);
         let (mut concrete, embedded) = tokio::try_join!(concrete_builds, embedded_builds)?;


### PR DESCRIPTION
This updates the internal caches used by spk's spfs repository to thread-safe caches by using `DashMap`s for the caches. It adds a dependency on `dashmap`, moves the caches into the spfs repository type, and adds a new cache for `list_build_components()` to improve repeated package component name lookups.

This forms the basis for the task/threads update to the impossible request checks in https://github.com/imageworks/spk/pull/506