### PR TITLE
Fix CompatRange::is_satisfied_by wrong Compatible case

### DIFF
--- a/crates/spk-schema/crates/foundation/src/version_range/mod.rs
+++ b/crates/spk-schema/crates/foundation/src/version_range/mod.rs
@@ -1048,6 +1048,11 @@ impl Ranged for CompatRange {
     where
         V: Versioned,
     {
+        // The version of the spec must be >= base to satisfy the request.
+        if *spec.version() < self.base {
+            return Compatibility::Incompatible(format!("version too low for {}", self.base));
+        }
+
         // XXX: Should this custom logic be in `is_applicable` instead?
         if let Some(r) = self.required {
             required = r;

--- a/crates/spk-schema/src/version_range_test.rs
+++ b/crates/spk-schema/src/version_range_test.rs
@@ -146,6 +146,8 @@ fn test_version_range_is_applicable(
 #[case("API:1.38.0", spec!({"pkg": "test/1.38.0+r.3/JRSXNRF4", "compat": "x.x.x+ab"}), true)]
 // newer post-release but `x.x.x+ab` compat with Binary compatibility
 #[case("Binary:1.38.0", spec!({"pkg": "test/1.38.0+r.3/JRSXNRF4", "compat": "x.x.x+ab"}), true)]
+// smaller numbers are not compatible
+#[case("Binary:5.12.2.1", spec!({"pkg": "test/5.12.2/JRSXNRF4", "compat": "x.x.ab"}), false)]
 fn test_version_range_is_satisfied(
     #[case] range: &str,
     #[case] spec: Spec,


### PR DESCRIPTION
This addresses #547 by getting to the root cause of the problem described there. A build that embeds a package at version 5.15.2 should not be picked if there is an existing `CompatRange` request for that package with `Binary:5.12.2.1`, because 5.15.2 < 5.12.2.1.

Signed-off-by: J Robert Ray <jrray@imageworks.com>