### PR TITLE
Fix for spfs-cli to correctly enable the 'sentry' feature

### DIFF
--- a/crates/spfs-cli/common/src/args.rs
+++ b/crates/spfs-cli/common/src/args.rs
@@ -252,7 +252,7 @@ pub fn capture_if_relevant(err: &spfs::Error) {
         spfs::Error::AmbiguousReference(_) => (),
         spfs::Error::NothingToCommit => (),
         _ => {
-            #[cfg(features = "sentry")]
+            #[cfg(feature = "sentry")]
             sentry::capture_error(err);
         }
     }


### PR DESCRIPTION
This fixes a typo in spfs-cli that prevented the sentry feature from being fully enabled for the spfs commands.
