### PR TITLE
Set sync policy when syncing tag in spk-launcher

### DIFF
--- a/crates/spk-launcher/src/main.rs
+++ b/crates/spk-launcher/src/main.rs
@@ -118,6 +118,7 @@ impl<'a> Dynamic<'a> {
             // Ensure tag is sync'd local because `render_into_directory` operates
             // out of the local repo.
             let syncer = spfs::Syncer::new(remote, local)
+                .with_policy(spfs::sync::SyncPolicy::LatestTags)
                 .with_reporter(spfs::sync::ConsoleSyncReporter::default());
             let r = syncer.sync_env(env_spec).await.context("sync reference")?;
             let env_spec = r.env;


### PR DESCRIPTION
The default policy will not pick up changes to an existing tag.

spk-launcher will resolve a tag on the remote to find its manifest digest, and then use that digest for the name of directory used to render out the manifest. But when it renders it resolves the local tag which might already exist but be older content. The `LatestTags` policy is needed to ensure the local content is the same as the remote content (subject to a race with the tag being modified between resolving it and syncing it).

Signed-off-by: J Robert Ray <jrray@imageworks.com>