### PR TITLE
Fix bug parsing envop with separator field

### DIFF
--- a/crates/spk-schema/src/environ.rs
+++ b/crates/spk-schema/src/environ.rs
@@ -92,7 +92,9 @@ impl<'de> Deserialize<'de> for EnvOp {
                                 Some((OpKind::Set, map.next_value::<Stringified>()?.0));
                         }
                         "value" => self.value = Some(map.next_value::<Stringified>()?.0),
-                        "separator" => self.value = Some(map.next_value::<Stringified>()?.0),
+                        "separator" => {
+                            self.separator = map.next_value::<Option<Stringified>>()?.map(|s| s.0)
+                        }
                         _ => {
                             // ignore any unknown field for the sake of
                             // forward compatibility
@@ -142,6 +144,7 @@ impl<'de> Deserialize<'de> for EnvOp {
 pub struct AppendEnv {
     append: String,
     value: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     separator: Option<String>,
 }
 
@@ -190,6 +193,7 @@ impl AppendEnv {
 pub struct PrependEnv {
     prepend: String,
     value: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     separator: Option<String>,
 }
 

--- a/crates/spk-schema/src/environ_test.rs
+++ b/crates/spk-schema/src/environ_test.rs
@@ -53,3 +53,15 @@ fn test_valid_tcsh(#[case] op: &str) {
     );
     assert!(out.status.success(), "failed to execute tcsh source");
 }
+
+#[rstest]
+#[case("{append: SPK_TEST_VAR, value: simple}")]
+#[case("{prepend: SPK_TEST_VAR, value: simple}")]
+#[case("{set: SPK_TEST_VAR, value: simple}")]
+#[case("{append: SPK_TEST_VAR, value: simple, separator: '+'}")]
+fn test_yaml_round_trip(#[case] op: &str) {
+    let op: EnvOp = serde_yaml::from_str(op).unwrap();
+    let yaml = serde_yaml::to_string(&op).unwrap();
+    let op2: EnvOp = serde_yaml::from_str(&yaml).unwrap();
+    assert_eq!(op2, op, "should be the same after sending through yaml");
+}


### PR DESCRIPTION
This was a small but sneaky bug where env ops were saved out with a `None` value for the separator which was then read back in and replaced the actually value of the env var. I added a test to check the round-trip and also stopped writing out the redundant `None` values altogether.