### PR TITLE
Remove redundant solve in binary build

### DIFF
--- a/crates/spk-build/src/build/binary.rs
+++ b/crates/spk-build/src/build/binary.rs
@@ -260,7 +260,6 @@ where
         self.environment
             .extend(solution.to_environment(Some(std::env::vars())));
 
-        let solution = self.resolve_build_environment(&all_options).await?;
         {
             // original options to be reapplied. It feels like this
             // shouldn't be necessary but I've not been able to isolate what


### PR DESCRIPTION
There are two calls to `resolve_build_environment` right after each other that don't have any effect on the outcome of tests, so I think they are a mistake.