### PR TITLE
Allow components to use undeclared default ones

### DIFF
--- a/crates/spk-schema/src/component_spec_list.rs
+++ b/crates/spk-schema/src/component_spec_list.rs
@@ -125,9 +125,11 @@ impl<'de> Deserialize<'de> for ComponentSpecList {
                 // present in all specs, using a default setup if needed
                 if !seen.contains(&Component::Build) {
                     components.push(ComponentSpec::default_build());
+                    seen.insert(Component::Build);
                 }
                 if !seen.contains(&Component::Run) {
                     components.push(ComponentSpec::default_run());
+                    seen.insert(Component::Run);
                 }
 
                 if seen.contains(&Component::All) {


### PR DESCRIPTION
We were not tracking the fact that default components were being added and so adding a `use: [build]` that referenced the default `build` component would fail despite it being injected and valid.