### PR TITLE
Update sentry configuration to use env! macro

### DIFF
--- a/.site/spi/.spdev.yaml
+++ b/.site/spi/.spdev.yaml
@@ -11,6 +11,7 @@ toolchain:
   - kind: Shell
     variables:
       SENTRY_ENVIRONMENT: development
+      SENTRY_DSN: http://4506b47108ac4b648fdf18a8d803f403@sentry.spimageworks.com/25
       PATH: $SPDEV_ENV/bin:$PATH
 
 components:

--- a/crates/spk-cli/common/src/env.rs
+++ b/crates/spk-cli/common/src/env.rs
@@ -65,12 +65,12 @@ pub fn configure_sentry() -> sentry::ClientInitGuard {
     // When using the sentry feature it is expected that the DSN
     // and other configuration is provided at *compile* time.
     let guard = sentry::init((
-        option_env!("SENTRY_DSN"),
+        env!("SENTRY_DSN"),
         sentry::ClientOptions {
             release: sentry::release_name!(),
-            environment: option_env!("SENTRY_ENVIRONMENT")
-                .map(ToString::to_string)
-                .map(std::borrow::Cow::Owned),
+            environment: Some(std::borrow::Cow::Owned(String::from(env!(
+                "SENTRY_ENVIRONMENT"
+            )))),
             before_send: Some(std::sync::Arc::new(|mut event| {
                 // Remove ansi color codes from the event message
                 if let Some(message) = event.message {


### PR DESCRIPTION
This replaces `option_env!` with `env!` for sentry configuration to ensure compile time errors will be thrown when the `sentry` feature is enabled but key environment variables have not been set.
