### PR TITLE
search bug-fixes for deleted and deprecated packages

### DIFF
--- a/crates/spk-cli/group4/src/cmd_search.rs
+++ b/crates/spk-cli/group4/src/cmd_search.rs
@@ -50,7 +50,7 @@ impl Run for Search {
 
                     let builds = repo.list_package_builds(&ident).await?;
                     if builds.is_empty() {
-                        // A version with no builds is treated as it
+                        // A version with no builds is treated as if
                         // it does not really exist. This can happen
                         // when a previously published package is
                         // deleted by 'spk rm'.
@@ -97,9 +97,8 @@ impl Run for Search {
 
                     exit = 0;
                     println!(
-                        "{repo_name: <width$} {}{}",
-                        ident.format_ident(),
-                        deprecation_status
+                        "{repo_name: <width$} {}{deprecation_status}",
+                        ident.format_ident()
                     );
                 }
             }


### PR DESCRIPTION
This fixes the `search` command so it filters out deleted and deprecated packages. It also adds a `--deprecated` flag to `search` to show deprecated packages in the output.

Example output before the change, where most of these packages are deleted and some are deprecated:
```sh
> spk search opencue
origin opencue/1.0.0
origin opencue/1.4.2
origin opencue/1.4.3
origin opencue/1.4.4
origin opencue/1.5.1
origin opencue/1.5.2
origin opencue/1.5.3
origin opencue/1.6.0
origin opencue/1.6.1
origin opencue/1.7.0
origin opencue/1.7.1
origin opencue/1.8.0
origin opencue/1.8.2
origin opencue/1.8.3
origin opencue/1.9.2
origin opencue/1.9.3
origin opencue/1.9.4
origin opencue/1.9.4+r.1
origin opencue/1.9.4+r.2
origin opencue/1.9.5
```
And after the change,:
```sh
> spk search opencue 
origin opencue/1.0.0
origin opencue/1.9.4+r.2

# And show to the deprecated ones
> spk search opencue --deprecated
origin opencue/1.0.0
origin opencue/1.7.1 DEPRECATED
origin opencue/1.8.3 DEPRECATED
origin opencue/1.9.3 DEPRECATED
origin opencue/1.9.4 DEPRECATED
origin opencue/1.9.4+r.1 DEPRECATED
origin opencue/1.9.4+r.2
```