### PR TITLE
Handle "object is not a blob" in spfs clean

### DIFF
--- a/crates/spfs/src/clean.rs
+++ b/crates/spfs/src/clean.rs
@@ -389,6 +389,10 @@ pub async fn get_all_unattached_payloads(
             Err(Error::UnknownObject(_)) => {
                 orphaned_payloads.insert(digest);
             }
+            Err(Error::ObjectNotABlob(..)) => {
+                tracing::warn!("Found payload with object that was not a blob: {digest}");
+                continue;
+            }
             Err(err) => return Err(err),
             Ok(_) => continue,
         }

--- a/crates/spfs/src/error.rs
+++ b/crates/spfs/src/error.rs
@@ -58,6 +58,8 @@ pub enum Error {
     InvalidReference(String),
     #[error("Repository does not support manifest rendering: {0:?}")]
     NoRenderStorage(url::Url),
+    #[error("Object is not a blob: {1}")]
+    ObjectNotABlob(crate::graph::Object, encoding::Digest),
 
     #[error(
         "Failed to open repository: {reason}, {}",

--- a/crates/spfs/src/storage/blob.rs
+++ b/crates/spfs/src/storage/blob.rs
@@ -7,7 +7,7 @@ use std::pin::Pin;
 use futures::Stream;
 use tokio_stream::StreamExt;
 
-use crate::{encoding, graph, Result};
+use crate::{encoding, graph, Error, Result};
 
 pub type BlobStreamItem = Result<(encoding::Digest, graph::Blob)>;
 
@@ -37,7 +37,7 @@ pub trait BlobStorage: graph::Database + Sync + Send {
         match self.read_object(digest).await {
             Err(err) => Err(err),
             Ok(Object::Blob(blob)) => Ok(blob),
-            Ok(_) => Err(format!("Object is not a blob: {:?}", digest).into()),
+            Ok(object) => Err(Error::ObjectNotABlob(object, digest)),
         }
     }
 


### PR DESCRIPTION
Work around `spfs clean` failing without doing any cleaning if it encounters a payload digest that resolves to a non-Blob. On my workstation it was encountering an empty manifest object. The payload is an 8-byte file of all nulls.

Signed-off-by: J Robert Ray <jrray@imageworks.com>