### PR TITLE
Track flattened layers in runtime

### DIFF
--- a/crates/spfs-cli/cmd-enter/src/cmd_enter.rs
+++ b/crates/spfs-cli/cmd-enter/src/cmd_enter.rs
@@ -77,9 +77,9 @@ impl CmdEnter {
     }
 
     pub async fn run_async(&mut self, config: &spfs::Config) -> spfs::Result<i32> {
-        let runtime = self.load_runtime(config).await?;
+        let mut runtime = self.load_runtime(config).await?;
         if self.remount {
-            spfs::reinitialize_runtime(&runtime).await?;
+            spfs::reinitialize_runtime(&mut runtime).await?;
             Ok(0)
         } else {
             let mut terminate = signal(SignalKind::terminate())
@@ -88,7 +88,7 @@ impl CmdEnter {
                 .map_err(|err| Error::process_spawn_error("signal()".into(), err, None))?;
             let mut quit = signal(SignalKind::quit())
                 .map_err(|err| Error::process_spawn_error("signal()".into(), err, None))?;
-            let owned = spfs::runtime::OwnedRuntime::upgrade_as_owner(runtime).await?;
+            let mut owned = spfs::runtime::OwnedRuntime::upgrade_as_owner(runtime).await?;
 
             // At this point, our pid is owned by root and has not moved into
             // the proper mount namespace; spfs-monitor will not be able to
@@ -111,7 +111,7 @@ impl CmdEnter {
             };
 
             tracing::debug!("initializing runtime");
-            spfs::initialize_runtime(&owned).await?;
+            spfs::initialize_runtime(&mut owned).await?;
 
             // Now we have dropped privileges and are running as the invoking
             // user (same uid as spfs-monitor) and have entered the mount

--- a/crates/spfs/src/resolve_test.rs
+++ b/crates/spfs/src/resolve_test.rs
@@ -68,7 +68,7 @@ async fn test_auto_merge_layers(tmpdir: tempfile::TempDir) {
         runtime.push_digest(layer.digest().unwrap());
     }
 
-    let dirs = crate::resolve::resolve_overlay_dirs(&runtime, &repo)
+    let dirs = crate::resolve::resolve_overlay_dirs(&mut runtime, &repo)
         .await
         .expect("resolve overlay dirs successfully");
 

--- a/crates/spfs/src/runtime/storage.rs
+++ b/crates/spfs/src/runtime/storage.rs
@@ -3,6 +3,7 @@
 // https://github.com/imageworks/spk
 
 ///! Definition and persistent storage of runtimes.
+use std::collections::HashSet;
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
@@ -49,6 +50,10 @@ impl Default for Author {
 pub struct Status {
     /// The set of layers that are being used in this runtime
     pub stack: Vec<encoding::Digest>,
+    /// Additional layers that were created automatically due to the stack
+    /// being too large.
+    #[serde(default, skip_serializing_if = "HashSet::is_empty")]
+    pub(crate) flattened_layers: HashSet<encoding::Digest>,
     /// Whether or not this runtime is editable
     ///
     /// An editable runtime is mounted with working directories
@@ -593,7 +598,9 @@ impl Storage {
     pub async fn save_runtime(&self, rt: &Runtime) -> Result<()> {
         let payload_tag = runtime_tag(RuntimeDataType::Payload, rt.name())?;
         let meta_tag = runtime_tag(RuntimeDataType::Metadata, rt.name())?;
-        let platform: graph::Object = graph::Platform::new(&mut rt.status.stack.iter())?.into();
+        let mut platform = graph::Platform::new(&mut rt.status.stack.iter())?;
+        platform.stack.extend(rt.status.flattened_layers.iter());
+        let platform: graph::Object = platform.into();
         let platform_digest = platform.digest()?;
         let config_data = serde_json::to_string(&rt.data)?;
         let (_, config_digest) = tokio::try_join!(

--- a/crates/spfs/src/status.rs
+++ b/crates/spfs/src/status.rs
@@ -78,12 +78,10 @@ pub async fn active_runtime() -> Result<runtime::Runtime> {
 }
 
 /// Reinitialize the current spfs runtime as rt (in case of runtime config changes).
-pub async fn reinitialize_runtime(rt: &runtime::Runtime) -> Result<()> {
+pub async fn reinitialize_runtime(rt: &mut runtime::Runtime) -> Result<()> {
+    let dirs = resolve_and_render_overlay_dirs(rt).await?;
     tracing::debug!("computing runtime manifest");
-    let (dirs, manifest) = tokio::try_join!(
-        resolve_and_render_overlay_dirs(rt),
-        compute_runtime_manifest(rt)
-    )?;
+    let manifest = compute_runtime_manifest(rt).await?;
 
     let original = env::become_root()?;
     env::ensure_mounts_already_exist()?;
@@ -96,12 +94,10 @@ pub async fn reinitialize_runtime(rt: &runtime::Runtime) -> Result<()> {
 }
 
 /// Initialize the current runtime as rt.
-pub async fn initialize_runtime(rt: &runtime::Runtime) -> Result<()> {
+pub async fn initialize_runtime(rt: &mut runtime::Runtime) -> Result<()> {
+    let dirs = resolve_and_render_overlay_dirs(rt).await?;
     tracing::debug!("computing runtime manifest");
-    let (dirs, manifest) = tokio::try_join!(
-        resolve_and_render_overlay_dirs(rt),
-        compute_runtime_manifest(rt)
-    )?;
+    let manifest = compute_runtime_manifest(rt).await?;
     env::enter_mount_namespace()?;
     let original = env::become_root()?;
     env::privatize_existing_mounts()?;


### PR DESCRIPTION
When resolving overlay dirs, the length of the runtime layer stack may be too large and requires merging layers together. These merged layers are created on the fly and pushed into storage as new manifests, and then rendered out. If there is no hard reference to these manifests, then `spfs clean` will delete the render, even if it is still in use.

Now, `resolve_overlay_dirs` will populate a new field in `Runtime` that contains a list of these manufactured manifest layers, and these get saved into the runtime storage.

Fixes #577