### PR TITLE
Add post rule to rpm to mkdir /spfs

### DIFF
--- a/.site/spi/spk.spec
+++ b/.site/spi/spk.spec
@@ -57,6 +57,10 @@ cp "$RELEASE_DIR"/spk %{buildroot}/opt/spk.dist/
 /usr/local/bin/spk-launcher
 /opt/spk.dist/
 
+%post
+mkdir -p /spfs
+chmod 777 /spfs
+
 %preun
 [ -e /usr/local/bin/spk ] && unlink /usr/local/bin/spk
 


### PR DESCRIPTION
Missing from SPI's version of spk.spec.

Signed-off-by: J Robert Ray <jrray@imageworks.com>