### PR TITLE
Fix zombie spfs-monitor caused by lost pid events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2833,6 +2833,7 @@ dependencies = [
  "nix 0.26.2",
  "nonempty",
  "once_cell",
+ "pin-project-lite",
  "procfs",
  "prost",
  "protobuf-src",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ lazy_static = "1.4"
 libc = "0.2.80"
 nix = "0.26.2"
 once_cell = "1.8"
+pin-project-lite = "0.2.0"
 procfs = "0.13.2"
 sentry = { version = "0.27.0" }
 sentry-anyhow = { version = "0.27.0" }

--- a/THIRD_PARTY.md
+++ b/THIRD_PARTY.md
@@ -27,4 +27,38 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 -------------------------------------------------------------------------
 
+The MIT License (MIT)
+
+SPDX-License-Identifier: MIT
+
+* [tokio-stream](https://github.com/tokio-rs/tokio/blob/master/tokio-stream/LICENSE)
+
+Copyright (c) 2023 Tokio Contributors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+-------------------------------------------------------------------------
+
 If we have left anything out, it is unintentional. Please let us know.

--- a/crates/spfs/Cargo.toml
+++ b/crates/spfs/Cargo.toml
@@ -43,6 +43,7 @@ libc = { workspace = true }
 nix = { workspace = true }
 nonempty = "0.8.1"
 once_cell = { workspace = true }
+pin-project-lite = { workspace = true }
 procfs = { workspace = true }
 prost = "0.11"
 rand = "0.8.5"

--- a/crates/spfs/src/env.rs
+++ b/crates/spfs/src/env.rs
@@ -17,6 +17,7 @@ use tokio_stream::wrappers::{IntervalStream, UnboundedReceiverStream};
 use tokio_stream::StreamExt;
 
 use super::runtime;
+use crate::repeating_timeout::RepeatingTimeout;
 use crate::{Error, Result};
 
 const PROC_DIR: &str = "/proc";
@@ -392,7 +393,7 @@ pub async fn wait_for_empty_runtime(rt: &runtime::Runtime) -> Result<()> {
 
     // Add a timeout to be able to detect when no relevant pid events are
     // arriving for a period of time.
-    let events_stream = events_stream.timeout(tokio::time::Duration::from_secs(60));
+    let events_stream = RepeatingTimeout::new(events_stream, tokio::time::Duration::from_secs(60));
     tokio::pin!(events_stream);
 
     async fn repair_tracked_processes<S>(tracked_processes: &Arc<DashSet<u32, S>>, ns: &Path)

--- a/crates/spfs/src/lib.rs
+++ b/crates/spfs/src/lib.rs
@@ -25,6 +25,7 @@ pub mod io;
 pub mod prelude;
 pub mod proto;
 mod prune;
+mod repeating_timeout;
 mod resolve;
 pub mod runtime;
 #[cfg(feature = "server")]

--- a/crates/spfs/src/repeating_timeout.rs
+++ b/crates/spfs/src/repeating_timeout.rs
@@ -1,0 +1,103 @@
+// Copyright (c) 2023 Tokio Contributors
+
+// Derived from <https://docs.rs/tokio-stream/latest/tokio_stream/trait.StreamExt.html#method.timeout>
+// but modified so timeouts can repeat even if there are no new events on the
+// wrapped stream. Licensed under the MIT license. Any additional changes are:
+// Copyright (c) Sony Pictures Imageworks, et al.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/imageworks/spk
+
+use core::pin::Pin;
+use core::task::{Context, Poll};
+use std::fmt;
+use std::time::Duration;
+
+use futures::stream::Fuse;
+use futures::{ready, Future, Stream, StreamExt};
+use pin_project_lite::pin_project;
+use tokio::time::{Instant, Sleep};
+
+pin_project! {
+    #[must_use = "streams do nothing unless polled"]
+    #[derive(Debug)]
+    pub struct RepeatingTimeout<S> {
+        #[pin]
+        stream: Fuse<S>,
+        #[pin]
+        deadline: Sleep,
+        duration: Duration,
+    }
+}
+
+/// Error returned by `RepeatingTimeout`.
+#[derive(Debug, PartialEq)]
+pub struct Elapsed(());
+
+impl<S: Stream> RepeatingTimeout<S> {
+    pub(super) fn new(stream: S, duration: Duration) -> Self {
+        let next = Instant::now() + duration;
+        let deadline = tokio::time::sleep_until(next);
+
+        RepeatingTimeout {
+            stream: stream.fuse(),
+            deadline,
+            duration,
+        }
+    }
+}
+
+impl<S: Stream> Stream for RepeatingTimeout<S> {
+    type Item = Result<S::Item, Elapsed>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut me = self.project();
+
+        match me.stream.poll_next(cx) {
+            Poll::Ready(v) => {
+                if v.is_some() {
+                    let next = Instant::now() + *me.duration;
+                    me.deadline.reset(next);
+                }
+                return Poll::Ready(v.map(Ok));
+            }
+            Poll::Pending => {}
+        };
+
+        ready!(me.deadline.as_mut().poll(cx));
+
+        let next = Instant::now() + *me.duration;
+        me.deadline.reset(next);
+
+        Poll::Ready(Some(Err(Elapsed::new())))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (lower, _) = self.stream.size_hint();
+
+        // The timeout stream may insert an infinite number of timeouts.
+
+        (lower, None)
+    }
+}
+
+// ===== impl Elapsed =====
+
+impl Elapsed {
+    pub(crate) fn new() -> Self {
+        Elapsed(())
+    }
+}
+
+impl fmt::Display for Elapsed {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        "deadline has elapsed".fmt(fmt)
+    }
+}
+
+impl std::error::Error for Elapsed {}
+
+impl From<Elapsed> for std::io::Error {
+    fn from(_err: Elapsed) -> std::io::Error {
+        std::io::ErrorKind::TimedOut.into()
+    }
+}


### PR DESCRIPTION
Don't trust that cnproc delivers every pid event. There are two ways that
lost events can cause problems:

1. a process we're tracking has exited but we don't know; spfs-monitor will
   continue running indefinitely
2. we missed a process creation event and a process exists but we don't
   know; the runtime might be deleted prematurely

This still uses cnproc for efficient push notifications about pid events,
but checks the process tree using the existing fallback mechanism that is
there for cases when cnproc is disabled.

Every minute, if there have been no pid events, refresh the set manually
via the proc filesystem.

When we think there are no processes remaining by watching events, verify
that is true before actually quitting.

Related to https://github.com/imageworks/spk/issues/581.