### PR TITLE
Simplify Solution Type

### DIFF
--- a/crates/spk-build/src/build/binary.rs
+++ b/crates/spk-build/src/build/binary.rs
@@ -272,7 +272,7 @@ where
             // original options to be reapplied. It feels like this
             // shouldn't be necessary but I've not been able to isolate what
             // goes wrong when this is removed.
-            let mut opts = solution.options();
+            let mut opts = solution.options().clone();
             std::mem::swap(&mut opts, &mut all_options);
             all_options.extend(opts);
         }

--- a/crates/spk-build/src/build/binary_test.rs
+++ b/crates/spk-build/src/build/binary_test.rs
@@ -232,7 +232,7 @@ async fn test_build_package_pinning() {
         .unwrap();
 
     let spec = rt.tmprepo.read_package(spec.ident()).await.unwrap();
-    let req = spec.runtime_requirements().get(0).unwrap();
+    let req = spec.runtime_requirements().first().unwrap().clone();
     match req {
         Request::Pkg(req) => {
             assert_eq!(&req.pkg.to_string(), "dep/~1.0");

--- a/crates/spk-cli/cmd-install/src/cmd_install.rs
+++ b/crates/spk-cli/cmd-install/src/cmd_install.rs
@@ -54,7 +54,7 @@ impl Run for Install {
             .await?;
 
         for solved in env.items() {
-            solver.add_request(solved.request.into());
+            solver.add_request(solved.request.clone().into());
         }
         for request in requests {
             solver.add_request(request);

--- a/crates/spk-cli/cmd-test/src/test/build.rs
+++ b/crates/spk-cli/cmd-test/src/test/build.rs
@@ -138,7 +138,7 @@ impl<'a> PackageBuildTester<'a> {
         rt.save_state_to_storage().await?;
         spfs::remount_runtime(&rt).await?;
 
-        self.options.extend(solution.options());
+        self.options.extend(solution.options().clone());
         let _spec = self
             .recipe
             .generate_binary_build(&self.options, &solution)?;

--- a/crates/spk-cli/common/src/env.rs
+++ b/crates/spk-cli/common/src/env.rs
@@ -27,7 +27,7 @@ pub async fn current_env() -> crate::Result<Solution> {
     }
 
     let repo = Arc::new(storage::RepositoryHandle::Runtime(Default::default()));
-    let mut solution = Solution::new(None);
+    let mut solution = Solution::default();
     for name in repo.list_packages().await? {
         for version in repo.list_package_versions(&name).await?.iter() {
             let pkg = parse_ident(format!("{name}/{version}"))?;
@@ -49,7 +49,7 @@ pub async fn current_env() -> crate::Result<Solution> {
                 request.prerelease_policy = PreReleasePolicy::IncludeAll;
                 let repo = repo.clone();
                 solution.add(
-                    &request,
+                    request,
                     spec,
                     PackageSource::Repository { repo, components },
                 );

--- a/crates/spk-cli/group1/src/cmd_bake.rs
+++ b/crates/spk-cli/group1/src/cmd_bake.rs
@@ -174,7 +174,7 @@ impl Bake {
         // Get the layer(s) for the packages from their source repos
         let mut layers_to_packages: HashMap<Digest, (String, String)> = HashMap::new();
         for resolved in items {
-            let spfs_layers = match self.get_spfs_component_layers(&resolved) {
+            let spfs_layers = match self.get_spfs_component_layers(resolved) {
                 Ok(layers) => layers,
                 Err(Error::SkipEmbedded) => continue,
                 Err(e) => return Err(e.into()),
@@ -262,12 +262,12 @@ impl Bake {
         // the solve. Need to reverse it to match up with the spfs
         // layering order, which is the order they would come out of
         // an active runtime.
-        let mut items = solution.items();
+        let mut items = solution.items().collect::<Vec<_>>();
         items.reverse();
 
         let mut stack: Vec<BakeLayer> = Vec::with_capacity(items.len());
         for resolved in items {
-            let spfs_layers = match self.get_spfs_component_layers(&resolved) {
+            let spfs_layers = match self.get_spfs_component_layers(resolved) {
                 Ok(layers) => layers,
                 Err(Error::SkipEmbedded) => continue,
                 Err(e) => return Err(e.into()),

--- a/crates/spk-exec/src/exec.rs
+++ b/crates/spk-exec/src/exec.rs
@@ -17,7 +17,7 @@ pub async fn resolve_runtime_layers(solution: &Solution) -> Result<Vec<Digest>> 
     let mut stack = Vec::new();
     let mut to_sync = Vec::new();
     for resolved in solution.items() {
-        let (repo, components) = match resolved.source {
+        let (repo, components) = match &resolved.source {
             PackageSource::Repository { repo, components } => (repo, components),
             PackageSource::Embedded => continue,
             PackageSource::BuildFromSource { recipe } => {
@@ -25,7 +25,7 @@ pub async fn resolve_runtime_layers(solution: &Solution) -> Result<Vec<Digest>> 
                 // to be built with specific options because such a
                 // build doesn't exist in a repo.
                 let spec_options = recipe
-                    .resolve_options(&solution.options())
+                    .resolve_options(solution.options())
                     .unwrap_or_default();
                 return Err(Error::String(format!(
                     "Solution includes package that needs building from source: {} with these options: {}",
@@ -42,7 +42,7 @@ pub async fn resolve_runtime_layers(solution: &Solution) -> Result<Vec<Digest>> 
             );
             continue;
         }
-        let mut desired_components = resolved.request.pkg.components;
+        let mut desired_components = resolved.request.pkg.components.clone();
         if desired_components.is_empty() {
             desired_components.insert(Component::All);
         }

--- a/crates/spk-solve/crates/graph/src/graph.rs
+++ b/crates/spk-solve/crates/graph/src/graph.rs
@@ -1113,12 +1113,12 @@ impl State {
     }
 
     pub fn as_solution(&self) -> Result<Solution> {
-        let mut solution = Solution::new(Some((&self.options).into()));
+        let mut solution = Solution::new((&self.options).into());
         for (spec, source) in self.packages.values() {
             let req = self
                 .get_merged_request(spec.name())
                 .map_err(GraphError::RequestError)?;
-            solution.add(&req, Arc::clone(spec), source.clone());
+            solution.add(req, Arc::clone(spec), source.clone());
         }
         Ok(solution)
     }

--- a/crates/spk-solve/crates/solution/src/solution.rs
+++ b/crates/spk-solve/crates/solution/src/solution.rs
@@ -13,7 +13,6 @@ use spk_schema::foundation::format::{
     FormatSolution,
 };
 use spk_schema::foundation::ident_component::Component;
-use spk_schema::foundation::name::PkgNameBuf;
 use spk_schema::foundation::option_map::OptionMap;
 use spk_schema::foundation::version::VERSION_SEP;
 use spk_schema::ident::{PkgRequest, RequestedBy};
@@ -83,6 +82,7 @@ impl PartialOrd for PackageSource {
 }
 
 /// Represents a package request that has been resolved.
+#[derive(Clone, Debug)]
 pub struct SolvedRequest {
     pub request: PkgRequest,
     pub spec: Arc<Spec>,
@@ -99,52 +99,29 @@ impl SolvedRequest {
 #[derive(Clone, Debug, Default)]
 pub struct Solution {
     options: OptionMap,
-    resolved: HashMap<PkgRequest, (Arc<Spec>, PackageSource)>,
-    by_name: HashMap<PkgNameBuf, Arc<Spec>>,
-    insertion_order: HashMap<PkgRequest, usize>,
+    resolved: Vec<SolvedRequest>,
 }
 
 impl Solution {
-    pub fn new(options: Option<OptionMap>) -> Self {
+    pub fn new(options: OptionMap) -> Self {
         Self {
-            options: options.unwrap_or_default(),
-            resolved: HashMap::default(),
-            by_name: HashMap::default(),
-            insertion_order: HashMap::default(),
+            options,
+            resolved: Default::default(),
         }
     }
 
-    pub fn items(&self) -> Vec<SolvedRequest> {
-        let mut items = self
-            .resolved
-            .clone()
-            .into_iter()
-            .map(|(request, (spec, source))| SolvedRequest {
-                request,
-                spec,
-                source,
-            })
-            .collect::<Vec<_>>();
-        // Test suite expects these items to be returned in original insertion order.
-        items.sort_by_key(|sr| self.insertion_order.get(&sr.request).unwrap());
-        items
+    pub fn items(&self) -> std::slice::Iter<'_, SolvedRequest> {
+        self.resolved.iter()
     }
 
-    pub fn get<S: AsRef<str>>(&self, name: S) -> Option<SolvedRequest> {
-        for (request, (spec, source)) in &self.resolved {
-            if request.pkg.name.as_str() == name.as_ref() {
-                return Some(SolvedRequest {
-                    request: request.clone(),
-                    spec: spec.clone(),
-                    source: source.clone(),
-                });
-            }
-        }
-        None
+    pub fn get<S: AsRef<str>>(&self, name: S) -> Option<&SolvedRequest> {
+        self.resolved
+            .iter()
+            .find(|r| r.request.pkg.name.as_str() == name.as_ref())
     }
 
-    pub fn options(&self) -> OptionMap {
-        self.options.clone()
+    pub fn options(&self) -> &OptionMap {
+        &self.options
     }
 
     /// The number of packages in this solution
@@ -160,24 +137,27 @@ impl Solution {
     }
 
     /// Add a resolved request to this solution
-    pub fn add(&mut self, request: &PkgRequest, package: Arc<Spec>, source: PackageSource) {
-        if self
-            .resolved
-            .insert(request.clone(), (package.clone(), source))
-            .is_none()
-        {
-            self.insertion_order
-                .insert(request.clone(), self.insertion_order.len());
+    pub fn add(&mut self, request: PkgRequest, spec: Arc<Spec>, source: PackageSource) {
+        let existing = self.resolved.iter_mut().find(|r| r.request == request);
+        let new = SolvedRequest {
+            request,
+            spec,
+            source,
+        };
+        match existing {
+            Some(existing) => {
+                *existing = new;
+            }
+            None => self.resolved.push(new),
         }
-        self.by_name.insert(request.pkg.name.clone(), package);
     }
 
     /// Return the set of repositories in this solution.
     pub fn repositories(&self) -> Vec<Arc<RepositoryHandle>> {
         let mut seen = HashSet::new();
         let mut repos = Vec::new();
-        for (_, source) in self.resolved.values() {
-            if let PackageSource::Repository { repo, .. } = source {
+        for resolved in self.resolved.iter() {
+            if let PackageSource::Repository { repo, .. } = &resolved.source {
                 let addr = repo.address();
                 if seen.contains(addr) {
                     continue;
@@ -204,7 +184,8 @@ impl Solution {
         out.retain(|name, _| !name.starts_with("SPK_PKG_"));
 
         out.insert("SPK_ACTIVE_PREFIX".to_owned(), "/spfs".to_owned());
-        for (_request, (spec, _source)) in self.resolved.iter() {
+        for resolved in self.resolved.iter() {
+            let spec = &resolved.spec;
             out.insert(format!("SPK_PKG_{}", spec.name()), spec.ident().to_string());
             out.insert(
                 format!("SPK_PKG_{}_VERSION", spec.name()),
@@ -248,8 +229,7 @@ impl BuildEnv for Solution {
     fn build_env(&self) -> Vec<Self::Package> {
         self.resolved
             .iter()
-            .map(|(_, (spec, _))| spec)
-            .cloned()
+            .map(|resolved| Arc::clone(&resolved.spec))
             .collect::<Vec<_>>()
     }
 }
@@ -268,7 +248,7 @@ impl FormatSolution for Solution {
             let mut installed =
                 PkgRequest::from_ident(req.spec.ident().to_any(), RequestedBy::DoesNotMatter);
 
-            if let PackageSource::Repository { components, .. } = req.source {
+            if let PackageSource::Repository { components, .. } = &req.source {
                 let mut installed_components = req.request.pkg.components.clone();
                 if installed_components.remove(&Component::All) {
                     installed_components.extend(components.keys().cloned());

--- a/crates/spk-solve/src/macros.rs
+++ b/crates/spk-solve/src/macros.rs
@@ -123,11 +123,11 @@ macro_rules! make_build_and_components {
                 let recipe = spec.clone().map_ident(|i| i.into_base());
                 let mut build_opts = $opts.clone();
                 #[allow(unused_mut)]
-                let mut solution = $crate::Solution::new(Some(build_opts.clone()));
+                let mut solution = $crate::Solution::new(build_opts.clone());
                 $(
                 let dep = Arc::new($dep.clone());
                 solution.add(
-                    &$crate::PkgRequest::from_ident(
+                    $crate::PkgRequest::from_ident(
                         $dep.ident().to_any(),
                         $crate::RequestedBy::SpkInternalTest,
                     ),

--- a/crates/spk-solve/src/solver_test.rs
+++ b/crates/spk-solve/src/solver_test.rs
@@ -77,7 +77,7 @@ macro_rules! assert_resolved {
         let pkg = $solution
             .get($pkg)
             .expect("expected package to be in solution");
-        match pkg.source {
+        match &pkg.source {
             PackageSource::Repository{components, ..} => {
                 resolved.extend(components.keys().map(ToString::to_string));
             }
@@ -670,7 +670,7 @@ async fn test_solver_option_injection(mut solver: Solver) {
 
     let solution = run_and_print_resolve_for_tests(&solver).await.unwrap();
 
-    let mut opts = solution.options();
+    let mut opts = solution.options().clone();
     assert_eq!(opts.remove(opt_name!("vnp3")), Some("~2.0.0".to_string()));
     assert_eq!(
         opts.remove(opt_name!("vnp3.python")),
@@ -1457,7 +1457,13 @@ async fn test_solver_components(mut solver: Solver) {
 
     let solution = run_and_print_resolve_for_tests(&solver).await.unwrap();
 
-    let resolved = solution.get("python").unwrap().request.pkg.components;
+    let resolved = solution
+        .get("python")
+        .unwrap()
+        .request
+        .pkg
+        .components
+        .clone();
     let expected = ["interpreter", "doc", "lib", "run"]
         .iter()
         .map(|c| Component::parse(c).map_err(|err| err.into()))
@@ -1504,7 +1510,13 @@ async fn test_solver_components_when_no_components_requested(mut solver: Solver)
 
     let solution = run_and_print_resolve_for_tests(&solver).await.unwrap();
 
-    let resolved = solution.get("python").unwrap().request.pkg.components;
+    let resolved = solution
+        .get("python")
+        .unwrap()
+        .request
+        .pkg
+        .components
+        .clone();
     let expected = [Component::default_for_run()]
         .iter()
         .map(|c| Component::parse(c).map_err(|err| err.into()))


### PR DESCRIPTION
There were a number of inefficiencies and weird ownership issues in the solution that created unnecessary cloning and duplication of data. The primary change here is to store `SolvedRequets` directly in the solution and return references to the data from `Solution::items` instead of copying the data.

Depends on #530 