### PR TITLE
Add test for large, contentious sync operations

### DIFF
--- a/crates/spfs/src/graph/manifest.rs
+++ b/crates/spfs/src/graph/manifest.rs
@@ -30,6 +30,12 @@ impl From<&tracking::Manifest> for Manifest {
     }
 }
 
+impl From<tracking::Manifest> for Manifest {
+    fn from(source: tracking::Manifest) -> Self {
+        Self::from(source.root())
+    }
+}
+
 impl From<&tracking::Entry> for Manifest {
     fn from(source: &tracking::Entry) -> Self {
         let mut manifest = Self::default();


### PR DESCRIPTION
@paxsonsa I can't generate any errors locally, but maybe try running this on an NFS path (hardcoded tmpdir, perhaps...)

```sh
cargo test -p spfs --features=server -- sync_test::test_sync_with_payloads
```