### PR TITLE
Return missing object as UnknownObject during clean

### DIFF
--- a/crates/spfs/src/storage/fs/database.rs
+++ b/crates/spfs/src/storage/fs/database.rs
@@ -135,7 +135,10 @@ impl graph::Database for super::FSRepository {
 
         let metadata = tokio::fs::symlink_metadata(&filepath)
             .await
-            .map_err(|err| Error::StorageReadError(filepath.clone(), err))?;
+            .map_err(|err| match err.kind() {
+                std::io::ErrorKind::NotFound => Error::UnknownObject(digest),
+                _ => Error::StorageReadError(filepath.clone(), err),
+            })?;
 
         let mtime = metadata
             .modified()


### PR DESCRIPTION
This allows clean to finish without error and remove orphaned payloads, in the case where a payload file exists but the corresponding blob object is missing.

Signed-off-by: J Robert Ray <jrray@imageworks.com>