### PR TITLE
Add `spfs runtime prune`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2799,12 +2799,14 @@ dependencies = [
 name = "spfs-cli-main"
 version = "0.34.6"
 dependencies = [
+ "chrono",
  "clap 3.2.11",
  "colored",
  "futures",
  "hyper",
  "itertools",
  "nix",
+ "procfs",
  "relative-path",
  "serde_json",
  "spfs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,7 @@ members = [
     "crates/spk-storage",
     "crates/spk",
 ]
+
+[workspace.dependencies]
+chrono = { version = "0.4.19", features = ["serde"] }
+procfs = "0.13.2"

--- a/crates/spfs-cli/cmd-clean/Cargo.toml
+++ b/crates/spfs-cli/cmd-clean/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/cmd_clean.rs"
 sentry = ["spfs-cli-common/sentry"]
 
 [dependencies]
-chrono = { version = "0.4.19", features = ["serde"] }
+chrono = { workspace = true }
 clap = { version = "3.2", features = ["derive", "env"] }
 colored = "2.0"
 question = "0.2.2"

--- a/crates/spfs-cli/main/Cargo.toml
+++ b/crates/spfs-cli/main/Cargo.toml
@@ -15,11 +15,13 @@ server = ["spfs/server", "dep:hyper", "dep:tonic", "dep:url"]
 
 [dependencies]
 clap = { version = "3.2", features = ["derive", "env"] }
+chrono = { workspace = true }
 colored = "2.0"
 futures = "0.3.9"
 hyper = { version = "0.14.16", optional = true }
 itertools = "0.10.3"
 nix = "0.24.1"
+procfs = { workspace = true }
 relative-path = "1.3"
 serde_json = "1.0"
 spfs = { path = "../../spfs" }

--- a/crates/spfs-cli/main/src/bin.rs
+++ b/crates/spfs-cli/main/src/bin.rs
@@ -25,6 +25,7 @@ mod cmd_run;
 mod cmd_runtime;
 mod cmd_runtime_info;
 mod cmd_runtime_list;
+mod cmd_runtime_prune;
 mod cmd_runtime_remove;
 mod cmd_search;
 #[cfg(feature = "server")]

--- a/crates/spfs-cli/main/src/cmd_runtime.rs
+++ b/crates/spfs-cli/main/src/cmd_runtime.rs
@@ -22,6 +22,7 @@ impl CmdRuntime {
 pub enum Command {
     Info(super::cmd_runtime_info::CmdRuntimeInfo),
     List(super::cmd_runtime_list::CmdRuntimeList),
+    Prune(super::cmd_runtime_prune::CmdRuntimePrune),
     Remove(super::cmd_runtime_remove::CmdRuntimeRemove),
 }
 
@@ -30,6 +31,7 @@ impl Command {
         match self {
             Self::Info(cmd) => cmd.run(config).await,
             Self::List(cmd) => cmd.run(config).await,
+            Self::Prune(cmd) => cmd.run(config).await,
             Self::Remove(cmd) => cmd.run(config).await,
         }
     }

--- a/crates/spfs-cli/main/src/cmd_runtime_prune.rs
+++ b/crates/spfs-cli/main/src/cmd_runtime_prune.rs
@@ -1,0 +1,151 @@
+// Copyright (c) Sony Pictures Imageworks, et al.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/imageworks/spk
+
+use chrono::{Duration, Utc};
+use clap::Args;
+use tokio_stream::StreamExt;
+
+/// List runtime information from the repository
+#[derive(Debug, Args)]
+#[clap(visible_alias = "prune")]
+pub struct CmdRuntimePrune {
+    /// Prune a runtime in a remote or alternate repository
+    #[clap(short, long)]
+    remote: Option<String>,
+
+    /// Remove the runtime even if it's owned by someone else
+    #[clap(long)]
+    ignore_user: bool,
+
+    /// Remove the runtime even if it appears to be from a different host
+    ///
+    /// Implies --ignore-monitor
+    #[clap(long)]
+    ignore_host: bool,
+
+    /// Do not try and terminate the monitor process, just remove runtime data
+    #[clap(long)]
+    ignore_monitor: bool,
+
+    /// Remove runtimes started before last reboot
+    #[clap(long)]
+    from_before_boot: bool,
+}
+
+impl CmdRuntimePrune {
+    pub async fn run(&mut self, config: &spfs::Config) -> spfs::Result<i32> {
+        let runtime_storage = match &self.remote {
+            Some(remote) => {
+                let repo = config.get_remote(remote).await?;
+                spfs::runtime::Storage::new(repo)
+            }
+            None => config.get_runtime_storage().await?,
+        };
+
+        // TODO: Clap 4.x AppGroup supports grouping flags better.
+        if !self.from_before_boot {
+            tracing::info!("No pruning strategy selected.");
+            return Ok(1);
+        }
+
+        let default_author = spfs::runtime::Author::default();
+
+        let boot_time = match procfs::Uptime::new() {
+            Ok(uptime) => {
+                Utc::now()
+                    - Duration::from_std(uptime.uptime_duration()).map_err(|err| {
+                        spfs::Error::String(format!("Failed to convert uptime duration: {err}"))
+                    })?
+            }
+            Err(err) => {
+                tracing::error!("Failed to get system uptime: {err}");
+                return Ok(1);
+            }
+        };
+
+        let mut runtimes = runtime_storage.iter_runtimes().await;
+        while let Some(runtime) = runtimes.next().await {
+            match runtime {
+                Ok(runtime) => {
+                    if runtime.author.created >= boot_time {
+                        // This runtime is newer than the system boot time.
+                        tracing::debug!(
+                            created = ?runtime.author.created,
+                            ?boot_time,
+                            "Skipping runtime created since boot: {name}",
+                            name = runtime.name()
+                        );
+                        continue;
+                    }
+
+                    let is_same_author = runtime.author.user_name == default_author.user_name;
+                    if !self.ignore_user && !is_same_author {
+                        tracing::info!(
+                            "Won't delete, this runtime belongs to '{}'",
+                            runtime.author.user_name
+                        );
+                        tracing::info!(" > use --ignore-user to ignore this error");
+                        continue;
+                    }
+
+                    let is_same_host = runtime.author.host_name == default_author.host_name;
+                    if !self.ignore_host && !is_same_host {
+                        tracing::info!(
+                            "Won't delete, this runtime was spawned on a different machine: '{}'",
+                            runtime.author.host_name
+                        );
+                        tracing::info!(" > use --ignore-host to ignore this error");
+                        continue;
+                    }
+
+                    if !self.ignore_monitor && is_same_host && is_monitor_running(&runtime) {
+                        tracing::info!(
+                            "Won't delete, the monitor process appears to still be running",
+                        );
+                        tracing::info!(
+                            " > terminating the command should trigger the cleanup process"
+                        );
+                        tracing::info!(" > use --ignore-monitor to ignore this error");
+                        continue;
+                    }
+
+                    if let Err(err) = runtime_storage.remove_runtime(runtime.name()).await {
+                        tracing::error!(
+                            "Failed to remove runtime {name}: {err}",
+                            name = runtime.name()
+                        );
+                        continue;
+                    }
+
+                    tracing::info!("Pruned runtime {name}", name = runtime.name());
+                }
+                Err(err) => {
+                    tracing::error!("Failed to read runtime: {}", err);
+                }
+            }
+        }
+
+        Ok(0)
+    }
+}
+
+fn is_monitor_running(rt: &spfs::runtime::Runtime) -> bool {
+    if let Some(pid) = rt.status.monitor {
+        // we are blatantly ignoring the fact that this pid might
+        // have been reused and is not the monitor anymore. Given
+        // that there will always be a race condition to this effect
+        // even if we did try to check the command line args for this
+        // process. So we stick on the extra conservative side
+        is_process_running(pid)
+    } else {
+        false
+    }
+}
+
+fn is_process_running(pid: u32) -> bool {
+    // sending a null signal to the pid just allows us to check
+    // if the process actually exists without affecting it
+    let pid = nix::unistd::Pid::from_raw(pid as i32);
+    nix::sys::signal::kill(pid, None).is_ok()
+}

--- a/crates/spfs/Cargo.toml
+++ b/crates/spfs/Cargo.toml
@@ -24,7 +24,7 @@ async-trait = "0.1.52"
 async-recursion = "1.0"
 async-stream = "0.3"
 caps = "0.5.3"
-chrono = { version = "0.4.19", features = ["serde"] }
+chrono = { workspace = true }
 close-err = "1.0"
 cnproc = { git = "https://github.com/rydrman/cnproc-rs", branch = "act-like-iterator" }
 colored = "2.0"
@@ -43,7 +43,7 @@ libc = "0.2.80"
 nix = "0.24.1"
 nonempty = "0.8.1"
 once_cell = "1.8"
-procfs = "0.13.2"
+procfs = { workspace = true }
 prost = "0.11"
 rand = "0.8.5"
 relative-path = "1.3"


### PR DESCRIPTION
One and only strategy currently is to remove runtimes that have a creation time from before the current boot time. The goal is to have different strategies that are individually enabled on the command line. With no flags enabled, nothing happens.

This is a mashup of the `runtime ls` and `runtime rm` commands and there could be some better code sharing here...

Signed-off-by: J Robert Ray <jrray@imageworks.com>