### PR TITLE
Fix test that was failing for the wrong reason

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,6 +1198,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1531,6 +1537,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aeaf4ad7403de93e699c191202f017118df734d3850b01e13a3a8b2e6953d3c9"
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1661,6 +1677,12 @@ name = "os_str_bytes"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -1834,6 +1856,22 @@ name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
+name = "predicates"
+version = "2.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
+dependencies = [
+ "itertools",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f883590242d3c6fc5bf50299011695fa6590c2c70eac95ee1bdb9a733ad1a2"
 
 [[package]]
 name = "prettyplease"
@@ -2488,7 +2526,7 @@ checksum = "ea50bcf843510179a7ba41c9fe4d83a8958e9f8adf707ec731ff999297536344"
 dependencies = [
  "sentry-core",
  "tracing-core",
- "tracing-subscriber 0.3.14",
+ "tracing-subscriber 0.3.16",
 ]
 
 [[package]]
@@ -2736,7 +2774,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "tracing",
- "tracing-subscriber 0.3.14",
+ "tracing-subscriber 0.3.16",
  "url",
  "uuid",
  "walkdir",
@@ -2769,7 +2807,7 @@ dependencies = [
  "spfs",
  "strip-ansi-escapes",
  "tracing",
- "tracing-subscriber 0.3.14",
+ "tracing-subscriber 0.3.16",
  "whoami",
 ]
 
@@ -2945,7 +2983,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.14",
+ "tracing-subscriber 0.3.16",
  "whoami",
 ]
 
@@ -3235,6 +3273,7 @@ dependencies = [
  "format_serde_error",
  "ignore",
  "itertools",
+ "lazy_static",
  "nom",
  "nom-supreme",
  "once_cell",
@@ -3250,7 +3289,8 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tracing",
- "tracing-subscriber 0.2.25",
+ "tracing-capture",
+ "tracing-subscriber 0.3.16",
 ]
 
 [[package]]
@@ -3324,6 +3364,7 @@ dependencies = [
  "spk-solve-solution",
  "spk-solve-validation",
  "spk-storage",
+ "strip-ansi-escapes",
  "thiserror",
  "tokio",
  "tracing",
@@ -3858,10 +3899,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-core"
-version = "0.1.28"
+name = "tracing-capture"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
+checksum = "0c3b1b84b84d7f95504091cb9518dea662eacba7a3bc23f23e98fe5fafede344"
+dependencies = [
+ "id-arena",
+ "predicates",
+ "tracing-core",
+ "tracing-subscriber 0.3.16",
+ "tracing-tunnel",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -3922,12 +3976,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.14"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a713421342a5a666b7577783721d3117f1b69a393df803ee17bb73b1e122a59"
+checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
 dependencies = [
- "ansi_term",
  "matchers 0.1.0",
+ "nu-ansi-term",
  "once_cell",
  "regex",
  "sharded-slab",
@@ -3936,6 +3990,16 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tracing-tunnel"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507bbab1fc2c9e606543558f5656b62e8014ba7e0ffa68b9484511b6871019c5"
+dependencies = [
+ "serde",
+ "tracing-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,13 @@ async-trait = "0.1"
 chrono = { version = "0.4.19", features = ["serde"] }
 clap = { version = "3.2", features = ["derive", "env"] }
 colored = "2.0.0"
+lazy_static = "1.4"
 libc = "0.2.80"
 procfs = "0.13.2"
 sentry = { version = "0.27.0" }
 sentry-anyhow = { version = "0.27.0" }
+strip-ansi-escapes = "0.1.1"
 tokio = { version = "1.20", features = ["rt"] }
 tracing = "0.1.35"
+tracing-capture = "0.1"
+tracing-subscriber = "0.3.14"

--- a/crates/spfs-cli/cmd-clean/Cargo.toml
+++ b/crates/spfs-cli/cmd-clean/Cargo.toml
@@ -19,4 +19,4 @@ question = "0.2.2"
 spfs = { path = "../../spfs" }
 spfs-cli-common = { path = "../common" }
 tokio = { version = "1.20", features = ["rt", "rt-multi-thread"] }
-tracing = "0.1.22"
+tracing = { workspace = true }

--- a/crates/spfs-cli/cmd-enter/Cargo.toml
+++ b/crates/spfs-cli/cmd-enter/Cargo.toml
@@ -16,5 +16,5 @@ clap = { workspace = true }
 spfs = { path = "../../spfs" }
 spfs-cli-common = { path = "../common" }
 tokio = { version = "1.20", features = ["rt", "rt-multi-thread"] }
-tracing = "0.1.22"
+tracing = { workspace = true }
 url = "2.2"

--- a/crates/spfs-cli/cmd-join/Cargo.toml
+++ b/crates/spfs-cli/cmd-join/Cargo.toml
@@ -16,4 +16,4 @@ clap = { workspace = true }
 spfs = { path = "../../spfs" }
 spfs-cli-common = { path = "../common" }
 tokio = { version = "1.20", features = ["rt", "rt-multi-thread"] }
-tracing = "0.1.22"
+tracing = { workspace = true }

--- a/crates/spfs-cli/cmd-monitor/Cargo.toml
+++ b/crates/spfs-cli/cmd-monitor/Cargo.toml
@@ -16,5 +16,5 @@ clap = { workspace = true }
 spfs = { path = "../../spfs" }
 spfs-cli-common = { path = "../common" }
 tokio = { version = "1.20", features = ["rt", "rt-multi-thread"] }
-tracing = "0.1.22"
+tracing = { workspace = true }
 url = "2.2"

--- a/crates/spfs-cli/cmd-render/Cargo.toml
+++ b/crates/spfs-cli/cmd-render/Cargo.toml
@@ -16,4 +16,4 @@ clap = { workspace = true }
 spfs = { path = "../../spfs" }
 spfs-cli-common = { path = "../common" }
 tokio = { version = "1.20", features = ["rt", "rt-multi-thread"] }
-tracing = "0.1.22"
+tracing = { workspace = true }

--- a/crates/spfs-cli/common/Cargo.toml
+++ b/crates/spfs-cli/common/Cargo.toml
@@ -14,7 +14,7 @@ sentry = { workspace = true, optional = true }
 sentry-tracing = { version = "0.27.0", optional = true }
 serde_json = { version = "1.0.57", optional = true}
 spfs = { path = "../../spfs" }
-strip-ansi-escapes = { version = "0.1.1", optional = true }
-tracing = "0.1.22"
-tracing-subscriber = { version = "0.3.14", features = ["env-filter"] }
+strip-ansi-escapes = { workspace = true, optional = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 whoami = { version = "1.2", optional = true }

--- a/crates/spfs-cli/main/Cargo.toml
+++ b/crates/spfs-cli/main/Cargo.toml
@@ -29,5 +29,5 @@ spfs-cli-common = { path = "../common" }
 tokio = { version = "1.20", features = ["io-util", "rt", "rt-multi-thread"] }
 tokio-stream = { version = "0.1", features = ["net"] }
 tonic = { version = "0.8", optional = true }
-tracing = "0.1.22"
+tracing = { workspace = true }
 url = { version = "2.2", optional = true }

--- a/crates/spfs/Cargo.toml
+++ b/crates/spfs/Cargo.toml
@@ -38,7 +38,7 @@ glob = "0.3.0"
 hyper = { version = "0.14.16", features = ["client"] }
 indicatif = "0.16.2"
 itertools = "0.10.3"
-lazy_static = "1.4"
+lazy_static = { workspace = true }
 libc = { workspace = true }
 nix = "0.24.1"
 nonempty = "0.8.1"
@@ -72,7 +72,7 @@ tokio = { version = "1.20", features = [
 tokio-stream = { version = "0.1", features = ["net"] }
 tokio-util = { version = "0.7.3", features = ["compat"] }
 tonic = "0.8"
-tracing = "0.1.22"
+tracing = { workspace = true }
 url = { version = "2.2", features = ["serde"] }
 uuid = { version = "1.1", features = ["v4"] }
 walkdir = "2.3"

--- a/crates/spk-cli/common/Cargo.toml
+++ b/crates/spk-cli/common/Cargo.toml
@@ -14,7 +14,7 @@ clap = { workspace = true }
 colored = { workspace = true }
 futures = "0.3.9"
 glob = "0.3.0"
-lazy_static = "1.4.0"
+lazy_static = { workspace = true }
 once_cell = "1.8.0"
 serde_json = "1.0.57"
 serde_yaml = "0.8.17"

--- a/crates/spk-schema/crates/foundation/Cargo.toml
+++ b/crates/spk-schema/crates/foundation/Cargo.toml
@@ -32,7 +32,9 @@ sys-info = "0.9.0"
 tempfile = "3.3"
 thiserror = "1.0"
 tracing = { workspace = true }
-tracing-subscriber = "0.2.16"
+tracing-subscriber = { workspace = true }
+tracing-capture = { workspace = true }
+lazy_static = { workspace = true }
 
 [dev-dependencies]
 rstest = "0.15.0"

--- a/crates/spk-schema/crates/foundation/src/fixtures.rs
+++ b/crates/spk-schema/crates/foundation/src/fixtures.rs
@@ -3,14 +3,26 @@
 // https://github.com/imageworks/spk
 
 use rstest::fixture;
+use tracing_capture::{CaptureLayer, SharedStorage};
+use tracing_subscriber::prelude::*;
 
-pub fn init_logging() {
+lazy_static::lazy_static! {
+    static ref TRACING_STORAGE: SharedStorage = SharedStorage::default();
+}
+
+/// Initialize tracing logs for testing.
+///
+/// Returns a shared storage instance for checking
+/// events and spans that were logged
+pub fn init_logging() -> &'static SharedStorage {
     let sub = tracing_subscriber::FmtSubscriber::builder()
         .with_max_level(tracing::Level::TRACE)
         .without_time()
         .with_test_writer()
-        .finish();
+        .finish()
+        .with(CaptureLayer::new(&TRACING_STORAGE));
     let _ = tracing::subscriber::set_global_default(sub);
+    &TRACING_STORAGE
 }
 
 #[fixture]

--- a/crates/spk-solve/Cargo.toml
+++ b/crates/spk-solve/Cargo.toml
@@ -36,3 +36,4 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 rstest = "0.15.0"
+strip-ansi-escapes = { workspace = true }

--- a/crates/spk-storage/Cargo.toml
+++ b/crates/spk-storage/Cargo.toml
@@ -16,7 +16,7 @@ glob = "0.3.0"
 ignore = "0.4.18"
 indexmap = "1.7.0"
 itertools = "0.10"
-lazy_static = "1.4.0"
+lazy_static = { workspace = true }
 nom = "7.1"
 once_cell = "1.8.0"
 regex = "1.5.4"


### PR DESCRIPTION
I've included a way to log solver output to tracing, and then a tracing layer that allows the events to be introspected after the fact. This way, the test can properly detect the failure case that it was looking for. Additionally, I've had to republish the recipe within that test to properly create the desired state where a source build is tried and fails

Closes #615 