### PR TITLE
Pass --python-version when pip converting packages

### DIFF
--- a/packages/spk-convert-pip/spk-convert-pip
+++ b/packages/spk-convert-pip/spk-convert-pip
@@ -149,6 +149,8 @@ class PipImporter:
                 "pip",
                 "download",
                 f"{name}{version}",
+                "--python-version",
+                self._python_version,
                 "--abi",
                 self._python_abi,
                 "--no-deps",

--- a/packages/spk-convert-pip/spk-convert-pip.spk.yaml
+++ b/packages/spk-convert-pip/spk-convert-pip.spk.yaml
@@ -1,4 +1,4 @@
-pkg: spk-convert-pip/1.1.0
+pkg: spk-convert-pip/1.2.0
 api: v0/package
 build:
   script:


### PR DESCRIPTION
Without this, despite --abi, it ends up using the python interpreter being used (3.7) to resolve compatibility, no matter what --python-version is passed to spk-convert-pip, making things difficult for those of us still suffering with python 2.7.

The help for --abi in `pip download --help` mentions --python-version being needed along with a few other things that default to the current interpreter. The other ones are probably okay to default that way though.

Signed-off-by: J Robert Ray <jrray@imageworks.com>