### PR TITLE
Handle "Failed to render" when out of disk space

### DIFF
--- a/crates/spfs-cli/common/src/args.rs
+++ b/crates/spfs-cli/common/src/args.rs
@@ -357,6 +357,10 @@ macro_rules! handle_result {
     ($result:ident) => {
         match $result {
             Err(err) => match err {
+                spfs::Error::Errno(msg, errno) if errno == $crate::__private::libc::ENOSPC => {
+                    tracing::error!("Out of disk space: {msg}");
+                    1
+                }
                 spfs::Error::RuntimeWriteError(path, io_err)
                 | spfs::Error::StorageWriteError(_, path, io_err)
                     if std::matches!(


### PR DESCRIPTION
This needs its own case because of the use of `Error::wrap`; failing to render could get its own error type to recognize this common error.

Signed-off-by: J Robert Ray <jrray@imageworks.com>