### PR TITLE
Bugfix for missing build info for "(requested by..." etc lines in solver output

### DIFF
--- a/crates/spk-schema/crates/ident/src/request.rs
+++ b/crates/spk-schema/crates/ident/src/request.rs
@@ -374,7 +374,10 @@ pub enum RequestedBy {
     /// For a request made during spk's automated (unit) test code
     SpkInternalTest,
     /// A package build that made the request, usually during a solve
-    PackageBuild(VersionIdent),
+    PackageBuild(BuildIdent),
+    /// A package version/recipe that made the request as part of
+    /// building from source during a solve
+    PackageVersion(VersionIdent),
 }
 
 impl std::fmt::Display for RequestedBy {
@@ -393,6 +396,7 @@ impl std::fmt::Display for RequestedBy {
             RequestedBy::NoState => write!(f, "no state? this should not happen?"),
             RequestedBy::SpkInternalTest => write!(f, "spk's test suite"),
             RequestedBy::PackageBuild(ident) => write!(f, "{ident}"),
+            RequestedBy::PackageVersion(ident) => write!(f, "{ident} recipe"),
         }
     }
 }

--- a/crates/spk-solve/crates/graph/src/graph.rs
+++ b/crates/spk-solve/crates/graph/src/graph.rs
@@ -142,7 +142,7 @@ impl FormatChange for Change {
                                 // display what requested them.
                                 match &c.source {
                                     PackageSource::BuildFromSource { recipe } => {
-                                        vec![RequestedBy::PackageBuild(recipe.ident().clone())
+                                        vec![RequestedBy::PackageVersion(recipe.ident().clone())
                                             .to_string()]
                                     }
                                     PackageSource::Embedded => {
@@ -257,7 +257,7 @@ impl<'state, 'cmpt> DecisionBuilder<'state, 'cmpt> {
                 Arc::clone(recipe),
             )))];
 
-            let requested_by = RequestedBy::PackageBuild(spec.ident().base().clone());
+            let requested_by = RequestedBy::PackageBuild(spec.ident().clone());
             changes
                 .extend(self.requirements_to_changes(spec.runtime_requirements(), &requested_by));
             changes.extend(self.components_to_changes(spec.components(), &requested_by));
@@ -280,7 +280,7 @@ impl<'state, 'cmpt> DecisionBuilder<'state, 'cmpt> {
                 source,
             )))];
 
-            let requested_by = RequestedBy::PackageBuild(spec.ident().base().clone());
+            let requested_by = RequestedBy::PackageBuild(spec.ident().clone());
             changes
                 .extend(self.requirements_to_changes(spec.runtime_requirements(), &requested_by));
             changes.extend(self.components_to_changes(spec.components(), &requested_by));
@@ -374,7 +374,7 @@ impl<'state, 'cmpt> DecisionBuilder<'state, 'cmpt> {
             if !added_components.contains(&component.name) {
                 continue;
             }
-            let requested_by = RequestedBy::PackageBuild(spec.ident().base().clone());
+            let requested_by = RequestedBy::PackageBuild(spec.ident().clone());
             changes.extend(self.requirements_to_changes(&component.requirements, &requested_by));
         }
         changes

--- a/crates/spk-solve/src/solver.rs
+++ b/crates/spk-solve/src/solver.rs
@@ -358,7 +358,7 @@ impl Solver {
                 return Err(Error::OutOfOptions(OutOfOptions {
                     request: PkgRequest::new(
                         missing_embed_provider.clone().into(),
-                        RequestedBy::PackageBuild(unprovided_embedded.base().clone()),
+                        RequestedBy::PackageBuild(unprovided_embedded.clone()),
                     ),
                     notes,
                 }));


### PR DESCRIPTION
This contains the bugfixes for missing build info for "(requested by..." etc lines in solver output, see #624 for more details. 

It adds a new value, `PackageVersion(VersionIdent)`, to the `RequestedBy` enum.
