### PR TITLE
#608 Ensure that blob payload exist when sync a blob

### DIFF
--- a/crates/spfs/src/sync.rs
+++ b/crates/spfs/src/sync.rs
@@ -409,7 +409,7 @@ where
     /// as any payload should be synced alongside its
     /// corresponding Blob instance - use [`Self::sync_blob`] instead
     async unsafe fn sync_payload(&self, digest: encoding::Digest) -> Result<SyncPayloadResult> {
-        if self.processed_digests.write().await.contains(&digest) {
+        if self.processed_digests.read().await.contains(&digest) {
             return Ok(SyncPayloadResult::Duplicate);
         }
 


### PR DESCRIPTION
Closes Issue: #608 

Signed-off-by: Andrew Paxson <apaxson@ilm.com>

This MR aims to resolve an issue where a blob maybe sync'd but its payload is not during concurrent workloads. This is one possible process for handling this. This has fixed out problems at ILM.

Note: I am considering making the entire `sync_payload()` process synchronous as there are a few .await location that could be problematic in HIGHLY concurrent workloads.