### PR TITLE
Add safety check when publishing unstable APIs

### DIFF
--- a/crates/spk-cli/common/src/publish.rs
+++ b/crates/spk-cli/common/src/publish.rs
@@ -26,6 +26,7 @@ pub struct Publisher {
     from: Arc<storage::RepositoryHandle>,
     to: Arc<storage::RepositoryHandle>,
     skip_source_packages: bool,
+    allow_unstable_api: bool,
     force: bool,
 }
 
@@ -42,6 +43,7 @@ impl Publisher {
             from: source,
             to: destination,
             skip_source_packages: false,
+            allow_unstable_api: false,
             force: false,
         }
     }
@@ -61,6 +63,12 @@ impl Publisher {
     /// Do not publish source packages, even if they exist for the version being published.
     pub fn skip_source_packages(mut self, skip_source_packages: bool) -> Self {
         self.skip_source_packages = skip_source_packages;
+        self
+    }
+
+    /// Allow publishing packages defined with an unstable api version
+    pub fn allow_unstable_api(mut self, allow_unstable_api: bool) -> Self {
+        self.allow_unstable_api = allow_unstable_api;
         self
     }
 
@@ -93,6 +101,12 @@ impl Publisher {
             }
             Err(err) => return Err(err.into()),
             Ok(recipe) => {
+                if !recipe.api_version().is_stable() && !self.allow_unstable_api {
+                    return Err(Error::String(format!(
+                        "Recipe has unstable api version, and allow unstable is not set: {:?}",
+                        recipe.api_version()
+                    )));
+                }
                 tracing::info!("publishing recipe: {}", recipe.ident().format_ident());
                 if self.force {
                     self.to.force_publish_recipe(&recipe).await?;
@@ -151,6 +165,12 @@ impl Publisher {
 
             tracing::debug!("   loading package: {}", build.format_ident());
             let spec = self.from.read_package(build).await?;
+            if !spec.api_version().is_stable() && !self.allow_unstable_api {
+                return Err(Error::String(format!(
+                    "Package build has unstable api version, and allow unstable is not set: {:?}",
+                    spec.api_version()
+                )));
+            }
             let components = self.from.read_components(build).await?;
             tracing::info!("publishing package: {}", spec.ident().format_ident());
             let env_spec = components.values().cloned().collect();

--- a/crates/spk-cli/group2/src/cmd_publish.rs
+++ b/crates/spk-cli/group2/src/cmd_publish.rs
@@ -34,6 +34,12 @@ pub struct Publish {
     #[clap(long, short)]
     force: bool,
 
+    /// Allow publishing package specs written in unstable api versions
+    ///
+    /// The api version of a spec is the value of the `api` field within it.
+    #[clap(long)]
+    allow_unstable_api: bool,
+
     /// The local packages to publish
     ///
     /// This can be an entire package version with all builds or a
@@ -54,6 +60,7 @@ impl Run for Publish {
 
         let publisher = Publisher::new(Arc::new(source.into()), Arc::new(target.into()))
             .skip_source_packages(self.no_source)
+            .allow_unstable_api(self.allow_unstable_api)
             .force(self.force);
 
         let mut published = Vec::new();


### PR DESCRIPTION
This feels a little unnecessary without the additional definition of the new API type, but I'm leaving that part in #598 so that this can be merged separately. 