### PR TITLE
Remove `Error` implementation for `PkgRequest`

### DIFF
--- a/crates/spk-schema/crates/ident/src/request.rs
+++ b/crates/spk-schema/crates/ident/src/request.rs
@@ -9,7 +9,12 @@ use std::str::FromStr;
 
 use colored::Colorize;
 use serde::{Deserialize, Serialize};
-use spk_schema_foundation::format::{FormatBuild, FormatComponents, FormatRequest};
+use spk_schema_foundation::format::{
+    FormatBuild,
+    FormatChangeOptions,
+    FormatComponents,
+    FormatRequest,
+};
 use spk_schema_foundation::ident_component::ComponentSet;
 use spk_schema_foundation::name::{OptName, OptNameBuf, PkgName};
 use spk_schema_foundation::option_map::Stringified;
@@ -402,8 +407,7 @@ impl std::fmt::Display for RequestedBy {
 }
 
 /// A desired package and set of restrictions on how it's selected.
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize, thiserror::Error)]
-#[error("Package request for {pkg}")]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct PkgRequest {
     pub pkg: RangeIdent,
     #[serde(
@@ -449,6 +453,17 @@ pub struct PkgRequest {
     // more approachable.
     #[serde(skip)]
     pub requested_by: BTreeMap<String, Vec<RequestedBy>>,
+}
+
+impl std::fmt::Display for PkgRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if f.alternate() {
+            let fmt = self.format_request(&None, &self.pkg.name, &FormatChangeOptions::default());
+            f.write_str(&fmt)
+        } else {
+            self.pkg.fmt(f)
+        }
+    }
 }
 
 #[allow(clippy::derive_hash_xor_eq)]

--- a/crates/spk-solve/crates/graph/src/error.rs
+++ b/crates/spk-solve/crates/graph/src/error.rs
@@ -20,7 +20,7 @@ pub enum Error {
     #[error(transparent)]
     Graph(#[from] GraphError),
     #[error("Package not found: {0}")]
-    PackageNotFoundDuringSolve(#[from] PkgRequest),
+    PackageNotFoundDuringSolve(PkgRequest),
     #[error("Solver error: {0}")]
     SolverError(String),
     #[error("Solver interrupted: {0}")]


### PR DESCRIPTION
The `PkgRequest` type was using `thiserror::Error`, which doesn't seem appropriate or necessary to me. It seems like this was added in order to get the `Display` trait, or at least it was only being used for that, so I've added an explicit implementation and removed the derive. 