### PR TITLE
Remove unused `impl Satisfy` for recipe types

### DIFF
--- a/crates/spk-schema/src/spec.rs
+++ b/crates/spk-schema/src/spec.rs
@@ -183,14 +183,6 @@ pub enum SpecRecipe {
     V0Package(super::v0::Spec<VersionIdent>),
 }
 
-impl Satisfy<PkgRequest> for SpecRecipe {
-    fn check_satisfies_request(&self, request: &PkgRequest) -> Compatibility {
-        match self {
-            SpecRecipe::V0Package(r) => r.check_satisfies_request(request),
-        }
-    }
-}
-
 impl Recipe for SpecRecipe {
     type Output = Spec;
 

--- a/crates/spk-schema/src/v0/spec.rs
+++ b/crates/spk-schema/src/v0/spec.rs
@@ -126,16 +126,6 @@ impl<Ident> Spec<Ident> {
     }
 }
 
-impl Spec<VersionIdent> {
-    /// Check if this package spec satisfies the given request.
-    pub fn satisfies_request(&self, request: Request) -> Compatibility {
-        match request {
-            Request::Pkg(request) => Satisfy::check_satisfies_request(self, &request),
-            Request::Var(request) => Satisfy::check_satisfies_request(self, &request),
-        }
-    }
-}
-
 impl Spec<BuildIdent> {
     /// Check if this package spec satisfies the given request.
     pub fn satisfies_request(&self, request: Request) -> Compatibility {
@@ -413,44 +403,6 @@ impl Recipe for Spec<VersionIdent> {
             .render_all_pins(options, specs.values().map(|p| p.ident()))?;
         let digest = updated.resolve_options(options)?.digest();
         Ok(updated.map_ident(|i| i.into_build(Build::Digest(digest))))
-    }
-}
-
-impl Satisfy<PkgRequest> for Spec<VersionIdent> {
-    fn check_satisfies_request(&self, pkg_request: &PkgRequest) -> Compatibility {
-        if pkg_request.pkg.name != *self.pkg.name() {
-            return Compatibility::Incompatible(format!(
-                "different package name: {} != {}",
-                pkg_request.pkg.name,
-                self.pkg.name()
-            ));
-        }
-
-        if self.is_deprecated() {
-            // deprecated builds are only okay if their build
-            // was specifically requested
-            if pkg_request.pkg.build.is_none() {
-                return Compatibility::Incompatible(
-                    "Build is deprecated and was not specifically requested".to_string(),
-                );
-            }
-        }
-
-        if pkg_request.prerelease_policy == PreReleasePolicy::ExcludeAll
-            && !self.version().pre.is_empty()
-        {
-            return Compatibility::Incompatible("prereleases not allowed".to_string());
-        }
-
-        let c = pkg_request
-            .pkg
-            .version
-            .is_satisfied_by(self, CompatRule::API);
-        if !c.is_ok() {
-            return c;
-        }
-
-        Compatibility::Compatible
     }
 }
 


### PR DESCRIPTION
It doesn't really make sense that recipes can satisfy package requests. Our v0 spec can do this (sometimes) because it shares so much code with the package spec type, but this becomes a really strange implementation to write once the v1 spec is introduced. Ultimately, we were not using this implementation at all so it makes sense to just remove it.