### PR TITLE
Stop treating AlreadyExists from rename as success

### DIFF
--- a/crates/spfs/src/storage/fs/database.rs
+++ b/crates/spfs/src/storage/fs/database.rs
@@ -118,14 +118,11 @@ impl graph::Database for super::FSRepository {
             Ok(_) => Ok(()),
             Err(err) => {
                 let _ = tokio::fs::remove_file(&working_file).await;
-                match err.kind() {
-                    std::io::ErrorKind::AlreadyExists => Ok(()),
-                    _ => Err(Error::StorageWriteError(
-                        "rename on object file",
-                        filepath,
-                        err,
-                    )),
-                }
+                Err(Error::StorageWriteError(
+                    "rename on object file",
+                    filepath,
+                    err,
+                ))
             }
         }
     }

--- a/crates/spfs/src/storage/fs/hash_store.rs
+++ b/crates/spfs/src/storage/fs/hash_store.rs
@@ -296,16 +296,11 @@ impl FSHashStore {
             } => {
                 if let Err(err) = tokio::fs::rename(&working_file, &path).await {
                     let _ = tokio::fs::remove_file(&working_file).await;
-                    match err.kind() {
-                        ErrorKind::AlreadyExists => (),
-                        _ => {
-                            return Err(Error::StorageWriteError(
-                                "rename on hash store object",
-                                path,
-                                err,
-                            ))
-                        }
-                    }
+                    return Err(Error::StorageWriteError(
+                        "rename on hash store object",
+                        path,
+                        err,
+                    ));
                 }
                 copied
             }


### PR DESCRIPTION
For files...

rename replaces a file if it is already exists and returns Ok in that case;
it does not return EEXIST.

I couldn't find a case where rename returns EEXIST (ubuntu 20.04).
Attempting to rename a file onto a empty/non-empty directory fails with
EISDIR.

For directores...

The semantics for renaming directories is different, so add a code comment
where it is possible that the error to rename should be ignored. Add
checking for ENOTEMPTY too because in experimentation (again, on ubuntu)
that's the actual error returned for the situation we're trying to detect.

Signed-off-by: J Robert Ray <jrray@jrray.org>