### PR TITLE
Fix broken Makefile check for src package

### DIFF
--- a/packages/Makefile
+++ b/packages/Makefile
@@ -86,7 +86,7 @@ import:
 %: $</$<.spk
 
 %.spk : %.spk.yaml
-	spk info -r local $<@source > /dev/null 2>&1 || spk make-source -v $<
+	spk info -r local $<@sources > /dev/null 2>&1 || spk make-source -v $<
 	spk mkb -r origin -v $<
 	spk export $< $@
 


### PR DESCRIPTION
This was trying to determine if the src package needed to be built but was never succeeding because of the type