### PR TITLE
Bugfix for prerelease interaction with initial request impossible checks

### DIFF
--- a/crates/spk-solve/src/solver.rs
+++ b/crates/spk-solve/src/solver.rs
@@ -765,7 +765,10 @@ impl Solver {
             let dummy_spec = make_build!({"pkg": format!("initialrequest/{}", count + 1),
                                           "install": {
                                               "requirements": [
-                                                  req
+                                                  {"pkg": format!("{}", req.pkg ),
+                                                   "prereleasePolicy": req.prerelease_policy.clone(),
+                                                   "inclusionPolicy": req.inclusion_policy.clone(),
+                                                  }
                                               ]
                                           }
             });


### PR DESCRIPTION
This prevents a solver with impossible checks enabled from failing when the initial requests are set to include prereleases, e.g. during a `spk build` on a prerelease version, or `spk explain --pre ...`.
