### PR TITLE
Bugfix for initial requests impossible checks task ordering issue

### DIFF
--- a/crates/spk-solve/src/solver.rs
+++ b/crates/spk-solve/src/solver.rs
@@ -761,10 +761,7 @@ impl Solver {
             let dummy_spec = make_build!({"pkg": format!("initialrequest/{}", count + 1),
                                           "install": {
                                               "requirements": [
-                                                  {"pkg": format!("{}", req.pkg ),
-                                                   "prereleasePolicy": req.prerelease_policy.clone(),
-                                                   "inclusionPolicy": req.inclusion_policy.clone(),
-                                                  }
+                                                  req
                                               ]
                                           }
             });
@@ -789,8 +786,7 @@ impl Solver {
 
         // Only once all the tasks are finished, the user is warned
         // about the impossible initial request, if there are any.
-        let results: Vec<_> = tasks.collect().await;
-        for (checked_req, result) in results {
+        for (checked_req, result) in tasks.collect::<Vec<_>>().await {
             let compat = match result {
                 Ok(c) => c,
                 Err(err) => {


### PR DESCRIPTION
This fixes an issue that sometimes causes the wrong package to be reported as impossible during the initial request checked. The tasks and request list are not always consistent. This fixes the problem by adding the request to the task and changing the task return the request so it can be used with the task's result.