### PR TITLE
Add ability to commit a platform by refs

### DIFF
--- a/crates/spfs-cli/main/src/cmd_commit.rs
+++ b/crates/spfs-cli/main/src/cmd_commit.rs
@@ -29,6 +29,10 @@ pub struct CmdCommit {
     #[clap(long)]
     path: Option<PathBuf>,
 
+    /// Combine existing items into a platform, use a '+' to join multiple
+    #[clap(long = "ref")]
+    reference: Option<String>,
+
     /// Hash the files while committing, rather than before.
     ///
     /// This option can improve commit times when a large number of the
@@ -65,11 +69,11 @@ pub struct CmdCommit {
     )]
     pub max_concurrent_branches: usize,
 
-    /// The desired object type to create, skip this when giving --path
+    /// The desired object type to create, skip this when giving --path or --ref
     #[clap(
         value_parser = ["layer", "platform"],
-        conflicts_with_all = &["path", "remote"],
-        required_unless_present = "path",
+        conflicts_with_all = &["path", "remote", "reference"],
+        required_unless_present_any = &["path", "reference"]
     )]
     kind: Option<String>,
 }
@@ -130,8 +134,20 @@ impl CmdCommit {
                 .await?
                 .into());
         }
-        // no path given, commit the current runtime
 
+        if let Some(reference) = &self.reference {
+            let env_spec = spfs::tracking::EnvSpec::parse(reference)?;
+            let mut digests = spfs::graph::Stack::default();
+            for env_item in env_spec.iter() {
+                let env_item = env_item.to_string();
+                let digest = repo.resolve_ref(env_item.as_ref()).await?;
+                digests.push(digest);
+            }
+
+            return Ok(repo.create_platform(digests).await?.into());
+        }
+
+        // no path or reference given, commit the current runtime
         let mut runtime = spfs::active_runtime().await?;
 
         if !runtime.status.editable {


### PR DESCRIPTION
This MR adds the ability to commit a platform by specifying a valid env ref. We are using this to quickly generate platforms of composable layers for our thirdparty library collections:
```
spfs commit --ref tags/A+tags/B+tags/C platforms/myplatform
```