### PR TITLE
Draft: prevent list_remotes from failing when a single remote is unreachable.

### DIFF
--- a/crates/spfs-cli/cmd-render/src/cmd_render.rs
+++ b/crates/spfs-cli/cmd-render/src/cmd_render.rs
@@ -4,6 +4,7 @@
 
 use clap::builder::TypedValueParser;
 use clap::Parser;
+use futures::future::FutureExt;
 use miette::{Context, Result};
 use spfs::prelude::*;
 use spfs::storage::fallback::FallbackProxy;
@@ -55,7 +56,7 @@ impl CmdRender {
         let (repo, origin, remotes) = tokio::try_join!(
             config.get_opened_local_repository(),
             config.get_remote("origin"),
-            config.list_remotes()
+            config.list_remotes().map(Ok)
         )?;
 
         let handle = repo.clone().into();

--- a/crates/spfs/src/resolve.rs
+++ b/crates/spfs/src/resolve.rs
@@ -353,8 +353,10 @@ pub(crate) async fn resolve_and_render_overlay_dirs(
     skip_runtime_save: bool,
 ) -> Result<RenderResult> {
     let config = get_config()?;
-    let (repo, remotes) =
-        tokio::try_join!(config.get_opened_local_repository(), config.list_remotes())?;
+    let (repo, remotes) = tokio::try_join!(
+        config.get_opened_local_repository(),
+        config.list_remotes().map(Ok)
+    )?;
     let fallback_repo = FallbackProxy::new(repo, remotes);
 
     let manifests = resolve_overlay_dirs(runtime, &fallback_repo, skip_runtime_save).await?;


### PR DESCRIPTION
We have found `config.list_remotes` to be faulty in multi-remote environments. When using CLI commands like `spfs-render` it requires that all remotes be reachable. This is not always possible.

This MR updates the `config.list_remotes` to be lossy when fetching a remote is fails. 