### PR TITLE
Bugfix adds missing send_solver_start_metrics() call

### DIFF
--- a/crates/spk-solve/src/io.rs
+++ b/crates/spk-solve/src/io.rs
@@ -786,6 +786,9 @@ impl DecisionFormatter {
             let mut task_solver_runtime = solver_settings.solver.run();
 
             let task = async move {
+                #[cfg(feature = "statsd")]
+                task_formatter.send_solver_start_metrics(&task_solver_runtime);
+
                 let start = Instant::now();
                 let loop_outcome = task_formatter
                     .run_solver_loop(&mut task_solver_runtime, output_location)


### PR DESCRIPTION
This adds a `send_solver_start_metrics()` call that was missing. The method is part of the `statsd` feature, but the call to it was lost during porting.
