### PR TITLE
Remove spfs-enter from process tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3010,6 +3010,7 @@ version = "0.34.6"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
+ "nix 0.26.2",
  "spfs",
  "spfs-cli-common",
  "tokio",

--- a/crates/spfs-cli/cmd-enter/Cargo.toml
+++ b/crates/spfs-cli/cmd-enter/Cargo.toml
@@ -14,6 +14,7 @@ sentry = ["spfs-cli-common/sentry"]
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
+nix = { workspace = true }
 spfs = { path = "../../spfs" }
 spfs-cli-common = { path = "../common" }
 tokio = { version = "1.20", features = ["rt", "rt-multi-thread"] }


### PR DESCRIPTION
We were watching the child process for its duration, but realistically there was no need. This also allows processes to integrate slightly better in some environments because the actual name of the process launched by spfs will be the process that the user specified rather than spfs-enter.

This is part of a larger effort to improve the shell experience in spfs, with our goal of starting all users in an empty spfs shell environment if it's possible to replicate the experience of a vanilla shell.

Aside from the gymnastics to convert the command into `CString`s, this actually is more of an exercise of removing code.

IIRC what I am removing here remains from a time before spfs-monitor was a separate command altogether and the spfs-enter command dealt with the cleanup.