### PR TITLE
Update to multiple solver selection and finished solver messages

### DIFF
--- a/crates/spk-cli/common/src/flags.rs
+++ b/crates/spk-cli/common/src/flags.rs
@@ -771,18 +771,21 @@ impl Repositories {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
-pub enum SolverToShow {
-    /// Output from the solver specified by the command line parameters
+pub enum SolverToRun {
+    /// Run and show output from the solver specified by the command line parameters
     Cli,
-    /// Output from the solver based on the cli solver and with all impossible request checks enabled
+    /// Run and show output from the solver based on the cli solver and with all impossible request checks enabled
     Checks,
+    /// Run both solvers but show outputform the Cli solver
+    All,
 }
 
-impl From<SolverToShow> for MultiSolverKind {
-    fn from(item: SolverToShow) -> MultiSolverKind {
+impl From<SolverToRun> for MultiSolverKind {
+    fn from(item: SolverToRun) -> MultiSolverKind {
         match item {
-            SolverToShow::Cli => MultiSolverKind::Unchanged,
-            SolverToShow::Checks => MultiSolverKind::AllImpossibleChecks,
+            SolverToRun::Cli => MultiSolverKind::Unchanged,
+            SolverToRun::Checks => MultiSolverKind::AllImpossibleChecks,
+            SolverToRun::All => MultiSolverKind::All,
         }
     }
 }
@@ -838,13 +841,14 @@ pub struct DecisionFormatterSettings {
     #[clap(long)]
     pub status_bar: bool,
 
-    /// Show output from the named solver. There are two solver
-    /// configurations run in parallel when finding a solution for a
-    /// requested solve: one configured from the command line, one
-    /// based on the command line with all impossible request checks
-    /// enabled.
-    #[clap(long, value_enum, default_value_t = SolverToShow::Cli)]
-    pub solver_output_from: SolverToShow,
+    /// Run and show output from the named solver. There are two
+    /// solver configurations: one configured from the command line
+    /// (cli), and one based on the command line but with all
+    /// impossible request checks enabled (checks). By default, they
+    /// are both (all) run in parallel when finding a solution for a
+    /// requested solve.
+    #[clap(long, value_enum, default_value_t = SolverToRun::All)]
+    pub solver_to_run: SolverToRun,
 
     /// Display a report on of the search space size for the resolved solution.
     #[clap(long)]
@@ -884,7 +888,7 @@ impl DecisionFormatterSettings {
             .with_long_solves_threshold(self.long_solves)
             .with_max_frequent_errors(self.max_frequent_errors)
             .with_status_bar(self.status_bar)
-            .with_solver_output_from(self.solver_output_from.into())
+            .with_solver_to_run(self.solver_to_run.into())
             .with_search_space_size(self.show_search_size);
         Ok(builder)
     }


### PR DESCRIPTION
This replaces the `--solver-to-show` option with `--solver-to-run` to allow more control over running multiple solvers. This was triggered by user feedback resulting frominteracting with multiple solvers.

The `--solver-to-run <solver name>` option specifies the solver to run and show the output from. It defaults to `all`, which runs all the available solvers (`cli` and `checks`) in parallel and shows the output from the `cli` solver. This matches the default current behaviour. However, if it is given `cli`or `checks`, it will run just that solver and only show its output.

This also updates the solver finished messages to be clearer about what happened and how to rerun the solver if the one that finished first had its output hidden.
