### PR TITLE
Bugfix for invalid package handling in search space size calcs

### DIFF
--- a/crates/spk-solve/src/search_space.rs
+++ b/crates/spk-solve/src/search_space.rs
@@ -94,10 +94,7 @@ async fn get_package_version_build_states(
                         Err(InvalidPackageSpec(ident, message)) => {
                             // Ignore invalid package spec errors for
                             // the purposes of getting all the valid
-                            // package version builds. These are
-                            // likely to be older packages with
-                            // references to Uppercase package names
-                            // in their dependencies.
+                            // package version builds.
                             tracing::warn!("{}", InvalidPackageSpec(ident, message).to_string());
                             continue;
                         }


### PR DESCRIPTION
This fixes invalid package handling in search space size calculations so spk doesn't exit when it hits the first invalid package in a repo. We have a number of these in our repo from earlier iterations of spk's rules around packages.  Invalid packages are skipped and ignored instead of causing the calculations to error out.
