### PR TITLE
Allow manifest entries to hold user data

### DIFF
--- a/crates/spfs/src/clean_test.rs
+++ b/crates/spfs/src/clean_test.rs
@@ -190,7 +190,7 @@ async fn test_clean_untagged_objects(#[future] tmprepo: TempRepo, tmpdir: tempfi
 async fn test_clean_untagged_objects_layers_platforms(#[future] tmprepo: TempRepo) {
     init_logging();
     let tmprepo = tmprepo.await;
-    let manifest = tracking::Manifest::default();
+    let manifest = tracking::Manifest::<()>::default();
     let layer = tmprepo
         .create_layer(&graph::Manifest::from(&manifest))
         .await

--- a/crates/spfs/src/graph/entry.rs
+++ b/crates/spfs/src/graph/entry.rs
@@ -20,7 +20,7 @@ pub struct Entry {
 }
 
 impl Entry {
-    pub fn from(name: String, entry: &tracking::Entry) -> Self {
+    pub fn from<T>(name: String, entry: &tracking::Entry<T>) -> Self {
         Self {
             object: entry.object,
             kind: entry.kind,

--- a/crates/spfs/src/graph/manifest.rs
+++ b/crates/spfs/src/graph/manifest.rs
@@ -24,14 +24,20 @@ pub struct Manifest {
     trees: BTreeMap<encoding::Digest, Tree>,
 }
 
-impl From<&tracking::Manifest> for Manifest {
-    fn from(source: &tracking::Manifest) -> Self {
+impl<T> From<&tracking::Manifest<T>> for Manifest
+where
+    T: std::cmp::Eq + std::cmp::PartialEq,
+{
+    fn from(source: &tracking::Manifest<T>) -> Self {
         Self::from(source.root())
     }
 }
 
-impl From<&tracking::Entry> for Manifest {
-    fn from(source: &tracking::Entry) -> Self {
+impl<T> From<&tracking::Entry<T>> for Manifest
+where
+    T: std::cmp::Eq + std::cmp::PartialEq,
+{
+    fn from(source: &tracking::Entry<T>) -> Self {
         let mut manifest = Self::default();
         let mut root = Tree::default();
 

--- a/crates/spfs/src/tracking/manifest_test.rs
+++ b/crates/spfs/src/tracking/manifest_test.rs
@@ -105,7 +105,7 @@ async fn test_layer_manifests(tmpdir: tempfile::TempDir) {
 #[rstest]
 #[tokio::test]
 async fn test_layer_manifests_removal() {
-    let mut a = Manifest::default();
+    let mut a = Manifest::<()>::default();
     a.mkfile("a_only").unwrap();
 
     let mut b = Manifest::default();

--- a/crates/spk-build/src/build/binary_test.rs
+++ b/crates/spk-build/src/build/binary_test.rs
@@ -42,6 +42,7 @@ fn test_split_manifest_permissions() {
                 mode: 0o555,
                 size: 0,
                 entries: Default::default(),
+                user_data: (),
             },
         )
         .unwrap();


### PR DESCRIPTION
Not of any particular use here, but used in the fuse implementation to associate inode information to entries at runtime.