### PR TITLE
Parse env spec directly at the command line

### DIFF
--- a/crates/spfs-cli/common/src/args.rs
+++ b/crates/spfs-cli/common/src/args.rs
@@ -448,6 +448,7 @@ macro_rules! main {
 #[macro_export(local_inner_macros)]
 macro_rules! configure {
     ($opt:ident, $sentry:literal, $syslog:literal) => {{
+        use $crate::CommandName;
         // sentry makes this process multithreaded, and must be disabled
         // for commands that use system calls which are bothered by this
         #[cfg(feature = "sentry")]
@@ -471,7 +472,6 @@ macro_rules! configure {
 macro_rules! handle_result {
     ($result:ident) => {{
         let code = match $result {
-            //  Err(err) => match err {
             Err(err) => match err.root_cause().downcast_ref::<spfs::Error>() {
                 Some(spfs::Error::Errno(msg, errno))
                     if *errno == $crate::__private::libc::ENOSPC =>

--- a/crates/spfs-cli/main/src/cmd_ls.rs
+++ b/crates/spfs-cli/main/src/cmd_ls.rs
@@ -15,7 +15,7 @@ pub struct CmdLs {
 
     /// The tag or digest of the file tree to read from
     #[clap(value_name = "REF")]
-    reference: String,
+    reference: spfs::tracking::EnvSpecItem,
 
     /// The subdirectory to list
     #[clap(default_value = "/spfs")]
@@ -26,7 +26,7 @@ impl CmdLs {
     pub async fn run(&mut self, config: &spfs::Config) -> Result<i32> {
         let repo = spfs::config::open_repository_from_string(config, self.remote.as_ref()).await?;
 
-        let item = repo.read_ref(self.reference.as_str()).await?;
+        let item = repo.read_ref(&self.reference.to_string()).await?;
 
         let path = self
             .path

--- a/crates/spfs-cli/main/src/cmd_pull.rs
+++ b/crates/spfs-cli/main/src/cmd_pull.rs
@@ -26,7 +26,7 @@ pub struct CmdPull {
     /// These can be individual tags or digests, or they may also
     /// be a collection of items joined by a '+'
     #[clap(value_name = "REF", required = true)]
-    refs: Vec<String>,
+    refs: Vec<spfs::tracking::EnvSpec>,
 }
 
 impl CmdPull {
@@ -36,8 +36,7 @@ impl CmdPull {
             spfs::config::open_repository_from_string(config, self.remote.as_ref())
         )?;
 
-        let env_spec =
-            spfs::tracking::EnvSpec::parse(self.refs.join(spfs::tracking::ENV_SPEC_SEPARATOR))?;
+        let env_spec = self.refs.iter().cloned().collect();
         let summary = self
             .sync
             .get_syncer(&remote, &repo)

--- a/crates/spfs-cli/main/src/cmd_push.rs
+++ b/crates/spfs-cli/main/src/cmd_push.rs
@@ -24,7 +24,7 @@ pub struct CmdPush {
     /// These can be individual tags or digests, or they may also
     /// be a collection of items joined by a '+'
     #[clap(value_name = "REF", required = true)]
-    refs: Vec<String>,
+    refs: Vec<spfs::tracking::EnvSpec>,
 }
 
 impl CmdPush {
@@ -34,8 +34,7 @@ impl CmdPush {
             spfs::config::open_repository_from_string(config, Some(&self.remote)),
         )?;
 
-        let env_spec =
-            spfs::tracking::EnvSpec::parse(self.refs.join(spfs::tracking::ENV_SPEC_SEPARATOR))?;
+        let env_spec = self.refs.iter().cloned().collect();
         // the latest tag is always synced when pushing
         self.sync.sync = true;
         let summary = self

--- a/crates/spfs-cli/main/src/cmd_read.rs
+++ b/crates/spfs-cli/main/src/cmd_read.rs
@@ -16,7 +16,7 @@ pub struct CmdRead {
 
     /// The tag or digest of the blob/payload to output
     #[clap(value_name = "REF")]
-    reference: String,
+    reference: spfs::tracking::EnvSpecItem,
 
     /// If the given ref is not a blob, read the blob found at this path
     #[clap(value_name = "PATH")]
@@ -27,7 +27,7 @@ impl CmdRead {
     pub async fn run(&mut self, config: &spfs::Config) -> Result<i32> {
         let repo = spfs::config::open_repository_from_string(config, self.remote.as_ref()).await?;
 
-        let item = repo.read_ref(self.reference.as_str()).await?;
+        let item = repo.read_ref(&self.reference.to_string()).await?;
         use spfs::graph::Object;
         let blob = match item {
             Object::Blob(blob) => blob,

--- a/crates/spfs-cli/main/src/cmd_run.rs
+++ b/crates/spfs-cli/main/src/cmd_run.rs
@@ -28,7 +28,7 @@ pub struct CmdRun {
     /// The tag or id of the desired runtime
     ///
     /// Use '-' or an empty string to request an empty environment
-    pub reference: String,
+    pub reference: spfs::tracking::EnvSpec,
 
     /// The command to run in the environment
     pub command: OsString,
@@ -51,20 +51,18 @@ impl CmdRun {
             Some(name) => runtimes.create_named_runtime(name).await?,
             None => runtimes.create_runtime().await?,
         };
-        match self.reference.as_str() {
-            "-" | "" => self.edit = true,
-            reference => {
-                let env_spec = spfs::tracking::EnvSpec::parse(reference)?;
-                let origin = config.get_remote("origin").await?;
-                let synced = self
-                    .sync
-                    .get_syncer(&origin, &repo)
-                    .sync_env(env_spec)
-                    .await?;
-                for item in synced.env.iter() {
-                    let digest = item.resolve_digest(&*repo).await?;
-                    runtime.push_digest(digest);
-                }
+        if self.reference.is_empty() {
+            self.edit = true;
+        } else {
+            let origin = config.get_remote("origin").await?;
+            let synced = self
+                .sync
+                .get_syncer(&origin, &repo)
+                .sync_env(self.reference.clone())
+                .await?;
+            for item in synced.env.iter() {
+                let digest = item.resolve_digest(&*repo).await?;
+                runtime.push_digest(digest);
             }
         }
 

--- a/crates/spfs-cli/main/src/cmd_shell.rs
+++ b/crates/spfs-cli/main/src/cmd_shell.rs
@@ -29,7 +29,7 @@ pub struct CmdShell {
     ///
     /// Use '-' or nothing to request an empty environment
     #[clap(name = "REF")]
-    reference: Option<String>,
+    reference: spfs::tracking::EnvSpec,
 }
 
 impl CmdShell {
@@ -39,7 +39,7 @@ impl CmdShell {
             verbose: self.verbose,
             edit: self.edit,
             name: self.name.clone(),
-            reference: self.reference.clone().unwrap_or_else(|| "".into()),
+            reference: self.reference.clone(),
             command: Default::default(),
             args: Default::default(),
         };

--- a/crates/spfs/src/tracking/env_test.rs
+++ b/crates/spfs/src/tracking/env_test.rs
@@ -14,5 +14,10 @@ fn test_env_spec_validation() {
 
 #[rstest]
 fn test_env_spec_empty() {
-    EnvSpec::parse("").expect_err("empty spec should be invalid");
+    let empty = EnvSpec::parse("").expect("empty spec should be valid");
+    let dash = EnvSpec::parse(super::ENV_SPEC_EMPTY).expect("dash spec should be valid");
+    assert_eq!(
+        empty, dash,
+        "dash and empty string should be an empty spec (for cli parsing)"
+    );
 }

--- a/crates/spfs/src/tracking/mod.rs
+++ b/crates/spfs/src/tracking/mod.rs
@@ -14,7 +14,7 @@ mod tag;
 pub use blob_reader::{BlobRead, BlobReadExt};
 pub use diff::{compute_diff, Diff, DiffMode};
 pub use entry::{Entry, EntryKind};
-pub use env::{EnvSpec, EnvSpecItem, ENV_SPEC_SEPARATOR};
+pub use env::{EnvSpec, EnvSpecItem, ENV_SPEC_EMPTY, ENV_SPEC_SEPARATOR};
 pub use manifest::{
     compute_manifest,
     BlobHasher,

--- a/crates/spk-cli/common/src/flags.rs
+++ b/crates/spk-cli/common/src/flags.rs
@@ -119,7 +119,10 @@ impl Runtime {
             args.push(std::ffi::CString::new("--no-runtime").expect("--no-runtime is valid UTF-8"));
         }
         args.insert(0, std::ffi::CString::new("--").expect("should never fail"));
-        args.insert(0, std::ffi::CString::new("-").expect("should never fail"));
+        args.insert(
+            0,
+            std::ffi::CString::new(spfs::tracking::ENV_SPEC_EMPTY).expect("should never fail"),
+        );
         args.insert(0, std::ffi::CString::new("run").expect("should never fail"));
         args.insert(0, spfs.clone());
 


### PR DESCRIPTION
Some simplification of logic, by allowing the `EnvSpec` to parse from `""` and `"-"` directly. This allows the cli commands to take the type directly, avoiding the parsing altogether.

This has been pulled from the fuse branch, which relies on this logic to make the code for the fuse command simpler in a similar way.