### PR TITLE
Allow for custom shell messages

### DIFF
--- a/crates/spfs/src/bootstrap.rs
+++ b/crates/spfs/src/bootstrap.rs
@@ -16,6 +16,14 @@ mod bootstrap_test;
 /// when launching through certain shells (tcsh).
 const SPFS_ORIGINAL_HOME: &str = "SPFS_ORIGINAL_HOME";
 
+/// The environment variable used to store the message
+/// shown to users when an interactive spfs shell is started
+const SPFS_SHELL_MESSAGE: &str = "SPFS_SHELL_MESSAGE";
+
+/// The default message shows when an interactive
+/// spfs shell is started.
+const SPFS_SHELL_DEFAULT_MESSAGE: &str = "* You are now in a configured subshell *";
+
 /// A command to be executed
 #[derive(Debug, Clone)]
 pub struct Command {
@@ -99,6 +107,10 @@ pub fn build_interactive_shell_command(
     shell: Option<&str>,
 ) -> Result<Command> {
     let shell = find_best_shell(shell)?;
+    let shell_message = (
+        SPFS_SHELL_MESSAGE.into(),
+        std::env::var_os(SPFS_SHELL_MESSAGE).unwrap_or_else(|| SPFS_SHELL_DEFAULT_MESSAGE.into()),
+    );
     match shell {
         Shell::Tcsh(tcsh) => Ok(Command {
             executable: tcsh.into(),
@@ -117,6 +129,7 @@ pub fn build_interactive_shell_command(
                         .as_os_str()
                         .to_owned(),
                 ),
+                shell_message,
             ],
         }),
 
@@ -126,7 +139,7 @@ pub fn build_interactive_shell_command(
                 "--init-file".into(),
                 rt.config.sh_startup_file.as_os_str().to_owned(),
             ],
-            vars: vec![],
+            vars: vec![shell_message],
         }),
     }
 }

--- a/crates/spfs/src/runtime/startup_csh.rs
+++ b/crates/spfs/src/runtime/startup_csh.rs
@@ -53,7 +53,7 @@ if ( "$#argv" != 0 ) then
 endif
 
 # csh cannot echo to stderr, only sh can do that :/
-/bin/sh -c "echo '* You are now in a configured subshell *' 1>&2"
+/bin/sh -c "echo '$SPFS_SHELL_MESSAGE' 1>&2"
 "#
     )
 }

--- a/crates/spfs/src/runtime/startup_sh.rs
+++ b/crates/spfs/src/runtime/startup_sh.rs
@@ -43,7 +43,7 @@ if [ "$#" -ne 0 ]; then
     exit $?
 fi
 
-echo "* You are now in a configured subshell *" 1>&2
+echo "$SPFS_SHELL_MESSAGE" 1>&2
 "#
     )
 }


### PR DESCRIPTION
Now that we are trying to use spfs in all of our shells the "You are now in a configured subshell" is a little bit vague and unhelpful (both because it's not a subshell, nor is it really 'configured' in any meaningful way to the average user)

This change passes the message as an environment variable, and allows it to be overridden before calling spfs.

We've also had a grammatical error in that message for what seems like ever (`an configured` vs `a configured`)