### PR TITLE
Restore Config::csh_expect_file field

### DIFF
--- a/crates/spfs/src/runtime/storage.rs
+++ b/crates/spfs/src/runtime/storage.rs
@@ -114,6 +114,10 @@ pub struct Config {
     pub sh_startup_file: PathBuf,
     /// The location of the startup script for csh-based shells
     pub csh_startup_file: PathBuf,
+    /// The location of the expect utility script used for csh-based shell environments
+    /// [DEPRECATED] This field still exists for spk/spfs interop but is unused
+    #[serde(skip_deserializing, default = "Config::default_csh_expect_file")]
+    pub csh_expect_file: PathBuf,
     /// The name of the mount namespace this runtime is using, if known
     pub mount_namespace: Option<PathBuf>,
 }
@@ -131,6 +135,12 @@ impl Config {
     const WORK_DIR: &'static str = "work";
     const SH_STARTUP_FILE: &'static str = "startup.sh";
     const CSH_STARTUP_FILE: &'static str = ".cshrc";
+    const DEV_NULL: &'static str = "/dev/null";
+
+    /// Return a dummy value for the legacy csh_expect_file field.
+    fn default_csh_expect_file() -> PathBuf {
+        Self::DEV_NULL.into()
+    }
 
     fn from_root<P: Into<PathBuf>>(root: P) -> Self {
         let root = root.into();
@@ -143,6 +153,7 @@ impl Config {
             work_dir: root.join(Self::WORK_DIR),
             sh_startup_file: root.join(Self::SH_STARTUP_FILE),
             csh_startup_file: root.join(Self::CSH_STARTUP_FILE),
+            csh_expect_file: Self::default_csh_expect_file(),
             runtime_dir: Some(root),
             tmpfs_size,
             mount_namespace: None,


### PR DESCRIPTION
For interop between a new build of spk and an old build of spfs, bring this
field back so that when spk serializes this struct this field is present
(but with a dummy value).

spfs builds prior to #700 will fail to create a runtime if this field is
missing.

Mark the field with `serde(skip_deserializing)` so that while this field
is brought back, spfs will no longer _require_ the field be present. This
provides a migration path towards removing this field entirely after all
old installations of spfs have been updated.

At SPI our CI runs the test suite against whatever prod version of the
spfs+spk RPM is installed, rather than using a container like github CI
(for better or worse), so without these changes the test suite fails. We
also like to be able to invite testers to run newer versions of spk before
we dist out a new spfs+spk RPM.

Not all workflows are supported with this change. For example, if a runtime
is created with this change in a post-#700 spk, then using a pre-#700 spfs
build, it is not possible to `spfs join` the runtime:

    "/usr/bin/expect" "/dev/null" "/usr/bin/tcsh" "/tmp/spfs-runtime/startup.csh"

Signed-off-by: J Robert Ray <jrray@jrray.org>