### PR TITLE
Stops 'spfs run' syncing tags

### DIFF
--- a/crates/spfs-cli/main/src/cmd_run.rs
+++ b/crates/spfs-cli/main/src/cmd_run.rs
@@ -63,7 +63,7 @@ impl CmdRun {
             let repos: Vec<_> = vec![&*origin, &*repo];
             let references_to_sync = self
                 .reference
-                .convert_tags_to_underlying_digests(&repos)
+                .with_tag_items_resolved_to_digest_items(&repos)
                 .await?;
             let synced = self
                 .sync


### PR DESCRIPTION
This change stops `spfs run` commands from syncing tag objects to the local repo when setting up the runtime. The tags are replaced by their underlying digest references before syncing begins. This keeps the tags themselves out of the local spfs repo, but still syncs everything else needed for the runtime.