### PR TITLE
Improve error message when spfs-render fails

### DIFF
--- a/crates/spfs/src/error.rs
+++ b/crates/spfs/src/error.rs
@@ -20,9 +20,6 @@ pub enum Error {
     #[error("{0}")]
     #[diagnostic(code("spfs::generic"))]
     String(String),
-    #[error("{0}")]
-    #[diagnostic(code("spfs::generic"))]
-    StringWithSource(String, #[source] Box<dyn std::error::Error + Send + Sync>),
     #[cfg(unix)]
     #[error(transparent)]
     #[diagnostic(code("spfs::generic"))]


### PR DESCRIPTION
Here's what originally gets displayed to the user if a blob object happens to be missing.

    jrray@STRANDED:~/git/spk$ spk env spk-convert-pip
    ERROR Failed to spawn spfs-render

    Caused by:
        process exited with non-zero status
    ERROR Failed to re-mount runtime filesystem

This output is completely lacking any detail about what the problem might be.
The key problem is that spfs-render's stderr output was being captured and
not printed at all, so any extra detail was lost.

This PR starts printing spfs-render's stderr output if spfs-render fails, but goes
further to provide more context, because "Unknown Object: XYZ" alone is
still lacking any context about what that object is.

    jrray@STRANDED:~/git/spk$ spk env spk-convert-pip -- true
    ERROR render layers

    Caused by:
        0: render manifest N3PZ7AUENWBU7XOSOIH36KI4XLUY2KZ3LJQAVR3GEVU47WOO2LIQ====
        1: render manifest into working dir '/spfs-repos/local/renders/jrray/work/980d7dc8-96e1-482b-b474-5bae7730ba5f'
        2: render_into_dir <root node>
        3: render_into_dir 'bin'
        4: render blob 'spk-convert-pip'
        5: open payload
        6: Unknown Object: HZQX6ZMXPVJF724OJEXTL2BUPLQKEGDBRYY5G7OYI4O33ZDF4UYA====
    ERROR Failed to spawn spfs-render

    Caused by:
        process exited with non-zero status
    ERROR Failed to re-mount runtime filesystem