### PR TITLE
Also repair blobs in PayloadFallback

### DIFF
--- a/crates/spfs-cli/cmd-render/src/cmd_render.rs
+++ b/crates/spfs-cli/cmd-render/src/cmd_render.rs
@@ -5,7 +5,7 @@
 use anyhow::Result;
 use clap::Parser;
 use spfs::prelude::*;
-use spfs::storage::payload_fallback::PayloadFallback;
+use spfs::storage::fallback::FallbackProxy;
 use spfs::{Error, RenderResult};
 use spfs_cli_common as cli;
 use spfs_cli_common::CommandName;
@@ -64,14 +64,11 @@ impl CmdRender {
 
         // Use PayloadFallback to repair any missing payloads found in the
         // local repository by copying from any of the configure remotes.
-        let payload_fallback = PayloadFallback::new(repo, remotes);
+        let fallback = FallbackProxy::new(repo, remotes);
 
         let rendered = match &self.target {
-            Some(target) => {
-                self.render_to_dir(payload_fallback, synced.env, target)
-                    .await?
-            }
-            None => self.render_to_repo(payload_fallback, synced.env).await?,
+            Some(target) => self.render_to_dir(fallback, synced.env, target).await?,
+            None => self.render_to_repo(fallback, synced.env).await?,
         };
 
         tracing::debug!("render(s) completed successfully");
@@ -82,7 +79,7 @@ impl CmdRender {
 
     async fn render_to_dir(
         &self,
-        repo: PayloadFallback,
+        repo: FallbackProxy,
         env_spec: spfs::tracking::EnvSpec,
         target: &std::path::Path,
     ) -> Result<RenderResult> {
@@ -130,7 +127,7 @@ impl CmdRender {
 
     async fn render_to_repo(
         &self,
-        repo: PayloadFallback,
+        repo: FallbackProxy,
         env_spec: spfs::tracking::EnvSpec,
     ) -> spfs::Result<RenderResult> {
         let mut digests = Vec::with_capacity(env_spec.len());

--- a/crates/spfs/src/resolve.rs
+++ b/crates/spfs/src/resolve.rs
@@ -343,7 +343,7 @@ where
         storage::RepositoryHandle::FS(r) => resolve_stack_to_layers_with_repo(stack, r).await,
         storage::RepositoryHandle::Tar(r) => resolve_stack_to_layers_with_repo(stack, r).await,
         storage::RepositoryHandle::Rpc(r) => resolve_stack_to_layers_with_repo(stack, r).await,
-        storage::RepositoryHandle::PayloadFallback(r) => {
+        storage::RepositoryHandle::FallbackProxy(r) => {
             resolve_stack_to_layers_with_repo(stack, &**r).await
         }
         storage::RepositoryHandle::Proxy(r) => resolve_stack_to_layers_with_repo(stack, &**r).await,

--- a/crates/spfs/src/storage/fallback/mod.rs
+++ b/crates/spfs/src/storage/fallback/mod.rs
@@ -7,4 +7,4 @@
 //! are only used to fetch missing objects and tags.
 
 mod repository;
-pub use repository::{Config, PayloadFallback};
+pub use repository::{Config, FallbackProxy};

--- a/crates/spfs/src/storage/fallback/repository_test.rs
+++ b/crates/spfs/src/storage/fallback/repository_test.rs
@@ -38,7 +38,7 @@ async fn test_proxy_payload_repair(tmpdir: tempfile::TempDir) {
     assert!(err.is_err());
 
     // Loading the payload through the fallback should succeed.
-    let proxy = super::PayloadFallback::new(primary, vec![secondary.into()]);
+    let proxy = super::FallbackProxy::new(primary, vec![secondary.into()]);
     proxy
         .open_payload(digest)
         .await

--- a/crates/spfs/src/storage/mod.rs
+++ b/crates/spfs/src/storage/mod.rs
@@ -11,8 +11,8 @@ mod repository;
 mod tag;
 
 mod config;
+pub mod fallback;
 pub mod fs;
-pub mod payload_fallback;
 pub mod prelude;
 pub mod proxy;
 pub mod rpc;
@@ -35,7 +35,7 @@ pub enum RepositoryHandle {
     FS(fs::FSRepository),
     Tar(tar::TarRepository),
     Rpc(rpc::RpcRepository),
-    PayloadFallback(Box<payload_fallback::PayloadFallback>),
+    FallbackProxy(Box<fallback::FallbackProxy>),
     Proxy(Box<proxy::ProxyRepository>),
 }
 
@@ -45,7 +45,7 @@ impl RepositoryHandle {
             Self::FS(repo) => Box::new(repo),
             Self::Tar(repo) => Box::new(repo),
             Self::Rpc(repo) => Box::new(repo),
-            Self::PayloadFallback(repo) => repo,
+            Self::FallbackProxy(repo) => repo,
             Self::Proxy(repo) => repo,
         }
     }
@@ -59,7 +59,7 @@ impl std::ops::Deref for RepositoryHandle {
             RepositoryHandle::FS(repo) => repo,
             RepositoryHandle::Tar(repo) => repo,
             RepositoryHandle::Rpc(repo) => repo,
-            RepositoryHandle::PayloadFallback(repo) => &**repo,
+            RepositoryHandle::FallbackProxy(repo) => &**repo,
             RepositoryHandle::Proxy(repo) => &**repo,
         }
     }
@@ -71,7 +71,7 @@ impl std::ops::DerefMut for RepositoryHandle {
             RepositoryHandle::FS(repo) => repo,
             RepositoryHandle::Tar(repo) => repo,
             RepositoryHandle::Rpc(repo) => repo,
-            RepositoryHandle::PayloadFallback(repo) => &mut **repo,
+            RepositoryHandle::FallbackProxy(repo) => &mut **repo,
             RepositoryHandle::Proxy(repo) => &mut **repo,
         }
     }
@@ -92,9 +92,9 @@ impl From<rpc::RpcRepository> for RepositoryHandle {
         RepositoryHandle::Rpc(repo)
     }
 }
-impl From<payload_fallback::PayloadFallback> for RepositoryHandle {
-    fn from(repo: payload_fallback::PayloadFallback) -> Self {
-        RepositoryHandle::PayloadFallback(Box::new(repo))
+impl From<fallback::FallbackProxy> for RepositoryHandle {
+    fn from(repo: fallback::FallbackProxy) -> Self {
+        RepositoryHandle::FallbackProxy(Box::new(repo))
     }
 }
 impl From<proxy::ProxyRepository> for RepositoryHandle {

--- a/crates/spk-cli/cmd-render/src/cmd_render.rs
+++ b/crates/spk-cli/cmd-render/src/cmd_render.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 
 use anyhow::{bail, Context, Result};
 use clap::Args;
-use spfs::storage::payload_fallback::PayloadFallback;
+use spfs::storage::fallback::FallbackProxy;
 use spk_cli_common::{build_required_packages, flags, CommandArgs, Run};
 use spk_exec::resolve_runtime_layers;
 
@@ -94,8 +94,8 @@ impl Run for Render {
                 .render_into_directory(stack, &path, spfs::storage::fs::RenderType::Copy)
                 .await?;
         } else {
-            let payload_fallback = PayloadFallback::new(local, fallback_repository_handles);
-            spfs::storage::fs::Renderer::new(&payload_fallback)
+            let fallback = FallbackProxy::new(local, fallback_repository_handles);
+            spfs::storage::fs::Renderer::new(&fallback)
                 .with_reporter(spfs::storage::fs::ConsoleRenderReporter::default())
                 .render_into_directory(stack, &path, spfs::storage::fs::RenderType::Copy)
                 .await?;

--- a/crates/spk-launcher/src/main.rs
+++ b/crates/spk-launcher/src/main.rs
@@ -12,8 +12,8 @@ use anyhow::{anyhow, bail, Context, Result};
 use nix::unistd::execv;
 use spfs::encoding::Digest;
 use spfs::prelude::*;
+use spfs::storage::fallback::FallbackProxy;
 use spfs::storage::fs::FSRepository;
-use spfs::storage::payload_fallback::PayloadFallback;
 use spfs::storage::RepositoryHandle;
 use spfs::tracking::EnvSpec;
 
@@ -126,9 +126,9 @@ impl<'a> Dynamic<'a> {
             let r = syncer.sync_env(env_spec).await.context("sync reference")?;
             let env_spec = r.env;
 
-            let payload_fallback = PayloadFallback::new(local, vec![remote]);
+            let fallback = FallbackProxy::new(local, vec![remote]);
 
-            spfs::storage::fs::Renderer::new(&payload_fallback)
+            spfs::storage::fs::Renderer::new(&fallback)
                 .with_reporter(spfs::storage::fs::ConsoleRenderReporter::default())
                 .render_into_directory(
                     env_spec,


### PR DESCRIPTION
The question really is should we always run the syncer in a more expensive
mode where it verifies all objects really exist, or do we repair things as
they are discovered in a way that doesn't add any overhead?

A render can fail because of a missing blob object, but we're already using
a PayloadFallback repo and the missing blob is possible to be fetched from
the configured fallback(s). But the syncer has already skipped syncing the
blob because the manifest object already existed. It would be expensive to
verify every child object of a manifest really exists. But we will discover
which blobs are missing as things are rendered.

Now the name PayloadFallback is misleading because it does more than
repair payloads.

Signed-off-by: J Robert Ray <jrray@jrray.org>