### PR TITLE
Add `--check` flag to recover from missing objects

### DIFF
--- a/crates/spk-cli/group3/src/cmd_import_test.rs
+++ b/crates/spk-cli/group3/src/cmd_import_test.rs
@@ -62,8 +62,9 @@ async fn test_archive_io() {
     );
     let result = super::Import {
         sync: spfs_cli_common::Sync {
-            sync: true,
+            sync: false,
             resync: true,
+            check: false,
             max_concurrent_manifests: 10,
             max_concurrent_payloads: 10,
         },


### PR DESCRIPTION
This is not as heavy as --resync which pulls all the data again, but still traverses the entire graph to find and sync items that are not found in the target even if the parents exist.

I am also removing the short `-s` flag for `--sync` because I don't think anyone uses it and I don't think it's a good enough option to take the `-s` flag from other uses - but I can bring that back if there's concern.