### PR TITLE
Fix invalid version numbers in m4 package

### DIFF
--- a/packages/gnu/m4.spk.yaml
+++ b/packages/gnu/m4.spk.yaml
@@ -7,12 +7,12 @@ sources:
 build:
   options:
     - pkg: m4
-    - pkg: automake/1.10b
+    - pkg: automake/1.16
     - pkg: libtool/2.2
     - pkg: gettext/0.16
     - pkg: gperf/3.0
     - pkg: help2man/1.29
-    - pkg: xz/4.999.8beta
+    - pkg: xz/5.2.2
     - pkg: texinfo/4.8
   script:
     - cd m4-1.4.9


### PR DESCRIPTION
@jrray these seem like reasonable values, although I don't think that this package actually gets exercised in any of the build processes that are setup right now so it's not particularly important until that happens

closes #724