### PR TITLE
Add tracing_log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3002,6 +3002,7 @@ dependencies = [
  "strip-ansi-escapes",
  "syslog-tracing",
  "tracing",
+ "tracing-log",
  "tracing-subscriber 0.3.16",
  "whoami",
 ]
@@ -3196,6 +3197,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "tracing-log",
  "tracing-subscriber 0.3.16",
  "whoami",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,5 +55,6 @@ tokio = { version = "1.20", features = ["rt"] }
 tokio-retry = "0.3.0"
 tracing = "0.1.35"
 tracing-capture = "0.1"
+tracing-log = "0.1"
 tracing-subscriber = "0.3.14"
 whoami = "1.2"

--- a/crates/spfs-cli/common/Cargo.toml
+++ b/crates/spfs-cli/common/Cargo.toml
@@ -20,5 +20,6 @@ spfs = { path = "../../spfs" }
 strip-ansi-escapes = { workspace = true, optional = true }
 syslog-tracing = "0.1.0"
 tracing = { workspace = true }
+tracing-log = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 whoami = { workspace = true, optional = true }

--- a/crates/spfs-cli/common/src/args.rs
+++ b/crates/spfs-cli/common/src/args.rs
@@ -393,6 +393,10 @@ pub fn configure_logging(verbosity: usize, syslog: bool) {
 
         tracing::subscriber::set_global_default(sub).unwrap();
     };
+
+    if let Err(err) = tracing_log::LogTracer::init() {
+        tracing::info!("Failed to initialize LogTracer: {err}");
+    }
 }
 
 /// Trait all spfs cli command parsers must implement to provide the

--- a/crates/spk-cli/common/Cargo.toml
+++ b/crates/spk-cli/common/Cargo.toml
@@ -35,6 +35,7 @@ strip-ansi-escapes = { version = "0.1.1", optional = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt"] }
 tracing = { workspace = true }
+tracing-log = { workspace = true }
 tracing-subscriber = { version = "0.3.14", features = ["env-filter"] }
 whoami = { workspace = true }
 

--- a/crates/spk-cli/common/src/env.rs
+++ b/crates/spk-cli/common/src/env.rs
@@ -301,7 +301,13 @@ pub fn configure_logging(verbosity: u32) -> Result<()> {
             )
     };
 
-    tracing::subscriber::set_global_default(sub).context("Failed to set default logger")
+    let r = tracing::subscriber::set_global_default(sub).context("Failed to set default logger");
+
+    if let Err(err) = tracing_log::LogTracer::init() {
+        tracing::info!("Failed to initialize LogTracer: {err}");
+    }
+
+    r
 }
 
 static SPK_EXE: Lazy<&OsStr> = Lazy::new(|| match std::env::var_os("SPK_BIN_PATH") {


### PR DESCRIPTION
This is useful to capture any log messages from third-party crates that use
the `log` ecosystem for logging, e.g., fuser.

Signed-off-by: J Robert Ray <jrray@jrray.org>