### PR TITLE
Fixes for misleading help messages for 'spfs runtime' prune and remove subcommands

### DIFF
--- a/crates/spfs-cli/main/src/cmd_runtime_prune.rs
+++ b/crates/spfs-cli/main/src/cmd_runtime_prune.rs
@@ -7,7 +7,7 @@ use chrono::{Duration, Utc};
 use clap::Args;
 use tokio_stream::StreamExt;
 
-/// List runtime information from the repository
+/// Find and remove runtimes from the repository based on a pruning strategy
 #[derive(Debug, Args)]
 #[clap(visible_alias = "prune")]
 pub struct CmdRuntimePrune {

--- a/crates/spfs-cli/main/src/cmd_runtime_remove.rs
+++ b/crates/spfs-cli/main/src/cmd_runtime_remove.rs
@@ -5,7 +5,7 @@
 use anyhow::Result;
 use clap::Args;
 
-/// List runtime information from the repository
+/// Remove runtimes from the repository
 #[derive(Debug, Args)]
 #[clap(visible_alias = "rm")]
 pub struct CmdRuntimeRemove {


### PR DESCRIPTION
This updates the help message text for `spfs runtime prune` and `spfs runtime remove` commands so the messages match the commands, instead of the `spfs runtime list` command.

