### PR TITLE
Adds a check for an --env-name value and uses it to name spfs runtimes

### DIFF
--- a/crates/spk-cli/common/src/flags.rs
+++ b/crates/spk-cli/common/src/flags.rs
@@ -124,12 +124,15 @@ impl Runtime {
             std::ffi::CString::new(spfs::tracking::ENV_SPEC_EMPTY).expect("should never fail"),
         );
         if let Some(runtime_name) = &self.env_name {
-            // Inject '-n <runtime_name>' so the runtime will be named
+            // Inject '--name <runtime_name>' so the runtime will be named
             args.insert(
                 0,
                 std::ffi::CString::new(runtime_name.clone()).expect("should never fail"),
             );
-            args.insert(0, std::ffi::CString::new("-n").expect("should never fail"));
+            args.insert(
+                0,
+                std::ffi::CString::new("--name").expect("should never fail"),
+            );
         }
         args.insert(0, std::ffi::CString::new("run").expect("should never fail"));
         args.insert(0, spfs.clone());


### PR DESCRIPTION
This makes the `Runtime` struct in flags use its `--env-name / env_name` field. An `env_name` value is checked for, and if one exists it is used name the spfs runtime started by spk. The `--env-name` option existed before this, but wasn't being used. This wires it up to `spfs run`'s `-n name` argument, which allows spfs runtimes to be named from spk commands.