### PR TITLE
Expand on RuntimeConfigurator

### DIFF
--- a/crates/spfs/src/env.rs
+++ b/crates/spfs/src/env.rs
@@ -16,7 +16,7 @@ const NONE: Option<&str> = None;
 
 /// Manages the configuration of an spfs runtime environment.
 ///
-/// Specifically thing like, privilege escalation, mount namspespace,
+/// Specifically thing like, privilege escalation, mount namespace,
 /// filesystem mounts, etc.
 ///
 /// This type is explicitly not [`Send`] and not [`Sync`] because changes


### PR DESCRIPTION
Add another type `ProcessIsInMountNamespace` and add marker traits to facilitate making methods available to both this new type and the original one, now renamed to `ThreadIsInMountNamespace`.

In a roundabout way, fix the bug in `unmount_env` where it was using `tokio::spawn_blocking` inappropriately because it was only constrained to `ThreadIsInMountNamespace`. Now it is constrained to `ProcessIsInMountNamespace` and is free to use `tokio::spawn_blocking`.