### PR TITLE
Rework how packages describe how they contain the components of an embedded package

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -3,3 +3,12 @@ max-fn-params-bools = 1
 
 # default is 7
 too-many-arguments-threshold = 5
+
+ignore-interior-mutability = [
+    # Bytes is the default value for this setting.
+    "bytes::Bytes",
+    # FileMatcher contains a Gitignore field which has interior mutability,
+    # but FileMatcher has a custom hash implementation that skips that field.
+    "spk_schema_foundation::spec_ops::file_matcher::FileMatcher",
+]
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4374,6 +4374,7 @@ dependencies = [
  "itertools 0.12.0",
  "miette",
  "nom",
+ "nom-supreme",
  "proptest",
  "regex",
  "relative-path",

--- a/crates/spk-schema/Cargo.toml
+++ b/crates/spk-schema/Cargo.toml
@@ -29,6 +29,7 @@ indexmap = { workspace = true }
 is_default_derive_macro = { workspace = true }
 itertools = { workspace = true }
 nom = { workspace = true }
+nom-supreme = { workspace = true }
 regex = { workspace = true }
 relative-path = { workspace = true }
 ring = { workspace = true }

--- a/crates/spk-schema/crates/foundation/src/ident_ops/parsing/mod.rs
+++ b/crates/spk-schema/crates/foundation/src/ident_ops/parsing/mod.rs
@@ -26,7 +26,7 @@ mod ident;
 mod request;
 
 pub use ident::{ident_parts, ident_parts_with_components, IdentParts, IdentPartsBuf};
-pub use request::range_ident_pkg_name;
+pub use request::{range_ident_pkg_name, request_pkg_name_and_version};
 
 pub static KNOWN_REPOSITORY_NAMES: Lazy<HashSet<&'static str>> = Lazy::new(|| {
     let mut known_repositories = HashSet::from(["local"]);

--- a/crates/spk-schema/crates/foundation/src/ident_ops/parsing/request.rs
+++ b/crates/spk-schema/crates/foundation/src/ident_ops/parsing/request.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeSet;
 
 use nom::character::complete::char;
 use nom::combinator::{cut, map, opt};
-use nom::error::{ContextError, ParseError};
+use nom::error::{ContextError, FromExternalError, ParseError};
 use nom::sequence::{pair, preceded};
 use nom::IResult;
 use nom_supreme::tag::TagError;
@@ -15,6 +15,8 @@ use crate::ident_component::parsing::components;
 use crate::ident_component::Component;
 use crate::name::parsing::package_name;
 use crate::name::PkgName;
+use crate::version::parsing::version;
+use crate::version::Version;
 
 /// Parse a package name in the context of a range identity.
 ///
@@ -37,5 +39,41 @@ where
             opt(preceded(char(':'), cut(components))),
             |opt_components| opt_components.unwrap_or_default(),
         ),
+    )(input)
+}
+
+/// Parse a package name with optional components and optional version.
+///
+/// The package name must either be followed by a `/` or the end of input.
+///
+/// Examples:
+/// - `"package-name"`
+/// - `"package-name/"`
+/// - `"package-name/1.0.0"`
+/// - `"package-name:comp"`
+/// - `"package-name:{comp1,comp2}/"`
+/// - `"package-name:{comp1,comp2}/1.0.0"`
+pub fn request_pkg_name_and_version<'a, E>(
+    input: &'a str,
+) -> IResult<&'a str, (&PkgName, BTreeSet<Component>, Option<Version>), E>
+where
+    E: ParseError<&'a str>
+        + ContextError<&'a str>
+        + FromExternalError<&'a str, std::num::ParseIntError>
+        + FromExternalError<&'a str, crate::version::Error>
+        + TagError<&'a str, &'static str>,
+{
+    map(
+        pair(
+            package_name,
+            pair(
+                map(
+                    opt(preceded(char(':'), cut(components))),
+                    |opt_components| opt_components.unwrap_or_default(),
+                ),
+                opt(preceded(char('/'), cut(version))),
+            ),
+        ),
+        |(pkg_name, (components, opt_version))| (pkg_name, components, opt_version),
     )(input)
 }

--- a/crates/spk-schema/crates/foundation/src/ident_ops/parsing/request.rs
+++ b/crates/spk-schema/crates/foundation/src/ident_ops/parsing/request.rs
@@ -44,7 +44,8 @@ where
 
 /// Parse a package name with optional components and optional version.
 ///
-/// The package name must either be followed by a `/` or the end of input.
+/// The package name must either be followed by a `/` and a version, or the end
+/// of input.
 ///
 /// Examples:
 /// - `"package-name"`

--- a/crates/spk-schema/crates/foundation/src/version/compat/problems.rs
+++ b/crates/spk-schema/crates/foundation/src/version/compat/problems.rs
@@ -276,6 +276,15 @@ pub enum ComponentsMissingProblem {
         needed: CommaSeparated<BTreeSet<String>>,
         have: CommaSeparated<BTreeSet<String>>,
     },
+    #[strum(
+        to_string = "package {embedder} embeds {embedded} but does not provide all required components: needed {needed}; have {have}"
+    )]
+    EmbeddedComponentsNotProvided {
+        embedder: PkgNameBuf,
+        embedded: PkgNameBuf,
+        needed: CommaSeparated<BTreeSet<String>>,
+        have: CommaSeparated<BTreeSet<String>>,
+    },
 }
 
 impl IsSameReasonAs for ComponentsMissingProblem {

--- a/crates/spk-schema/crates/ident/src/ident_optversion.rs
+++ b/crates/spk-schema/crates/ident/src/ident_optversion.rs
@@ -1,0 +1,106 @@
+// Copyright (c) Sony Pictures Imageworks, et al.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/imageworks/spk
+
+use std::fmt::Write;
+use std::str::FromStr;
+
+use spk_schema_foundation::name::{PkgName, PkgNameBuf};
+use spk_schema_foundation::version::Version;
+
+use crate::{parsing, Ident, Result, VersionIdent};
+
+/// Identifies a package name and number version.
+pub type OptVersionIdent = Ident<PkgNameBuf, Option<Version>>;
+
+impl OptVersionIdent {
+    /// Create a new identifier for the named package and no version.
+    pub fn new_none<N: Into<PkgNameBuf>>(name: N) -> Self {
+        Self {
+            base: name.into(),
+            target: Default::default(),
+        }
+    }
+
+    /// Copy this identifier and add the given version.
+    pub fn to_version(&self, version: Version) -> VersionIdent {
+        VersionIdent {
+            base: self.base.clone(),
+            target: version,
+        }
+    }
+
+    /// Turn this identifier into one for the given version.
+    pub fn into_version(self, version: Version) -> VersionIdent {
+        VersionIdent {
+            base: self.base,
+            target: version,
+        }
+    }
+}
+
+macro_rules! opt_version_ident_methods {
+    ($Ident:ty $(, .$($access:ident).+)?) => {
+        impl $Ident {
+            /// The name of the identified package
+            pub fn name(&self) -> &PkgName {
+                self$(.$($access).+)?.base().as_ref()
+            }
+
+            /// Set the package name of this package identifier
+            pub fn set_name<T: Into<PkgNameBuf>>(&mut self, name: T) {
+                self$(.$($access).+)?.base = name.into();
+            }
+
+            /// Return a copy of this identifier with the given name instead
+            pub fn with_name<T: Into<PkgNameBuf>>(&self, name: T) -> Self {
+                let mut new = self.clone();
+                new$(.$($access).+)?.set_name(name);
+                new
+            }
+        }
+
+        impl spk_schema_foundation::spec_ops::Named for $Ident {
+            fn name(&self) -> &PkgName {
+                self.name()
+            }
+        }
+    };
+}
+
+pub(crate) use opt_version_ident_methods;
+
+opt_version_ident_methods!(OptVersionIdent);
+
+impl std::fmt::Display for OptVersionIdent {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        self.base.fmt(f)?;
+        if let Some(version) = &self.target {
+            f.write_char('/')?;
+            version.fmt(f)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl FromStr for OptVersionIdent {
+    type Err = crate::Error;
+
+    /// Parse the given identifier string into this instance.
+    fn from_str(source: &str) -> Result<Self> {
+        use nom::combinator::all_consuming;
+
+        all_consuming(parsing::opt_version_ident::<nom_supreme::error::ErrorTree<_>>)(source)
+            .map(|(_, ident)| ident)
+            .map_err(|err| match err {
+                nom::Err::Error(e) | nom::Err::Failure(e) => crate::Error::String(e.to_string()),
+                nom::Err::Incomplete(_) => unreachable!(),
+            })
+    }
+}
+
+/// Parse a package identifier string.
+pub fn parse_optversion_ident<S: AsRef<str>>(source: S) -> Result<OptVersionIdent> {
+    Ident::from_str(source.as_ref())
+}

--- a/crates/spk-schema/crates/ident/src/ident_version.rs
+++ b/crates/spk-schema/crates/ident/src/ident_version.rs
@@ -66,38 +66,17 @@ impl AsVersionIdent for VersionIdent {
 
 macro_rules! version_ident_methods {
     ($Ident:ty $(, .$($access:ident).+)?) => {
-        impl $Ident {
-            /// The name of the identified package
-            pub fn name(&self) -> &PkgName {
-                self$(.$($access).+)?.base().as_ref()
-            }
+        $crate::ident_optversion::opt_version_ident_methods!($Ident $(, .$($access).+)?);
 
+        impl $Ident {
             /// The version number identified for this package
             pub fn version(&self) -> &Version {
                 self$(.$($access).+)?.target()
             }
 
-            /// Set the package name of this package identifier
-            pub fn set_name<T: Into<PkgNameBuf>>(&mut self, name: T) {
-                self$(.$($access).+)?.base = name.into();
-            }
-
-            /// Return a copy of this identifier with the given name instead
-            pub fn with_name<T: Into<PkgNameBuf>>(&self, name: T) -> Self {
-                let mut new = self.clone();
-                new$(.$($access).+)?.set_name(name);
-                new
-            }
-
             /// Set the version number of this package identifier
             pub fn set_version(&mut self, version: Version) {
                 self$(.$($access).+)?.target = version;
-            }
-        }
-
-        impl spk_schema_foundation::spec_ops::Named for $Ident {
-            fn name(&self) -> &PkgName {
-                self.name()
             }
         }
 

--- a/crates/spk-schema/crates/ident/src/lib.rs
+++ b/crates/spk-schema/crates/ident/src/lib.rs
@@ -8,6 +8,7 @@ mod ident;
 mod ident_any;
 mod ident_build;
 mod ident_located;
+mod ident_optversion;
 mod ident_version;
 pub mod parsing;
 mod range_ident;
@@ -19,6 +20,7 @@ pub use ident::{AsVersionIdent, Ident};
 pub use ident_any::{parse_ident, AnyIdent, ToAnyIdentWithoutBuild};
 pub use ident_build::{parse_build_ident, BuildIdent};
 pub use ident_located::{LocatedBuildIdent, LocatedVersionIdent};
+pub use ident_optversion::{parse_optversion_ident, OptVersionIdent};
 pub use ident_version::{parse_version_ident, VersionIdent};
 pub use range_ident::{parse_ident_range, parse_ident_range_list, RangeIdent};
 pub use request::{

--- a/crates/spk-schema/crates/ident/src/parsing/ident.rs
+++ b/crates/spk-schema/crates/ident/src/parsing/ident.rs
@@ -12,7 +12,7 @@ use spk_schema_foundation::ident_ops::parsing::{version_and_build, version_and_r
 use spk_schema_foundation::name::parsing::package_name;
 use spk_schema_foundation::version::parsing::version;
 
-use crate::{AnyIdent, BuildIdent, VersionIdent};
+use crate::{AnyIdent, BuildIdent, OptVersionIdent, VersionIdent};
 
 /// Parse a package identity into an [`AnyIdent`].
 ///
@@ -41,6 +41,26 @@ where
         }
         None => Ok((input, ident)),
     }
+}
+
+/// Parse a package identity into a [`OptVersionIdent`].
+///
+/// Examples:
+/// - `"pkg-name"`
+/// - `"pkg-name/1.0"`
+pub fn opt_version_ident<'b, E>(input: &'b str) -> IResult<&'b str, OptVersionIdent, E>
+where
+    E: ParseError<&'b str>
+        + ContextError<&'b str>
+        + FromExternalError<&'b str, crate::error::Error>
+        + FromExternalError<&'b str, spk_schema_foundation::ident_build::Error>
+        + FromExternalError<&'b str, spk_schema_foundation::version::Error>
+        + FromExternalError<&'b str, std::num::ParseIntError>
+        + TagError<&'b str, &'static str>,
+{
+    let (input, ident) = package_ident(input)?;
+    let (input, v) = opt(preceded(char('/'), version))(input)?;
+    Ok((input, OptVersionIdent::new(ident.base, v)))
 }
 
 /// Parse a package identity into a [`VersionIdent`].

--- a/crates/spk-schema/crates/ident/src/parsing/mod.rs
+++ b/crates/spk-schema/crates/ident/src/parsing/mod.rs
@@ -9,7 +9,7 @@ mod request;
 #[path = "./parsing_test.rs"]
 mod parsing_test;
 
-pub use ident::{build_ident, ident, version_ident};
+pub use ident::{build_ident, ident, opt_version_ident, version_ident};
 pub use request::{
     range_ident,
     range_ident_comma_separated_list,

--- a/crates/spk-schema/src/component_embedded_packages.rs
+++ b/crates/spk-schema/src/component_embedded_packages.rs
@@ -10,13 +10,19 @@ use spk_schema_foundation::ident_component::{Component, Components};
 use spk_schema_foundation::ident_ops::parsing::request_pkg_name_and_version;
 use spk_schema_ident::OptVersionIdent;
 
+/// A struct describing a package that is embedded within a component of a
+/// host package.
+///
+/// A component of a host package may embed another package but only contain
+/// some of the files of the embedded package. This struct describes the
+/// identity of the embedded package and the components that are embedded.
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct EmbeddedComponents {
+pub struct ComponentEmbeddedPackage {
     pub pkg: OptVersionIdent,
     pub components: BTreeSet<Component>,
 }
 
-impl std::fmt::Display for EmbeddedComponents {
+impl std::fmt::Display for ComponentEmbeddedPackage {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         self.pkg.name().fmt(f)?;
         self.components.fmt_component_set(f)?;
@@ -28,7 +34,7 @@ impl std::fmt::Display for EmbeddedComponents {
     }
 }
 
-impl<'de> Deserialize<'de> for EmbeddedComponents {
+impl<'de> Deserialize<'de> for ComponentEmbeddedPackage {
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -36,7 +42,7 @@ impl<'de> Deserialize<'de> for EmbeddedComponents {
         struct EmbeddedComponentsVisitor;
 
         impl<'de> serde::de::Visitor<'de> for EmbeddedComponentsVisitor {
-            type Value = EmbeddedComponents;
+            type Value = ComponentEmbeddedPackage;
 
             fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
                 f.write_str("an embedded components")
@@ -64,7 +70,7 @@ impl<'de> Deserialize<'de> for EmbeddedComponents {
     }
 }
 
-impl Serialize for EmbeddedComponents {
+impl Serialize for ComponentEmbeddedPackage {
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -73,16 +79,16 @@ impl Serialize for EmbeddedComponents {
     }
 }
 
-/// A set of packages that are embedded/provided by another.
+/// A set of packages that are embedded within a component.
 #[derive(Clone, Debug, Default, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 #[serde(transparent)]
-pub struct EmbeddedComponentsList {
-    components: Vec<EmbeddedComponents>,
+pub struct ComponentEmbeddedPackagesList {
+    components: Vec<ComponentEmbeddedPackage>,
     #[serde(skip)]
     fabricated: bool,
 }
 
-impl EmbeddedComponentsList {
+impl ComponentEmbeddedPackagesList {
     /// Return if the list was fabricated by defaults.
     #[inline]
     pub fn is_fabricated(&self) -> bool {
@@ -96,22 +102,22 @@ impl EmbeddedComponentsList {
     }
 }
 
-impl std::ops::Deref for EmbeddedComponentsList {
-    type Target = Vec<EmbeddedComponents>;
+impl std::ops::Deref for ComponentEmbeddedPackagesList {
+    type Target = Vec<ComponentEmbeddedPackage>;
     fn deref(&self) -> &Self::Target {
         &self.components
     }
 }
 
-impl std::ops::DerefMut for EmbeddedComponentsList {
+impl std::ops::DerefMut for ComponentEmbeddedPackagesList {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.components
     }
 }
 
-impl<I> From<I> for EmbeddedComponentsList
+impl<I> From<I> for ComponentEmbeddedPackagesList
 where
-    I: IntoIterator<Item = EmbeddedComponents>,
+    I: IntoIterator<Item = ComponentEmbeddedPackage>,
 {
     fn from(items: I) -> Self {
         Self {

--- a/crates/spk-schema/src/component_spec.rs
+++ b/crates/spk-schema/src/component_spec.rs
@@ -37,9 +37,9 @@ pub struct ComponentSpec {
     pub requirements: super::RequirementsList,
     #[serde(
         default,
-        skip_serializing_if = "super::EmbeddedComponentsList::is_fabricated"
+        skip_serializing_if = "super::ComponentEmbeddedPackagesList::is_fabricated"
     )]
-    pub embedded_components: super::EmbeddedComponentsList,
+    pub embedded_packages: super::ComponentEmbeddedPackagesList,
     #[serde(default)]
     pub file_match_mode: ComponentFileMatchMode,
 }
@@ -55,7 +55,7 @@ impl ComponentSpec {
             uses: Default::default(),
             files: Default::default(),
             requirements: Default::default(),
-            embedded_components: Default::default(),
+            embedded_packages: Default::default(),
             file_match_mode: Default::default(),
         })
     }
@@ -68,7 +68,7 @@ impl ComponentSpec {
             uses: Default::default(),
             files: FileMatcher::all(),
             requirements: Default::default(),
-            embedded_components: Default::default(),
+            embedded_packages: Default::default(),
             file_match_mode: Default::default(),
         }
     }
@@ -81,7 +81,7 @@ impl ComponentSpec {
             uses: Default::default(),
             files: FileMatcher::all(),
             requirements: Default::default(),
-            embedded_components: Default::default(),
+            embedded_packages: Default::default(),
             file_match_mode: Default::default(),
         }
     }

--- a/crates/spk-schema/src/component_spec.rs
+++ b/crates/spk-schema/src/component_spec.rs
@@ -35,7 +35,10 @@ pub struct ComponentSpec {
     pub uses: Vec<Component>,
     #[serde(default)]
     pub requirements: super::RequirementsList,
-    #[serde(default)]
+    #[serde(
+        default,
+        skip_serializing_if = "super::EmbeddedComponentsList::is_fabricated"
+    )]
     pub embedded_components: super::EmbeddedComponentsList,
     #[serde(default)]
     pub file_match_mode: ComponentFileMatchMode,

--- a/crates/spk-schema/src/component_spec.rs
+++ b/crates/spk-schema/src/component_spec.rs
@@ -39,7 +39,8 @@ pub struct ComponentSpec {
         default,
         skip_serializing_if = "super::ComponentEmbeddedPackagesList::is_fabricated"
     )]
-    pub embedded_packages: super::ComponentEmbeddedPackagesList,
+    pub embedded: super::ComponentEmbeddedPackagesList,
+
     #[serde(default)]
     pub file_match_mode: ComponentFileMatchMode,
 }
@@ -55,7 +56,7 @@ impl ComponentSpec {
             uses: Default::default(),
             files: Default::default(),
             requirements: Default::default(),
-            embedded_packages: Default::default(),
+            embedded: Default::default(),
             file_match_mode: Default::default(),
         })
     }
@@ -68,7 +69,7 @@ impl ComponentSpec {
             uses: Default::default(),
             files: FileMatcher::all(),
             requirements: Default::default(),
-            embedded_packages: Default::default(),
+            embedded: Default::default(),
             file_match_mode: Default::default(),
         }
     }
@@ -81,7 +82,7 @@ impl ComponentSpec {
             uses: Default::default(),
             files: FileMatcher::all(),
             requirements: Default::default(),
-            embedded_packages: Default::default(),
+            embedded: Default::default(),
             file_match_mode: Default::default(),
         }
     }

--- a/crates/spk-schema/src/component_spec.rs
+++ b/crates/spk-schema/src/component_spec.rs
@@ -36,7 +36,7 @@ pub struct ComponentSpec {
     #[serde(default)]
     pub requirements: super::RequirementsList,
     #[serde(default)]
-    pub embedded: super::EmbeddedPackagesList,
+    pub embedded_components: super::EmbeddedComponentsList,
     #[serde(default)]
     pub file_match_mode: ComponentFileMatchMode,
 }
@@ -52,7 +52,7 @@ impl ComponentSpec {
             uses: Default::default(),
             files: Default::default(),
             requirements: Default::default(),
-            embedded: Default::default(),
+            embedded_components: Default::default(),
             file_match_mode: Default::default(),
         })
     }
@@ -65,7 +65,7 @@ impl ComponentSpec {
             uses: Default::default(),
             files: FileMatcher::all(),
             requirements: Default::default(),
-            embedded: Default::default(),
+            embedded_components: Default::default(),
             file_match_mode: Default::default(),
         }
     }
@@ -78,7 +78,7 @@ impl ComponentSpec {
             uses: Default::default(),
             files: FileMatcher::all(),
             requirements: Default::default(),
-            embedded: Default::default(),
+            embedded_components: Default::default(),
             file_match_mode: Default::default(),
         }
     }

--- a/crates/spk-schema/src/embedded_components_list.rs
+++ b/crates/spk-schema/src/embedded_components_list.rs
@@ -85,3 +85,12 @@ impl std::ops::DerefMut for EmbeddedComponentsList {
         &mut self.0
     }
 }
+
+impl<I> From<I> for EmbeddedComponentsList
+where
+    I: IntoIterator<Item = EmbeddedComponents>,
+{
+    fn from(items: I) -> Self {
+        Self(items.into_iter().collect())
+    }
+}

--- a/crates/spk-schema/src/embedded_components_list.rs
+++ b/crates/spk-schema/src/embedded_components_list.rs
@@ -1,0 +1,87 @@
+// Copyright (c) Sony Pictures Imageworks, et al.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/imageworks/spk
+
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+use spk_schema_foundation::ident_component::{Component, Components};
+use spk_schema_foundation::ident_ops::parsing::range_ident_pkg_name;
+use spk_schema_foundation::name::PkgNameBuf;
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct EmbeddedComponents {
+    pub name: PkgNameBuf,
+    pub components: BTreeSet<Component>,
+}
+
+impl std::fmt::Display for EmbeddedComponents {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        self.name.fmt(f)?;
+        self.components.fmt_component_set(f)?;
+        Ok(())
+    }
+}
+
+impl<'de> Deserialize<'de> for EmbeddedComponents {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct EmbeddedComponentsVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for EmbeddedComponentsVisitor {
+            type Value = EmbeddedComponents;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("an embedded components")
+            }
+
+            fn visit_str<E>(self, v: &str) -> std::result::Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                range_ident_pkg_name::<nom_supreme::error::ErrorTree<_>>(v)
+                    .map(|(_, (name, components))| Self::Value {
+                        name: name.to_owned(),
+                        components,
+                    })
+                    .map_err(|err| match err {
+                        nom::Err::Error(e) | nom::Err::Failure(e) => {
+                            serde::de::Error::custom(e.to_string())
+                        }
+                        nom::Err::Incomplete(_) => unreachable!(),
+                    })
+            }
+        }
+
+        deserializer.deserialize_str(EmbeddedComponentsVisitor)
+    }
+}
+
+impl Serialize for EmbeddedComponents {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&format!("{self}"))
+    }
+}
+
+/// A set of packages that are embedded/provided by another.
+#[derive(Clone, Debug, Default, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(transparent)]
+pub struct EmbeddedComponentsList(Vec<EmbeddedComponents>);
+
+impl std::ops::Deref for EmbeddedComponentsList {
+    type Target = Vec<EmbeddedComponents>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for EmbeddedComponentsList {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}

--- a/crates/spk-schema/src/embedded_components_list.rs
+++ b/crates/spk-schema/src/embedded_components_list.rs
@@ -71,18 +71,36 @@ impl Serialize for EmbeddedComponents {
 /// A set of packages that are embedded/provided by another.
 #[derive(Clone, Debug, Default, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 #[serde(transparent)]
-pub struct EmbeddedComponentsList(Vec<EmbeddedComponents>);
+pub struct EmbeddedComponentsList {
+    components: Vec<EmbeddedComponents>,
+    #[serde(skip)]
+    fabricated: bool,
+}
+
+impl EmbeddedComponentsList {
+    /// Return if the list was fabricated by defaults.
+    #[inline]
+    pub fn is_fabricated(&self) -> bool {
+        self.fabricated
+    }
+
+    /// Mark this list as having been fabricated by defaults.
+    #[inline]
+    pub fn set_fabricated(&mut self) {
+        self.fabricated = true;
+    }
+}
 
 impl std::ops::Deref for EmbeddedComponentsList {
     type Target = Vec<EmbeddedComponents>;
     fn deref(&self) -> &Self::Target {
-        &self.0
+        &self.components
     }
 }
 
 impl std::ops::DerefMut for EmbeddedComponentsList {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+        &mut self.components
     }
 }
 
@@ -91,6 +109,9 @@ where
     I: IntoIterator<Item = EmbeddedComponents>,
 {
     fn from(items: I) -> Self {
-        Self(items.into_iter().collect())
+        Self {
+            components: items.into_iter().collect(),
+            fabricated: false,
+        }
     }
 }

--- a/crates/spk-schema/src/embedded_packages_list.rs
+++ b/crates/spk-schema/src/embedded_packages_list.rs
@@ -4,11 +4,14 @@
 
 use serde::{Deserialize, Serialize};
 use spk_schema_foundation::ident_build::EmbeddedSource;
+use spk_schema_foundation::spec_ops::Named;
 use spk_schema_foundation::IsDefault;
 use spk_schema_ident::AnyIdent;
 
 use super::{BuildSpec, InstallSpec, Spec};
+use crate::embedded_components_list::EmbeddedComponents;
 use crate::foundation::ident_build::Build;
+use crate::Package;
 
 #[cfg(test)]
 #[path = "./embedded_packages_list_test.rs"]
@@ -18,6 +21,26 @@ mod embedded_packages_list_test;
 #[derive(Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 #[serde(transparent)]
 pub struct EmbeddedPackagesList(Vec<Spec>);
+
+impl EmbeddedPackagesList {
+    /// Return an iterator over the embedded packages that match the given
+    /// embedded component.
+    pub fn packages_matching_embedded_component<'a, 'b, 'c>(
+        &'a self,
+        embedded_component: &'b EmbeddedComponents,
+    ) -> impl Iterator<Item = &'a Spec> + 'c
+    where
+        'a: 'c,
+        'b: 'c,
+    {
+        self.iter().filter(move |embedded| {
+            embedded.name() == embedded_component.pkg.name()
+                && (embedded_component.pkg.target().is_none()
+                    || embedded.ident().version()
+                        == embedded_component.pkg.target().as_ref().unwrap())
+        })
+    }
+}
 
 impl IsDefault for EmbeddedPackagesList {
     fn is_default(&self) -> bool {

--- a/crates/spk-schema/src/embedded_packages_list.rs
+++ b/crates/spk-schema/src/embedded_packages_list.rs
@@ -9,7 +9,7 @@ use spk_schema_foundation::IsDefault;
 use spk_schema_ident::AnyIdent;
 
 use super::{BuildSpec, InstallSpec, Spec};
-use crate::embedded_components_list::EmbeddedComponents;
+use crate::component_embedded_packages::ComponentEmbeddedPackage;
 use crate::foundation::ident_build::Build;
 use crate::Package;
 
@@ -25,19 +25,19 @@ pub struct EmbeddedPackagesList(Vec<Spec>);
 impl EmbeddedPackagesList {
     /// Return an iterator over the embedded packages that match the given
     /// embedded component.
-    pub fn packages_matching_embedded_component<'a, 'b, 'c>(
+    pub fn packages_matching_embedded_package<'a, 'b, 'c>(
         &'a self,
-        embedded_component: &'b EmbeddedComponents,
+        embedded_package: &'b ComponentEmbeddedPackage,
     ) -> impl Iterator<Item = &'a Spec> + 'c
     where
         'a: 'c,
         'b: 'c,
     {
         self.iter().filter(move |embedded| {
-            embedded.name() == embedded_component.pkg.name()
-                && (embedded_component.pkg.target().is_none()
+            embedded.name() == embedded_package.pkg.name()
+                && (embedded_package.pkg.target().is_none()
                     || embedded.ident().version()
-                        == embedded_component.pkg.target().as_ref().unwrap())
+                        == embedded_package.pkg.target().as_ref().unwrap())
         })
     }
 }

--- a/crates/spk-schema/src/install_spec.rs
+++ b/crates/spk-schema/src/install_spec.rs
@@ -105,6 +105,7 @@ impl From<RawInstallSpec> for InstallSpec {
                     }
                 })
                 .into();
+            component.embedded_components.set_fabricated();
         }
 
         install

--- a/crates/spk-schema/src/install_spec.rs
+++ b/crates/spk-schema/src/install_spec.rs
@@ -87,7 +87,7 @@ impl From<RawInstallSpec> for InstallSpec {
 
         // Expand any use of "all" in the defined embedded components.
         for component in install.components.iter_mut() {
-            'embedded_package: for embedded_package in component.embedded_packages.iter_mut() {
+            'embedded_package: for embedded_package in component.embedded.iter_mut() {
                 // Also expand if no components were explicitly specified.
                 if !(embedded_package.components.is_empty()
                     || embedded_package.components.remove(&Component::All))
@@ -136,13 +136,12 @@ impl From<RawInstallSpec> for InstallSpec {
             }
         }
 
-        // Populate any missing components.embedded_packages with default
-        // values.
+        // Populate any missing components.embedded with default values.
         for component in install.components.iter_mut() {
-            if !component.embedded_packages.is_empty() {
+            if !component.embedded.is_empty() {
                 continue;
             }
-            component.embedded_packages = install
+            component.embedded = install
                 .embedded
                 .iter()
                 .filter_map(|embedded| {
@@ -156,7 +155,7 @@ impl From<RawInstallSpec> for InstallSpec {
                     }
                 })
                 .into();
-            component.embedded_packages.set_fabricated();
+            component.embedded.set_fabricated();
         }
 
         install

--- a/crates/spk-schema/src/install_spec.rs
+++ b/crates/spk-schema/src/install_spec.rs
@@ -81,7 +81,10 @@ impl From<RawInstallSpec> for InstallSpec {
         for component in install.components.iter_mut() {
             'embedded_component: for embedded_component in component.embedded_components.iter_mut()
             {
-                if !embedded_component.components.remove(&Component::All) {
+                // Also expand if no components were explicitly specified.
+                if !(embedded_component.components.is_empty()
+                    || embedded_component.components.remove(&Component::All))
+                {
                     continue;
                 }
 

--- a/crates/spk-schema/src/install_spec_test.rs
+++ b/crates/spk-schema/src/install_spec_test.rs
@@ -8,7 +8,7 @@ use spk_schema_foundation::option_map::OptionMap;
 use spk_schema_foundation::version::BINARY_STR;
 use spk_schema_ident::{parse_ident_range, PkgRequest, Request, RequestedBy};
 
-use crate::{InstallSpec, RequirementsList};
+use crate::{InstallSpec, Package, RequirementsList};
 
 #[rstest]
 fn test_render_all_pins_renders_requirements_in_components() {
@@ -61,4 +61,39 @@ fn test_render_all_pins_renders_requirements_in_components() {
         panic!("Expected a Pkg request");
     };
     assert_eq!(req.to_string(), "test/Binary:1.2.3");
+}
+
+#[rstest]
+fn test_embedded_components_defaults() {
+    // By default, embedded components will embed matching components from the
+    // defined embedded packages.
+    let install = serde_yaml::from_str::<InstallSpec>(
+        r#"
+embedded:
+  - pkg: "embedded/1.0.0"
+        "#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        install.components.len(),
+        2,
+        "expecting two default components: build and run"
+    );
+
+    assert_eq!(install.embedded.len(), 1, "expecting one embedded package");
+
+    assert_eq!(
+        install.embedded[0].components().len(),
+        2,
+        "expecting two default components: build and run"
+    );
+
+    for component in install.components.iter() {
+        assert_eq!(
+            component.embedded_components.len(),
+            1,
+            "expecting each host component to embed one component"
+        );
+    }
 }

--- a/crates/spk-schema/src/install_spec_test.rs
+++ b/crates/spk-schema/src/install_spec_test.rs
@@ -95,5 +95,26 @@ embedded:
             1,
             "expecting each host component to embed one component"
         );
+
+        assert_eq!(
+            component.embedded_components[0].name, "embedded",
+            "expecting the embedded package name to be correct"
+        );
+
+        assert_eq!(
+            component.embedded_components[0].components.len(),
+            1,
+            "expecting the build and run components to get mapped 1:1"
+        );
+
+        assert_eq!(
+            *component.embedded_components[0]
+                .components
+                .iter()
+                .next()
+                .unwrap(),
+            component.name,
+            "expecting the component names to agree"
+        );
     }
 }

--- a/crates/spk-schema/src/install_spec_test.rs
+++ b/crates/spk-schema/src/install_spec_test.rs
@@ -94,25 +94,25 @@ embedded:
 
     for component in install.components.iter() {
         assert_eq!(
-            component.embedded_components.len(),
+            component.embedded_packages.len(),
             1,
             "expecting each host component to embed one component"
         );
 
         assert_eq!(
-            component.embedded_components[0].pkg.name(),
+            component.embedded_packages[0].pkg.name(),
             "embedded",
             "expecting the embedded package name to be correct"
         );
 
         assert_eq!(
-            component.embedded_components[0].components.len(),
+            component.embedded_packages[0].components.len(),
             1,
             "expecting the build and run components to get mapped 1:1"
         );
 
         assert_eq!(
-            *component.embedded_components[0]
+            *component.embedded_packages[0]
                 .components
                 .iter()
                 .next()
@@ -157,25 +157,25 @@ embedded:
 
     for component in install.components.iter() {
         assert_eq!(
-            component.embedded_components.len(),
+            component.embedded_packages.len(),
             1,
             "expecting each host component to embed one component"
         );
 
         assert_eq!(
-            component.embedded_components[0].pkg.name(),
+            component.embedded_packages[0].pkg.name(),
             "embedded",
             "expecting the embedded package name to be correct"
         );
 
         assert_eq!(
-            component.embedded_components[0].components.len(),
+            component.embedded_packages[0].components.len(),
             1,
             "expecting all the host package's components to get mapped 1:1"
         );
 
         assert_eq!(
-            *component.embedded_components[0]
+            *component.embedded_packages[0]
                 .components
                 .iter()
                 .next()
@@ -210,19 +210,19 @@ fn test_embedding_multiple_versions_of_the_same_package(
         r#"
 components:
   - name: comp1
-    embedded_components:
+    embedded_packages:
       - embedded:all/1.0.0
   - name: comp2
-    embedded_components:
+    embedded_packages:
       - embedded:all/2.0.0
   - name: v3-with-all
-    embedded_components:
+    embedded_packages:
       - embedded:all/3.0.0
   - name: v3-with-components-elided
-    embedded_components:
+    embedded_packages:
       - embedded/3.0.0
   - name: v3-with-subset-of-components
-    embedded_components:
+    embedded_packages:
       - embedded:{aa,bb}/3.0.0
 embedded:
   - pkg: "embedded/1.0.0"
@@ -272,13 +272,13 @@ embedded:
         .unwrap();
 
     assert_eq!(
-        comp.embedded_components.len(),
+        comp.embedded_packages.len(),
         1,
         "expecting one embedded package"
     );
 
     assert_eq!(
-        comp.embedded_components[0].pkg.target(),
+        comp.embedded_packages[0].pkg.target(),
         &Some(Version::from_str(expected_component_version).unwrap()),
         "expecting the embedded package version to be correct"
     );
@@ -288,11 +288,11 @@ embedded:
             .iter()
             .cloned()
             .collect::<HashSet<_>>(),
-        comp.embedded_components[0]
+        comp.embedded_packages[0]
             .components
             .iter()
             .map(|c| c.as_str())
             .collect::<HashSet<_>>(),
-        "expecting embedded_components to be expanded correctly"
+        "expecting embedded_packages to be expanded correctly"
     );
 }

--- a/crates/spk-schema/src/install_spec_test.rs
+++ b/crates/spk-schema/src/install_spec_test.rs
@@ -94,29 +94,25 @@ embedded:
 
     for component in install.components.iter() {
         assert_eq!(
-            component.embedded_packages.len(),
+            component.embedded.len(),
             1,
             "expecting each host component to embed one component"
         );
 
         assert_eq!(
-            component.embedded_packages[0].pkg.name(),
+            component.embedded[0].pkg.name(),
             "embedded",
             "expecting the embedded package name to be correct"
         );
 
         assert_eq!(
-            component.embedded_packages[0].components.len(),
+            component.embedded[0].components.len(),
             1,
             "expecting the build and run components to get mapped 1:1"
         );
 
         assert_eq!(
-            *component.embedded_packages[0]
-                .components
-                .iter()
-                .next()
-                .unwrap(),
+            *component.embedded[0].components.iter().next().unwrap(),
             component.name,
             "expecting the component names to agree"
         );
@@ -157,29 +153,25 @@ embedded:
 
     for component in install.components.iter() {
         assert_eq!(
-            component.embedded_packages.len(),
+            component.embedded.len(),
             1,
             "expecting each host component to embed one component"
         );
 
         assert_eq!(
-            component.embedded_packages[0].pkg.name(),
+            component.embedded[0].pkg.name(),
             "embedded",
             "expecting the embedded package name to be correct"
         );
 
         assert_eq!(
-            component.embedded_packages[0].components.len(),
+            component.embedded[0].components.len(),
             1,
             "expecting all the host package's components to get mapped 1:1"
         );
 
         assert_eq!(
-            *component.embedded_packages[0]
-                .components
-                .iter()
-                .next()
-                .unwrap(),
+            *component.embedded[0].components.iter().next().unwrap(),
             component.name,
             "expecting the component names to agree"
         );
@@ -210,19 +202,19 @@ fn test_embedding_multiple_versions_of_the_same_package(
         r#"
 components:
   - name: comp1
-    embedded_packages:
+    embedded:
       - embedded:all/1.0.0
   - name: comp2
-    embedded_packages:
+    embedded:
       - embedded:all/2.0.0
   - name: v3-with-all
-    embedded_packages:
+    embedded:
       - embedded:all/3.0.0
   - name: v3-with-components-elided
-    embedded_packages:
+    embedded:
       - embedded/3.0.0
   - name: v3-with-subset-of-components
-    embedded_packages:
+    embedded:
       - embedded:{aa,bb}/3.0.0
 embedded:
   - pkg: "embedded/1.0.0"
@@ -271,14 +263,10 @@ embedded:
         .find(|c| c.name.as_str() == component_name)
         .unwrap();
 
-    assert_eq!(
-        comp.embedded_packages.len(),
-        1,
-        "expecting one embedded package"
-    );
+    assert_eq!(comp.embedded.len(), 1, "expecting one embedded package");
 
     assert_eq!(
-        comp.embedded_packages[0].pkg.target(),
+        comp.embedded[0].pkg.target(),
         &Some(Version::from_str(expected_component_version).unwrap()),
         "expecting the embedded package version to be correct"
     );
@@ -288,11 +276,11 @@ embedded:
             .iter()
             .cloned()
             .collect::<HashSet<_>>(),
-        comp.embedded_packages[0]
+        comp.embedded[0]
             .components
             .iter()
             .map(|c| c.as_str())
             .collect::<HashSet<_>>(),
-        "expecting embedded_packages to be expanded correctly"
+        "expecting embedded to be expanded correctly"
     );
 }

--- a/crates/spk-schema/src/install_spec_test.rs
+++ b/crates/spk-schema/src/install_spec_test.rs
@@ -106,13 +106,13 @@ embedded:
         );
 
         assert_eq!(
-            component.embedded[0].components.len(),
+            component.embedded[0].components().len(),
             1,
             "expecting the build and run components to get mapped 1:1"
         );
 
         assert_eq!(
-            *component.embedded[0].components.iter().next().unwrap(),
+            *component.embedded[0].components().iter().next().unwrap(),
             component.name,
             "expecting the component names to agree"
         );
@@ -165,13 +165,13 @@ embedded:
         );
 
         assert_eq!(
-            component.embedded[0].components.len(),
+            component.embedded[0].components().len(),
             1,
             "expecting all the host package's components to get mapped 1:1"
         );
 
         assert_eq!(
-            *component.embedded[0].components.iter().next().unwrap(),
+            *component.embedded[0].components().iter().next().unwrap(),
             component.name,
             "expecting the component names to agree"
         );
@@ -188,7 +188,6 @@ embedded:
 #[case::comp1("comp1", "1.0.0", &["build", "run"])]
 #[case::comp2("comp2", "2.0.0", &["build", "run"])]
 #[case::v3_with_all("v3-with-all", "3.0.0", &["build", "run", "aa", "bb", "cc"])]
-#[case::v3_with_components_elided("v3-with-components-elided", "3.0.0", &["build", "run", "aa", "bb", "cc"])]
 #[case::v3_with_subset_of_components("v3-with-subset-of-components", "3.0.0", &["aa", "bb"])]
 fn test_embedding_multiple_versions_of_the_same_package(
     #[case] component_name: &str,
@@ -210,9 +209,6 @@ components:
   - name: v3-with-all
     embedded:
       - embedded:all/3.0.0
-  - name: v3-with-components-elided
-    embedded:
-      - embedded/3.0.0
   - name: v3-with-subset-of-components
     embedded:
       - embedded:{aa,bb}/3.0.0
@@ -277,7 +273,7 @@ embedded:
             .cloned()
             .collect::<HashSet<_>>(),
         comp.embedded[0]
-            .components
+            .components()
             .iter()
             .map(|c| c.as_str())
             .collect::<HashSet<_>>(),

--- a/crates/spk-schema/src/lib.rs
+++ b/crates/spk-schema/src/lib.rs
@@ -3,10 +3,10 @@
 // https://github.com/spkenv/spk
 
 mod build_spec;
+mod component_embedded_packages;
 mod component_spec;
 mod component_spec_list;
 mod deprecate;
-mod embedded_components_list;
 mod embedded_packages_list;
 mod environ;
 mod error;
@@ -27,10 +27,10 @@ pub mod validation;
 pub mod variant;
 
 pub use build_spec::{BuildSpec, Script};
+pub use component_embedded_packages::ComponentEmbeddedPackagesList;
 pub use component_spec::{ComponentFileMatchMode, ComponentSpec};
 pub use component_spec_list::ComponentSpecList;
 pub use deprecate::{Deprecate, DeprecateMut};
-pub use embedded_components_list::EmbeddedComponentsList;
 pub use embedded_packages_list::EmbeddedPackagesList;
 pub use environ::{
     AppendEnv,

--- a/crates/spk-schema/src/lib.rs
+++ b/crates/spk-schema/src/lib.rs
@@ -6,6 +6,7 @@ mod build_spec;
 mod component_spec;
 mod component_spec_list;
 mod deprecate;
+mod embedded_components_list;
 mod embedded_packages_list;
 mod environ;
 mod error;
@@ -29,6 +30,7 @@ pub use build_spec::{BuildSpec, Script};
 pub use component_spec::{ComponentFileMatchMode, ComponentSpec};
 pub use component_spec_list::ComponentSpecList;
 pub use deprecate::{Deprecate, DeprecateMut};
+pub use embedded_components_list::EmbeddedComponentsList;
 pub use embedded_packages_list::EmbeddedPackagesList;
 pub use environ::{
     AppendEnv,

--- a/crates/spk-schema/src/v0/spec.rs
+++ b/crates/spk-schema/src/v0/spec.rs
@@ -145,7 +145,7 @@ impl<Ident> Spec<Ident> {
             files: Default::default(),
             uses: Default::default(),
             requirements: Default::default(),
-            embedded_components: Default::default(),
+            embedded_packages: Default::default(),
             file_match_mode: Default::default(),
         });
     }

--- a/crates/spk-schema/src/v0/spec.rs
+++ b/crates/spk-schema/src/v0/spec.rs
@@ -145,7 +145,7 @@ impl<Ident> Spec<Ident> {
             files: Default::default(),
             uses: Default::default(),
             requirements: Default::default(),
-            embedded: Default::default(),
+            embedded_components: Default::default(),
             file_match_mode: Default::default(),
         });
     }
@@ -281,13 +281,7 @@ impl Package for Spec<BuildIdent> {
         self.install
             .embedded
             .iter()
-            .map(|embed| (embed.clone(), None))
-            .chain(self.install.components.iter().flat_map(|cs| {
-                cs.embedded
-                    .iter()
-                    .map(move |embed| (embed.clone(), Some(cs.name.clone())))
-            }))
-            .map(|(recipe, component)| recipe.try_into().map(|r| (r, component)))
+            .map(|embed| embed.clone().try_into().map(|r| (r, None)))
             .collect()
     }
 

--- a/crates/spk-schema/src/v0/spec.rs
+++ b/crates/spk-schema/src/v0/spec.rs
@@ -145,7 +145,7 @@ impl<Ident> Spec<Ident> {
             files: Default::default(),
             uses: Default::default(),
             requirements: Default::default(),
-            embedded_packages: Default::default(),
+            embedded: Default::default(),
             file_match_mode: Default::default(),
         });
     }

--- a/crates/spk-solve/crates/graph/src/graph.rs
+++ b/crates/spk-solve/crates/graph/src/graph.rs
@@ -487,12 +487,9 @@ impl<'state, 'cmpt> DecisionBuilder<'state, 'cmpt> {
                     // TODO: It should be validated elsewhere that
                     // component.embedded_components only refers to valid
                     // packages declared in embedded.
-
-                    for embedded in embedded.iter() {
-                        if embedded.name() != embedded_component.pkg.name() {
-                            continue;
-                        }
-
+                    for embedded in
+                        embedded.packages_matching_embedded_component(embedded_component)
+                    {
                         (*merged_changes.entry(embedded).or_insert(BTreeSet::new()))
                             .extend(embedded_component.components.iter().cloned());
                     }

--- a/crates/spk-solve/crates/graph/src/graph.rs
+++ b/crates/spk-solve/crates/graph/src/graph.rs
@@ -166,7 +166,7 @@ impl FormatChange for Change {
                                         vec![RequestedBy::PackageVersion(recipe.ident().clone())
                                             .to_string()]
                                     }
-                                    PackageSource::Embedded { parent } => {
+                                    PackageSource::Embedded { parent, .. } => {
                                         vec![RequestedBy::Embedded(parent.clone()).to_string()]
                                     }
                                     _ => {
@@ -283,7 +283,11 @@ impl<'state, 'cmpt> DecisionBuilder<'state, 'cmpt> {
             changes
                 .extend(self.requirements_to_changes(&spec.runtime_requirements(), &requested_by));
             changes.extend(self.components_to_changes(spec.components(), requester_ident));
-            changes.extend(self.embedded_to_changes(spec.embedded(), requester_ident));
+            changes.extend(self.embedded_to_changes(
+                spec.embedded(),
+                spec.components(),
+                requester_ident,
+            ));
             changes.push(Self::options_to_change(spec));
 
             Ok(changes)
@@ -306,7 +310,11 @@ impl<'state, 'cmpt> DecisionBuilder<'state, 'cmpt> {
         let requested_by = RequestedBy::PackageBuild(requester_ident.clone());
         changes.extend(self.requirements_to_changes(&spec.runtime_requirements(), &requested_by));
         changes.extend(self.components_to_changes(spec.components(), requester_ident));
-        changes.extend(self.embedded_to_changes(spec.embedded(), requester_ident));
+        changes.extend(self.embedded_to_changes(
+            spec.embedded(),
+            spec.components(),
+            requester_ident,
+        ));
         changes.push(Self::options_to_change(&spec));
 
         changes
@@ -436,8 +444,61 @@ impl<'state, 'cmpt> DecisionBuilder<'state, 'cmpt> {
     fn embedded_to_changes(
         &self,
         embedded: &EmbeddedPackagesList,
+        components: &ComponentSpecList,
         parent: &BuildIdent,
     ) -> Vec<Change> {
+        let required = components.resolve_uses(self.components.iter().cloned());
+        if !required.is_empty() {
+            let mut merged_changes = HashMap::new();
+            for component in components.iter() {
+                if !required.contains(&component.name) {
+                    continue;
+                }
+                for embedded_component in component.embedded_components.iter() {
+                    // TODO: It should be validated elsewhere that
+                    // component.embedded_components only refers to valid
+                    // packages declared in embedded.
+
+                    for embedded in embedded.iter() {
+                        if embedded.name() != embedded_component.name {
+                            continue;
+                        }
+
+                        (*merged_changes.entry(embedded).or_insert(BTreeSet::new()))
+                            .extend(embedded_component.components.iter().cloned());
+                    }
+                }
+            }
+            if !merged_changes.is_empty() {
+                let mut changes = Vec::new();
+
+                for (spec, components) in merged_changes.into_iter() {
+                    let components_as_hashset = components.iter().cloned().collect();
+
+                    changes.push({
+                        let mut req_pkg = RequestPackage::new(PkgRequest::from_ident(
+                            spec.ident().to_any_ident(),
+                            RequestedBy::Embedded(parent.clone()),
+                        ));
+                        req_pkg.request.pkg.components = components;
+                        Change::RequestPackage(req_pkg)
+                    });
+
+                    changes.extend(self.set_package(
+                        Arc::new((*spec).clone()),
+                        PackageSource::Embedded {
+                            parent: parent.clone(),
+                            components: components_as_hashset,
+                        },
+                    ));
+                }
+
+                return changes;
+            }
+        }
+
+        // Fallback behavior: add all embedded packages.
+
         embedded
             .iter()
             .flat_map(|embedded| {
@@ -451,6 +512,7 @@ impl<'state, 'cmpt> DecisionBuilder<'state, 'cmpt> {
                     Arc::new(embedded.clone()),
                     PackageSource::Embedded {
                         parent: parent.clone(),
+                        components: Default::default(),
                     },
                 ));
                 changes

--- a/crates/spk-solve/crates/graph/src/graph.rs
+++ b/crates/spk-solve/crates/graph/src/graph.rs
@@ -483,15 +483,13 @@ impl<'state, 'cmpt> DecisionBuilder<'state, 'cmpt> {
                 if !required.contains(&component.name) {
                     continue;
                 }
-                for embedded_component in component.embedded_components.iter() {
+                for embedded_package in component.embedded_packages.iter() {
                     // TODO: It should be validated elsewhere that
-                    // component.embedded_components only refers to valid
+                    // component.embedded_packages only refers to valid
                     // packages declared in embedded.
-                    for embedded in
-                        embedded.packages_matching_embedded_component(embedded_component)
-                    {
+                    for embedded in embedded.packages_matching_embedded_package(embedded_package) {
                         (*merged_changes.entry(embedded).or_insert(BTreeSet::new()))
-                            .extend(embedded_component.components.iter().cloned());
+                            .extend(embedded_package.components.iter().cloned());
                     }
                 }
             }

--- a/crates/spk-solve/crates/graph/src/graph.rs
+++ b/crates/spk-solve/crates/graph/src/graph.rs
@@ -489,7 +489,7 @@ impl<'state, 'cmpt> DecisionBuilder<'state, 'cmpt> {
                     // packages declared in embedded.
                     for embedded in embedded.packages_matching_embedded_package(embedded_package) {
                         (*merged_changes.entry(embedded).or_insert(BTreeSet::new()))
-                            .extend(embedded_package.components.iter().cloned());
+                            .extend(embedded_package.components().iter().cloned());
                     }
                 }
             }

--- a/crates/spk-solve/crates/graph/src/graph.rs
+++ b/crates/spk-solve/crates/graph/src/graph.rs
@@ -383,7 +383,6 @@ impl<'state, 'cmpt> DecisionBuilder<'state, 'cmpt> {
                 continue;
             }
             changes.extend(self.requirements_to_changes(&component.requirements, &requested_by));
-            changes.extend(self.embedded_to_changes(&component.embedded, requester));
         }
         changes
     }

--- a/crates/spk-solve/crates/graph/src/graph.rs
+++ b/crates/spk-solve/crates/graph/src/graph.rs
@@ -356,6 +356,35 @@ impl<'state, 'cmpt> DecisionBuilder<'state, 'cmpt> {
         }
     }
 
+    /// Make this package the next request to be considered.
+    pub fn reconsider_package_with_additional_components(
+        self,
+        request: PkgRequest,
+        package_with_unsatisfied_components: &PkgName,
+        counter: Arc<AtomicU64>,
+    ) -> Decision {
+        let generate_changes = || {
+            let changes = vec![
+                Change::StepBack(StepBack::new(
+                    format!(
+                        "Package {package_with_unsatisfied_components} needs additional components from {}",
+                        request.pkg.name
+                    ),
+                    self.base,
+                    counter,
+                )),
+                Change::RequestPackage(RequestPackage::prioritize(request)),
+            ];
+
+            changes
+        };
+
+        Decision {
+            changes: generate_changes(),
+            notes: Vec::default(),
+        }
+    }
+
     fn requirements_to_changes(
         &self,
         requirements: &RequirementsList,

--- a/crates/spk-solve/crates/graph/src/graph.rs
+++ b/crates/spk-solve/crates/graph/src/graph.rs
@@ -489,7 +489,7 @@ impl<'state, 'cmpt> DecisionBuilder<'state, 'cmpt> {
                     // packages declared in embedded.
 
                     for embedded in embedded.iter() {
-                        if embedded.name() != embedded_component.name {
+                        if embedded.name() != embedded_component.pkg.name() {
                             continue;
                         }
 

--- a/crates/spk-solve/crates/graph/src/graph.rs
+++ b/crates/spk-solve/crates/graph/src/graph.rs
@@ -483,7 +483,7 @@ impl<'state, 'cmpt> DecisionBuilder<'state, 'cmpt> {
                 if !required.contains(&component.name) {
                     continue;
                 }
-                for embedded_package in component.embedded_packages.iter() {
+                for embedded_package in component.embedded.iter() {
                     // TODO: It should be validated elsewhere that
                     // component.embedded_packages only refers to valid
                     // packages declared in embedded.

--- a/crates/spk-solve/crates/solution/src/solution.rs
+++ b/crates/spk-solve/crates/solution/src/solution.rs
@@ -50,7 +50,10 @@ pub enum PackageSource {
         recipe: Arc<SpecRecipe>,
     },
     /// The package was embedded in another.
-    Embedded { parent: BuildIdent },
+    Embedded {
+        parent: BuildIdent,
+        components: HashSet<Component>,
+    },
     /// Only for a package being used in spk' automated (unit) test code
     /// when the source of the package is not relevant for the test.
     SpkInternalTest,
@@ -144,10 +147,11 @@ impl SolvedRequest {
             .map(ToOwned::to_owned)
             .collect();
 
-        let mut repo_name: Option<RepositoryNameBuf> = None;
-        if let PackageSource::Repository { repo, .. } = &self.source {
-            repo_name = Some(repo.name().to_owned());
-        }
+        let repo_name = if let PackageSource::Repository { repo, .. } = &self.source {
+            Some(repo.name().to_owned())
+        } else {
+            None
+        };
 
         // Pass zero verbosity to format_request(), via the format
         // change options, to stop it outputting the internal details.

--- a/crates/spk-solve/crates/validation/src/validators/components.rs
+++ b/crates/spk-solve/crates/validation/src/validators/components.rs
@@ -103,7 +103,7 @@ impl ComponentsValidator {
         let available_components: std::collections::HashSet<_> = match source {
             PackageSource::Repository { components, .. } => components.keys().collect(),
             PackageSource::BuildFromSource { .. } => package.components().names(),
-            PackageSource::Embedded { .. } => package.components().names(),
+            PackageSource::Embedded { components, .. } => components.iter().collect(),
             PackageSource::SpkInternalTest => package.components().names(),
         };
 

--- a/crates/spk-solve/crates/validation/src/validators/components.rs
+++ b/crates/spk-solve/crates/validation/src/validators/components.rs
@@ -7,7 +7,6 @@ use std::collections::BTreeSet;
 use spk_schema::version::{CommaSeparated, ComponentsMissingProblem, IncompatibleReason};
 
 use super::prelude::*;
-use crate::validators::EmbeddedPackageValidator;
 use crate::ValidatorT;
 
 /// Ensures that all of the requested components are available.
@@ -38,24 +37,6 @@ impl ValidatorT for ComponentsValidator {
             return Ok(Compatibility::Incompatible(reason));
         }
 
-        let required_components = spec
-            .components()
-            .resolve_uses(request.pkg.components.iter());
-
-        for component in spec.components().iter() {
-            if !required_components.contains(&component.name) {
-                continue;
-            }
-
-            for embedded in component.embedded.iter() {
-                let compat = EmbeddedPackageValidator::validate_embedded_package_against_state(
-                    spec, embedded, state,
-                )?;
-                if !&compat {
-                    return Ok(compat);
-                }
-            }
-        }
         Ok(Compatible)
     }
 

--- a/crates/spk-solve/crates/validation/src/validators/components.rs
+++ b/crates/spk-solve/crates/validation/src/validators/components.rs
@@ -7,6 +7,7 @@ use std::collections::BTreeSet;
 use spk_schema::version::{CommaSeparated, ComponentsMissingProblem, IncompatibleReason};
 
 use super::prelude::*;
+use crate::validators::EmbeddedPackageValidator;
 use crate::ValidatorT;
 
 /// Ensures that all of the requested components are available.
@@ -37,7 +38,9 @@ impl ValidatorT for ComponentsValidator {
             return Ok(Compatibility::Incompatible(reason));
         }
 
-        Ok(Compatible)
+        EmbeddedPackageValidator::validate_embedded_packages_in_required_components(
+            spec, &request, state,
+        )
     }
 
     fn validate_recipe<R: Recipe>(

--- a/crates/spk-solve/crates/validation/src/validators/embedded_package.rs
+++ b/crates/spk-solve/crates/validation/src/validators/embedded_package.rs
@@ -50,7 +50,7 @@ impl EmbeddedPackageValidator {
     {
         use Compatibility::Compatible;
 
-        // There may not be a "real" instance of the embedded package in the
+        // There must not be a "real" instance of the embedded package in the
         // solve already.
         if let Some((existing, _, _)) = state.get_resolved_packages().get(embedded.name()) {
             // If found, it must be the stub of the package now being embedded

--- a/crates/spk-solve/crates/validation/src/validators/embedded_package.rs
+++ b/crates/spk-solve/crates/validation/src/validators/embedded_package.rs
@@ -20,10 +20,37 @@ impl ValidatorT for EmbeddedPackageValidator {
     where
         P: Package,
     {
-        for embedded in spec.embedded().iter() {
-            let compat = Self::validate_embedded_package_against_state(spec, embedded, state)?;
-            if !&compat {
-                return Ok(compat);
+        // Only the embedded packages that are active based on the components
+        // being requested from this spec are checked. There may be
+        // incompatibilities with other embedded packages that are not active
+        // but that shouldn't block this spec from being valid.
+        let request = state.get_merged_request(spec.name())?;
+
+        // XXX: Can `request.pkg.components` be empty? What would that mean?
+        debug_assert!(
+            !request.pkg.components.is_empty(),
+            "empty request.pkg.components not handled"
+        );
+
+        let requesting_all = request.pkg.components.contains(&Component::All);
+
+        for component in spec.components().iter() {
+            // If the component is not active, skip it.
+            if !(requesting_all || request.pkg.components.contains(&component.name)) {
+                continue;
+            }
+
+            for embedded_component in component.embedded_components.iter() {
+                for embedded in spec
+                    .embedded()
+                    .packages_matching_embedded_component(embedded_component)
+                {
+                    let compat =
+                        Self::validate_embedded_package_against_state(spec, embedded, state)?;
+                    if !&compat {
+                        return Ok(compat);
+                    }
+                }
             }
         }
 

--- a/crates/spk-solve/crates/validation/src/validators/embedded_package.rs
+++ b/crates/spk-solve/crates/validation/src/validators/embedded_package.rs
@@ -107,10 +107,10 @@ impl EmbeddedPackageValidator {
                 continue;
             }
 
-            for embedded_component in component.embedded_components.iter() {
+            for embedded_package in component.embedded_packages.iter() {
                 for embedded in spec
                     .embedded()
-                    .packages_matching_embedded_component(embedded_component)
+                    .packages_matching_embedded_package(embedded_package)
                 {
                     let compat =
                         Self::validate_embedded_package_against_state(spec, embedded, state)?;

--- a/crates/spk-solve/crates/validation/src/validators/embedded_package.rs
+++ b/crates/spk-solve/crates/validation/src/validators/embedded_package.rs
@@ -107,7 +107,7 @@ impl EmbeddedPackageValidator {
                 continue;
             }
 
-            for embedded_package in component.embedded_packages.iter() {
+            for embedded_package in component.embedded.iter() {
                 for embedded in spec
                     .embedded()
                     .packages_matching_embedded_package(embedded_package)

--- a/crates/spk-solve/crates/validation/src/validators/embedded_package.rs
+++ b/crates/spk-solve/crates/validation/src/validators/embedded_package.rs
@@ -32,29 +32,7 @@ impl ValidatorT for EmbeddedPackageValidator {
             "empty request.pkg.components not handled"
         );
 
-        let requesting_all = request.pkg.components.contains(&Component::All);
-
-        for component in spec.components().iter() {
-            // If the component is not active, skip it.
-            if !(requesting_all || request.pkg.components.contains(&component.name)) {
-                continue;
-            }
-
-            for embedded_component in component.embedded_components.iter() {
-                for embedded in spec
-                    .embedded()
-                    .packages_matching_embedded_component(embedded_component)
-                {
-                    let compat =
-                        Self::validate_embedded_package_against_state(spec, embedded, state)?;
-                    if !&compat {
-                        return Ok(compat);
-                    }
-                }
-            }
-        }
-
-        Ok(Compatibility::Compatible)
+        Self::validate_embedded_packages_in_required_components(spec, &request, state)
     }
 
     fn validate_recipe<R: Recipe>(
@@ -106,5 +84,43 @@ impl EmbeddedPackageValidator {
             ));
         }
         Ok(Compatible)
+    }
+
+    /// Validate that any embedded packages that are present in any of the
+    /// components requested by the given request are compatible with the
+    /// current state.
+    pub(super) fn validate_embedded_packages_in_required_components<P>(
+        spec: &P,
+        request: &PkgRequest,
+        state: &State,
+    ) -> crate::Result<Compatibility>
+    where
+        P: Package,
+    {
+        let required_components = spec
+            .components()
+            .resolve_uses(request.pkg.components.iter());
+
+        for component in spec.components().iter() {
+            // If the component is not active, skip it.
+            if !required_components.contains(&component.name) {
+                continue;
+            }
+
+            for embedded_component in component.embedded_components.iter() {
+                for embedded in spec
+                    .embedded()
+                    .packages_matching_embedded_component(embedded_component)
+                {
+                    let compat =
+                        Self::validate_embedded_package_against_state(spec, embedded, state)?;
+                    if !&compat {
+                        return Ok(compat);
+                    }
+                }
+            }
+        }
+
+        Ok(Compatibility::Compatible)
     }
 }

--- a/crates/spk-solve/crates/validation/src/validators/pkg_request.rs
+++ b/crates/spk-solve/crates/validation/src/validators/pkg_request.rs
@@ -95,7 +95,7 @@ impl ValidatorT for PkgRequestValidator {
                     ));
                 }
                 PackageSource::Repository { .. } => {} // okay
-                PackageSource::Embedded { parent } => {
+                PackageSource::Embedded { parent, .. } => {
                     // TODO: from the right repo still?
                     return Ok(Compatibility::Incompatible(
                         IncompatibleReason::PackageRepoMismatch(

--- a/crates/spk-solve/crates/validation/src/validators/pkg_requirements.rs
+++ b/crates/spk-solve/crates/validation/src/validators/pkg_requirements.rs
@@ -138,7 +138,7 @@ impl PkgRequirementsValidator {
             if !required_components.contains(&component.name) {
                 continue;
             }
-            for embedded_package in component.embedded_packages.iter() {
+            for embedded_package in component.embedded.iter() {
                 for embedded in resolved
                     .embedded()
                     .packages_matching_embedded_package(embedded_package)

--- a/crates/spk-solve/crates/validation/src/validators/pkg_requirements.rs
+++ b/crates/spk-solve/crates/validation/src/validators/pkg_requirements.rs
@@ -138,10 +138,10 @@ impl PkgRequirementsValidator {
             if !required_components.contains(&component.name) {
                 continue;
             }
-            for embedded_component in component.embedded_components.iter() {
+            for embedded_package in component.embedded_packages.iter() {
                 for embedded in resolved
                     .embedded()
-                    .packages_matching_embedded_component(embedded_component)
+                    .packages_matching_embedded_package(embedded_package)
                 {
                     let compat = EmbeddedPackageValidator::validate_embedded_package_against_state(
                         &**resolved,

--- a/crates/spk-solve/crates/validation/src/validators/pkg_requirements.rs
+++ b/crates/spk-solve/crates/validation/src/validators/pkg_requirements.rs
@@ -78,9 +78,10 @@ impl PkgRequirementsValidator {
         let (resolved, provided_components) = match state.get_current_resolve(&request.pkg.name) {
             Ok((spec, source, _)) => match source {
                 PackageSource::Repository { components, .. } => (spec, components.keys().collect()),
-                PackageSource::BuildFromSource { .. }
-                | PackageSource::Embedded { .. }
-                | PackageSource::SpkInternalTest => (spec, spec.components().names()),
+                PackageSource::Embedded { components, .. } => (spec, components.iter().collect()),
+                PackageSource::BuildFromSource { .. } | PackageSource::SpkInternalTest => {
+                    (spec, spec.components().names())
+                }
             },
             Err(spk_solve_graph::GetCurrentResolveError::PackageNotResolved(_)) => {
                 return Ok(Compatible)

--- a/crates/spk-solve/src/solver.rs
+++ b/crates/spk-solve/src/solver.rs
@@ -743,15 +743,13 @@ impl Solver {
                                             .collect();
                                     let mut components_to_request = BTreeSet::new();
                                     for component in parent_spec.components().iter() {
-                                        for embedded_component in
-                                            component.embedded_components.iter()
-                                        {
-                                            if embedded_component.pkg.name() != embedded {
+                                        for embedded_package in component.embedded_packages.iter() {
+                                            if embedded_package.pkg.name() != embedded {
                                                 continue;
                                             }
 
                                             let overlapping: Vec<_> = remaining_missing_components
-                                                .intersection(&embedded_component.components)
+                                                .intersection(&embedded_package.components)
                                                 .collect();
                                             if overlapping.is_empty() {
                                                 continue;

--- a/crates/spk-solve/src/solver.rs
+++ b/crates/spk-solve/src/solver.rs
@@ -743,7 +743,7 @@ impl Solver {
                                             .collect();
                                     let mut components_to_request = BTreeSet::new();
                                     for component in parent_spec.components().iter() {
-                                        for embedded_package in component.embedded_packages.iter() {
+                                        for embedded_package in component.embedded.iter() {
                                             if embedded_package.pkg.name() != embedded {
                                                 continue;
                                             }

--- a/crates/spk-solve/src/solver.rs
+++ b/crates/spk-solve/src/solver.rs
@@ -657,7 +657,7 @@ impl Solver {
                                         spec.ident().to_any_ident(),
                                         Compatibility::Incompatible({
                                             match conflicting_pkg_source {
-                                                PackageSource::Embedded { parent } => {
+                                                PackageSource::Embedded { parent, .. } => {
                                                     IncompatibleReason::AlreadyEmbeddedPackage {
                                                         embedded: conflicting_package_name,
                                                         embedded_by: parent.name().to_owned(),

--- a/crates/spk-solve/src/solver.rs
+++ b/crates/spk-solve/src/solver.rs
@@ -749,7 +749,7 @@ impl Solver {
                                             }
 
                                             let overlapping: Vec<_> = remaining_missing_components
-                                                .intersection(&embedded_package.components)
+                                                .intersection(embedded_package.components())
                                                 .collect();
                                             if overlapping.is_empty() {
                                                 continue;

--- a/crates/spk-solve/src/solver.rs
+++ b/crates/spk-solve/src/solver.rs
@@ -746,7 +746,7 @@ impl Solver {
                                         for embedded_component in
                                             component.embedded_components.iter()
                                         {
-                                            if embedded_component.name != embedded {
+                                            if embedded_component.pkg.name() != embedded {
                                                 continue;
                                             }
 

--- a/crates/spk-solve/src/solver_test.rs
+++ b/crates/spk-solve/src/solver_test.rs
@@ -2393,8 +2393,8 @@ async fn test_solver_component_embedded_multiple_versions(
                 "pkg": "mypkg/1.0.0",
                 "install": {
                     "components": [
-                        {"name": "build", "embedded_packages": ["dep-e1:all/1.0.0"]},
-                        {"name": "run", "embedded_packages": ["dep-e1:all/2.0.0"]},
+                        {"name": "build", "embedded": ["dep-e1:all/1.0.0"]},
+                        {"name": "run", "embedded": ["dep-e1:all/2.0.0"]},
                     ],
                     "embedded": [
                         {"pkg": "dep-e1/1.0.0"},

--- a/crates/spk-solve/src/solver_test.rs
+++ b/crates/spk-solve/src/solver_test.rs
@@ -460,6 +460,50 @@ async fn test_solver_dependency_already_satisfied(mut solver: Solver) {
 
 #[rstest]
 #[tokio::test]
+async fn test_solver_dependency_already_satisfied_conflicting_components(mut solver: Solver) {
+    // like test_solver_dependency_already_satisfied but with conflicting components
+
+    let repo = make_repo!(
+        [
+            {
+                "pkg": "pkg-top/1.0.0",
+                "install": {
+                    "requirements": [{"pkg": "dep-1:comp1/~1.0.0"}, {"pkg": "dep-2/1"}]
+                },
+            },
+            {
+                "pkg": "dep-1/1.0.0",
+                "install": {
+                    "components": [
+                        {"name": "comp1", "embedded_packages": ["em-1/1.0.0"]},
+                        {"name": "comp2", "embedded_packages": ["em-1/2.0.0"]},
+                    ],
+                    "embedded": [
+                        {"pkg": "em-1/1.0.0"},
+                        {"pkg": "em-1/2.0.0"},
+                    ],
+                },
+            },
+            // when dep_2 gets resolved, it will re-request this but comp2 conflicts with comp1
+            {"pkg": "dep-2/1.0.0", "install": {"requirements": [{"pkg": "dep-1:comp2/1"}]}},
+        ]
+    );
+    solver.add_repository(Arc::new(repo));
+    solver.add_request(request!("pkg-top"));
+
+    // XXX: This test provides coverage for the
+    // "requires {}:{} which embeds {}" incompatibility check inside
+    // PkgRequirementsValidator::validate_request_against_existing_state.
+    // How can this test code verify that the solver is actually hitting
+    // that code path?
+
+    run_and_print_resolve_for_tests(&solver)
+        .await
+        .expect_err("solve should fail");
+}
+
+#[rstest]
+#[tokio::test]
 async fn test_solver_dependency_reopen_solvable(mut solver: Solver) {
     // test what happens when a dependency is added which represents
     // a package which has already been resolved
@@ -2399,6 +2443,44 @@ async fn test_solver_component_embedded_multiple_versions(
             assert!(!expected_solve_result, "expected solve to succeed");
         }
     }
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_solver_component_embedded_incompatible_requests(mut solver: Solver) {
+    // test when different components of a package embedded packages that
+    // make incompatible requests
+
+    let repo = make_repo!(
+        [
+            {
+                "pkg": "mypkg/1.0.0",
+                "install": {
+                    "components": [
+                        {"name": "comp1"},
+                        {"name": "comp2"},
+                    ],
+                    "embedded": [
+                        {"pkg": "dep-e1/1.0.0",
+                         "install": {"components": [
+                                        {"name": "comp1", "requirements": [{"pkg": "dep-e2/1.0.0"}]},
+                                        {"name": "comp2", "requirements": [{"pkg": "dep-e2/2.0.0"}]}
+                                    ]}
+                        },
+                    ],
+                },
+            },
+        ]
+    );
+    let repo = Arc::new(repo);
+
+    solver.add_repository(repo);
+    solver.add_request(request!("mypkg:comp1"));
+    solver.add_request(request!("mypkg:comp2"));
+
+    run_and_print_resolve_for_tests(&solver)
+        .await
+        .expect_err("expected solve to fail");
 }
 
 #[rstest]

--- a/crates/spk-solve/src/solver_test.rs
+++ b/crates/spk-solve/src/solver_test.rs
@@ -1881,13 +1881,13 @@ async fn test_solver_components_interaction_with_embeds(mut solver: Solver) {
                     "components": [
                         {
                             "name": "comp1",
-                            "embedded_components": [
+                            "embedded_packages": [
                                 "real-pkg:comp1",
                             ]
                         },
                         {
                             "name": "comp2",
-                            "embedded_components": [
+                            "embedded_packages": [
                                 "real-pkg:comp2",
                             ]
                         },
@@ -2221,8 +2221,8 @@ async fn test_solver_component_embedded(mut solver: Solver) {
                 "pkg": "mypkg/1.0.0",
                 "install": {
                     "components": [
-                        {"name": "build", "embedded_components": ["dep-e1:all"]},
-                        {"name": "run", "embedded_components": ["dep-e2:all"]},
+                        {"name": "build", "embedded_packages": ["dep-e1:all"]},
+                        {"name": "run", "embedded_packages": ["dep-e2:all"]},
                     ],
                     "embedded": [
                         {"pkg": "dep-e1/1.0.0"},
@@ -2349,8 +2349,8 @@ async fn test_solver_component_embedded_multiple_versions(
                 "pkg": "mypkg/1.0.0",
                 "install": {
                     "components": [
-                        {"name": "build", "embedded_components": ["dep-e1:all/1.0.0"]},
-                        {"name": "run", "embedded_components": ["dep-e1:all/2.0.0"]},
+                        {"name": "build", "embedded_packages": ["dep-e1:all/1.0.0"]},
+                        {"name": "run", "embedded_packages": ["dep-e1:all/2.0.0"]},
                     ],
                     "embedded": [
                         {"pkg": "dep-e1/1.0.0"},

--- a/cspell.json
+++ b/cspell.json
@@ -477,6 +477,7 @@
     "openvdb",
     "optix",
     "optruleset",
+    "optversion",
     "orld",
     "oslbatch",
     "oslcudatarget",

--- a/cspell.json
+++ b/cspell.json
@@ -186,6 +186,7 @@
     "EJATZPB",
     "elif",
     "ello",
+    "embedder",
     "EMLINK",
     "ENDL",
     "endmacro",

--- a/cspell.json
+++ b/cspell.json
@@ -268,6 +268,7 @@
     "hasattr",
     "hashable",
     "hashalgo",
+    "hashset",
     "Hasher",
     "helmignore",
     "HFSBQEYR",

--- a/cspell.json
+++ b/cspell.json
@@ -87,6 +87,7 @@
     "colour",
     "compat",
     "Compat",
+    "compn",
     "coreutils",
     "CORNIC",
     "couldnotsatisfy",

--- a/docs/ref/spec.md
+++ b/docs/ref/spec.md
@@ -287,9 +287,9 @@ The component spec defines a single component of a package. Components can be in
 
 #### ComponentEmbeddedPackagesSpec
 
-| Value | Description                                                                                                                                                                                                                                                                      |
-| ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| _str_ | A package and component(s), with optional version, in the form of either `pkg-name:comp-name[/version]` or `pkg-name:{comp1,comp2,...,compn}[/version]`, referring to an embedded package and its component(s) defined in the `embedded` section of [InstallSpec](#installspec). |
+| Value | Description                                                                                                                                                                                                                                                                                                          |
+| ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| _str_ | A package and component(s), with optional version, in the form of either `pkg-name:comp-name[/version]` or `pkg-name:{comp1,comp2,...,compn}[/version]`, referring to an embedded package and its component(s) defined in the `embedded` section of [InstallSpec](#installspec). At least one component is required. |
 
 #### ComponentFileMatchMode
 

--- a/docs/ref/spec.md
+++ b/docs/ref/spec.md
@@ -276,20 +276,20 @@ A test spec defines one test script that should be run against the package to va
 
 The component spec defines a single component of a package. Components can be individually requested for a package. The `build` and `run` components are generated automatically unless they are defined explicitly for a package.
 
-| Field               | Type                                                      | Description                                                                                                                                             |
-| ------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| name                | _string_                                                  | The name of this component                                                                                                                              |
-| files               | _List[string]_                                            | A list of patterns that identify which files belong to this component. Patterns follow the same syntax as gitignore files                               |
-| uses                | _List[string]_                                            | A list of other components from this package that this component uses, and are therefore also included whenever this component is included.             |
-| requirements        | _List[[Request](#request)]_                               | A list of requirements that this component has. These requirements are **in addition to** any requirements defined at the `install.requirements` level. |
-| embedded_components | _List[[EmbeddedComponentsSpec](#embeddedcomponentsspec)]_ | A list of which embedded packages' components are embedded in this component.                                                                           |
-| file_match_mode     | _List[[ComponentFileMatchMode](#componentfilematchmode)]_ | Control how the file filters are applied.                                                                                                               |
+| Field               | Type                                                                    | Description                                                                                                                                             |
+| ------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| name                | _string_                                                                | The name of this component                                                                                                                              |
+| files               | _List[string]_                                                          | A list of patterns that identify which files belong to this component. Patterns follow the same syntax as gitignore files                               |
+| uses                | _List[string]_                                                          | A list of other components from this package that this component uses, and are therefore also included whenever this component is included.             |
+| requirements        | _List[[Request](#request)]_                                             | A list of requirements that this component has. These requirements are **in addition to** any requirements defined at the `install.requirements` level. |
+| embedded_packages   | _List[[ComponentEmbeddedPackagesSpec](#componentembeddedpackagesspec)]_ | A list of which embedded packages are embedded in this component, and which components of the embedded package are present.                             |
+| file_match_mode     | _List[[ComponentFileMatchMode](#componentfilematchmode)]_               | Control how the file filters are applied.                                                                                                               |
 
-#### EmbeddedComponentsSpec
+#### ComponentEmbeddedPackagesSpec
 
-| Value | Description                                                                                                                                                                                                                          |
-| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| _str_ | A package and component(s) in the form of either `pkg-name:comp-name` or `pkg-name:{comp1,comp2,...,compn}`, referring to an embedded package and its component(s) defined in the `embedded` section of [InstallSpec](#installspec). |
+| Value | Description                                                                                                                                                                                                                                                                      |
+| ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| _str_ | A package and component(s), with optional version, in the form of either `pkg-name:comp-name[/version]` or `pkg-name:{comp1,comp2,...,compn}[/version]`, referring to an embedded package and its component(s) defined in the `embedded` section of [InstallSpec](#installspec). |
 
 #### ComponentFileMatchMode
 

--- a/docs/ref/spec.md
+++ b/docs/ref/spec.md
@@ -276,14 +276,20 @@ A test spec defines one test script that should be run against the package to va
 
 The component spec defines a single component of a package. Components can be individually requested for a package. The `build` and `run` components are generated automatically unless they are defined explicitly for a package.
 
-| Field           | Type                                                      | Description                                                                                                                                             |
-| --------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| name            | _string_                                                  | The name of this component                                                                                                                              |
-| files           | _List[string]_                                            | A list of patterns that identify which files belong to this component. Patterns follow the same syntax as gitignore files                               |
-| uses            | _List[string]_                                            | A list of other components from this package that this component uses, and are therefore also included whenever this component is included.             |
-| requirements    | _List[[Request](#request)]_                               | A list of requirements that this component has. These requirements are **in addition to** any requirements defined at the `install.requirements` level. |
-| embedded        | _List[[Spec](#package-spec)]_                             | A list of packages that are embedded in this component                                                                                                  |
-| file_match_mode | _List[[ComponentFileMatchMode](#componentfilematchmode)]_ | Control how the file filters are applied.                                                                                                               |
+| Field               | Type                                                      | Description                                                                                                                                             |
+| ------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| name                | _string_                                                  | The name of this component                                                                                                                              |
+| files               | _List[string]_                                            | A list of patterns that identify which files belong to this component. Patterns follow the same syntax as gitignore files                               |
+| uses                | _List[string]_                                            | A list of other components from this package that this component uses, and are therefore also included whenever this component is included.             |
+| requirements        | _List[[Request](#request)]_                               | A list of requirements that this component has. These requirements are **in addition to** any requirements defined at the `install.requirements` level. |
+| embedded_components | _List[[EmbeddedComponentsSpec](#embeddedcomponentsspec)]_ | A list of which embedded packages' components are embedded in this component.                                                                           |
+| file_match_mode     | _List[[ComponentFileMatchMode](#componentfilematchmode)]_ | Control how the file filters are applied.                                                                                                               |
+
+#### EmbeddedComponentsSpec
+
+| Value | Description                                                                                                                                                                                                                          |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| _str_ | A package and component(s) in the form of either `pkg-name:comp-name` or `pkg-name:{comp1,comp2,...,compn}`, referring to an embedded package and its component(s) defined in the `embedded` section of [InstallSpec](#installspec). |
 
 #### ComponentFileMatchMode
 

--- a/docs/ref/spec.md
+++ b/docs/ref/spec.md
@@ -276,14 +276,14 @@ A test spec defines one test script that should be run against the package to va
 
 The component spec defines a single component of a package. Components can be individually requested for a package. The `build` and `run` components are generated automatically unless they are defined explicitly for a package.
 
-| Field               | Type                                                                    | Description                                                                                                                                             |
-| ------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| name                | _string_                                                                | The name of this component                                                                                                                              |
-| files               | _List[string]_                                                          | A list of patterns that identify which files belong to this component. Patterns follow the same syntax as gitignore files                               |
-| uses                | _List[string]_                                                          | A list of other components from this package that this component uses, and are therefore also included whenever this component is included.             |
-| requirements        | _List[[Request](#request)]_                                             | A list of requirements that this component has. These requirements are **in addition to** any requirements defined at the `install.requirements` level. |
-| embedded_packages   | _List[[ComponentEmbeddedPackagesSpec](#componentembeddedpackagesspec)]_ | A list of which embedded packages are embedded in this component, and which components of the embedded package are present.                             |
-| file_match_mode     | _List[[ComponentFileMatchMode](#componentfilematchmode)]_               | Control how the file filters are applied.                                                                                                               |
+| Field           | Type                                                                    | Description                                                                                                                                             |
+| --------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| name            | _string_                                                                | The name of this component                                                                                                                              |
+| files           | _List[string]_                                                          | A list of patterns that identify which files belong to this component. Patterns follow the same syntax as gitignore files                               |
+| uses            | _List[string]_                                                          | A list of other components from this package that this component uses, and are therefore also included whenever this component is included.             |
+| requirements    | _List[[Request](#request)]_                                             | A list of requirements that this component has. These requirements are **in addition to** any requirements defined at the `install.requirements` level. |
+| embedded        | _List[[ComponentEmbeddedPackagesSpec](#componentembeddedpackagesspec)]_ | A list of which embedded packages are embedded in this component, and which components of the embedded package are present.                             |
+| file_match_mode | _List[[ComponentFileMatchMode](#componentfilematchmode)]_               | Control how the file filters are applied.                                                                                                               |
 
 #### ComponentEmbeddedPackagesSpec
 


### PR DESCRIPTION
Addresses the question from #742.

The original spec schema had multiple places where an embedded package could be defined:

```yaml
pkg: demo/1.0.0
install:
  components:
    - name: comp1
      embedded:
        # inside a component
        - pkg: embedded/2.0.0
  embedded:
    # outside a component
    - pkg: embedded/2.0.0
```

It becomes confusing if the embedded package also has components. Where do those components get defined? How can the parent package say which of its components contains the embedded packages' components?

## A motivating example

The package boost contains a lot of headers only needed during build so it benefits from having those files live only in the "build" component. A second package, boost-python, is also a full build of boost (plus extra python things), so it needs to embed boost. Since the boost-python package is a full build of boost, it also benefits from having the headers only live in the "build" component. It needs to be able to say that the `boost-python:build` component embeds the `boost:build` component.

```yaml
pkg: boost-python/1.76.0
install:
  components:
    - name: build
      files:
        - include/
        - lib/cmake/
        - lib/*.a
        - lib/*.so
      uses:
        - run
      embedded_components:    # <-- new
        - boost:build
    - name: run
      files:
        - "*"
      file_match_mode: Remaining
      embedded_components:    # <-- new
        - boost:run
  embedded:
    - pkg: boost/1.76.0
      install:
        components:
          - name: build
            uses:
              - run
          - name: run
```

This shows how the boost-python spec can now be written. The embedded boost package is defined once under `install.embedded` and its components are defined here. The new `install.components[].embeded_components` field is used to specify for each component of boost-python, which components of boost are present.

## Solver logic changes

There can be a situation where a certain combination of requests will cause the solver to fail even though there is nothing "wrong" about those requests.

First, there needs to be a request for a specific component of a real package: `real-package:comp1`. Assuming `real-package:comp1` exists, this request will solve successfully.

Then, some other package needs to exist that embeds `real-package`, let's call it `fake-package`. Assume `fake-package:comp1` embeds `real-package:comp1` and other components exist inside `fake-package`.

Now, add a request for a specific component of `fake-package` that isn't `comp1`: `fake-package:comp2`. As in, `spk env real-package:comp1 fake-package:comp2`.

The problem arises when `fake-package` replaces `real-package` in the solve, but only `fake-package:comp2` is part of the solution, because this does not include (embed) `real-package:comp1`.

The solver now needs to detect that the current set of requests do not bring in all the necessary components of the parent package in order to have the required components of the embedded package satisfied. It effectively needs to translate the `real-package:comp1` request into a request for `fake-package:comp1`. When this situation is detected, the state will be rolled back to just before `fake-package` is added to the solution, and a request for `fake-package:comp1` is added. This combines with the explicit request for `fake-package:comp2`, making the merged request into `fake-package:{comp1,comp2}`. Now when `fake-package` is added to the solution it will include `comp1` and the request for `real-package:comp1` will be satisfied.