### PR TITLE
Fix infinite loop attempting to repair missing payload

### DIFF
--- a/crates/spfs/src/storage/fallback/repository.rs
+++ b/crates/spfs/src/storage/fallback/repository.rs
@@ -212,8 +212,11 @@ impl PayloadStorage for FallbackProxy {
                 Ok(r) => return Ok(r),
                 Err(err @ Error::ObjectMissingPayload(_, _)) => err,
                 Err(err @ Error::UnknownObject(_)) => {
-                    // Try to repair the missing blob
-                    if self.read_object(digest).await.is_ok() {
+                    // Try to repair the missing blob. There can be hash
+                    // collisions so use `read_blob` specifically in case
+                    // there is an object of some other type with the same
+                    // digest.
+                    if self.read_blob(digest).await.is_ok() {
                         continue;
                     }
                     return Err(err);

--- a/crates/spfs/src/storage/fs/payloads.rs
+++ b/crates/spfs/src/storage/fs/payloads.rs
@@ -43,6 +43,7 @@ impl crate::storage::PayloadStorage for FSRepository {
                     // blob is really unknown or just the payload is missing.
                     match self.read_blob(digest).await {
                         Ok(blob) => Err(Error::ObjectMissingPayload(blob.into(), digest)),
+                        Err(err @ Error::ObjectNotABlob(_, _)) => Err(err),
                         Err(_) => Err(Error::UnknownObject(digest)),
                     }
                 }


### PR DESCRIPTION
`FallbackProxy::open_payload` could get stuck in an infinite loop if a
payload is missing and the object with the same payload is not a blob
object (see #674 for more about hash collisions in the repo).

Don't return a `read_blob` error as `UnknownObject` if the object exists
but is not a blob. Preserve the `ObjectNotABlob` error. For added safety
to prevent looping forever, require the digest match an existing blob
before retrying `open_payload`.

Signed-off-by: J Robert Ray <jrray@jrray.org>