### PR TITLE
Add wheel to spk-convert-pip requirements

### DIFF
--- a/packages/spk-convert-pip/requirements.txt
+++ b/packages/spk-convert-pip/requirements.txt
@@ -1,2 +1,5 @@
 pkginfo==1.7.0
 packaging==20.9
+# 0.40.0 latest at time of writing but no implied requirement for exactly this
+# version.
+wheel==0.40.0

--- a/packages/spk-convert-pip/spk-convert-pip.spk.yaml
+++ b/packages/spk-convert-pip/spk-convert-pip.spk.yaml
@@ -1,4 +1,4 @@
-pkg: spk-convert-pip/1.2.1
+pkg: spk-convert-pip/1.2.2
 api: v0/package
 build:
   script:


### PR DESCRIPTION
Otherwise some packages fail to convert with "No module named 'pip'".

https://stackoverflow.com/a/76441785