### PR TITLE
Removes cnproc from spfs-monitor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,14 +542,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cnproc"
-version = "0.2.1"
-source = "git+https://github.com/rydrman/cnproc-rs?branch=act-like-iterator#07184c89401cc0a49f15cd9a00552cbb003b82e5"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3142,7 +3134,6 @@ dependencies = [
  "caps",
  "chrono",
  "close-err",
- "cnproc",
  "colored",
  "config",
  "criterion",

--- a/crates/spfs/Cargo.toml
+++ b/crates/spfs/Cargo.toml
@@ -24,7 +24,6 @@ cached = { workspace = true }
 caps = "0.5.3"
 chrono = { workspace = true }
 close-err = "1.0"
-cnproc = { git = "https://github.com/rydrman/cnproc-rs", branch = "act-like-iterator" }
 colored = "2.0"
 config = { workspace = true }
 dashmap = { workspace = true }

--- a/crates/spfs/tests/integration/unprivileged/test_runtime_cleanup.sh
+++ b/crates/spfs/tests/integration/unprivileged/test_runtime_cleanup.sh
@@ -10,8 +10,7 @@ set -o errexit
 
 assert_runtime_count() {
     # give any runtimes created by other tests a chance to expire
-    # this number relates to the 2.5s poll interval when not using
-    # cnproc.
+    # this number relates to the 2.5s poll interval
     sleep 4
 
     count=$(spfs runtime list -q | wc -l)


### PR DESCRIPTION
This removes `cnproc` from spfs-monitor. It no longer uses cnproc or reads netlink messages. It relies process polling to send the internal process/pid changes messages instead. 

Closes https://github.com/imageworks/spk/issues/768