### PR TITLE
Add explicit permissions for created fs objects

### DIFF
--- a/crates/spfs/src/storage/fs/database.rs
+++ b/crates/spfs/src/storage/fs/database.rs
@@ -118,6 +118,15 @@ impl graph::Database for super::FSRepository {
                 err,
             ));
         }
+        let perms = std::fs::Permissions::from_mode(self.objects.file_permissions);
+        if let Err(err) = tokio::fs::set_permissions(&working_file, perms).await {
+            let _ = tokio::fs::remove_file(&working_file).await;
+            return Err(Error::StorageWriteError(
+                "set permissions on object file",
+                working_file,
+                err,
+            ));
+        }
         self.objects.ensure_base_dir(&filepath)?;
         match tokio::fs::rename(&working_file, &filepath).await {
             Ok(_) => Ok(()),


### PR DESCRIPTION
By not setting the default permissions, we are relying on the active umask which may create databases which are not able to be shared between users as we typically aim to support.

@jrray I know that you did a lot of work recently on the way we deal with permissions for payloads, so please let me know if I am forgetting any key details of how that may have affected objects.

IIRC we used to set object permissions explicitly but it seems like we don't anymore...