### PR TITLE
Add "last" arg marker to spfs-join

### DIFF
--- a/crates/spfs-cli/cmd-join/src/cmd_join.rs
+++ b/crates/spfs-cli/cmd-join/src/cmd_join.rs
@@ -36,13 +36,10 @@ pub struct CmdJoin {
     /// The command to run after initialization
     ///
     /// If not given, run an interactive shell environment
+    #[arg(last = true)]
     command: Option<OsString>,
 
     /// Additional arguments to provide to the command
-    ///
-    /// In order to ensure that flags are passed as-is, place '--' before
-    /// specifying any flags that should be given to the subcommand:
-    ///   eg `spfs enter <args> -- command --flag-for-command`
     args: Vec<OsString>,
 }
 


### PR DESCRIPTION
Clap has a limitation in how it can support alternative args. For example, in spfs-join, we intend to support two different ways of specifying the runtime, and Clap's generated usage reflects this:

    Usage: spfs-join [OPTIONS] <RUNTIME|--pid <PID>> [<COMMAND>] [ARGS]...
                               ^^^^^^^^^^^^^^^^^^^^^
Unfortunately, even when `--pid <pid>` is present on the command line, it still tries to assign any additional positional arguments into the "runtime" position, as in:

    $ spfs join --pid 162509 -- echo hi
    error: The argument '--pid <PID>' cannot be used with '<RUNTIME>'

    USAGE:
        spfs-join <RUNTIME|--pid <PID>> <COMMAND>

This happens with or without adding `--` to the command line.

By adding "last", Clap will _require_ the command line contains `--` if any command is being provided, but it removes the parsing ambiguity and makes the command line shown above work correctly.