### PR TITLE
Fix illegal env vars

### DIFF
--- a/crates/spk-schema/crates/foundation/src/spec_ops/env_name.rs
+++ b/crates/spk-schema/crates/foundation/src/spec_ops/env_name.rs
@@ -1,0 +1,20 @@
+// Copyright (c) Sony Pictures Imageworks, et al.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/imageworks/spk
+
+use crate::spec_ops::Named;
+
+/// Has a name that can be used as a valid environment variable
+pub trait EnvName {
+    /// A valid environment variable name for this item
+    fn env_name(&self) -> String;
+}
+
+impl<T> EnvName for T
+where
+    T: Named,
+{
+    fn env_name(&self) -> String {
+        self.name().replace('-', "_")
+    }
+}

--- a/crates/spk-schema/crates/foundation/src/spec_ops/mod.rs
+++ b/crates/spk-schema/crates/foundation/src/spec_ops/mod.rs
@@ -3,6 +3,7 @@
 // https://github.com/imageworks/spk
 
 mod component_ops;
+mod env_name;
 mod error;
 mod file_matcher;
 mod has_build;
@@ -11,6 +12,7 @@ mod named;
 mod versioned;
 
 pub use component_ops::ComponentOps;
+pub use env_name::EnvName;
 pub use error::{Error, Result};
 pub use file_matcher::FileMatcher;
 pub use has_build::HasBuild;
@@ -19,5 +21,5 @@ pub use named::Named;
 pub use versioned::{HasVersion, Versioned};
 
 pub mod prelude {
-    pub use super::{ComponentOps, HasBuild, HasLocation, HasVersion, Named, Versioned};
+    pub use super::{ComponentOps, EnvName, HasBuild, HasLocation, HasVersion, Named, Versioned};
 }

--- a/crates/spk-solve/crates/solution/src/solution.rs
+++ b/crates/spk-solve/crates/solution/src/solution.rs
@@ -355,29 +355,32 @@ impl Solution {
         out.insert("SPK_ACTIVE_PREFIX".to_owned(), "/spfs".to_owned());
         for resolved in self.resolved.iter() {
             let spec = &resolved.spec;
-            out.insert(format!("SPK_PKG_{}", spec.name()), spec.ident().to_string());
             out.insert(
-                format!("SPK_PKG_{}_VERSION", spec.name()),
+                format!("SPK_PKG_{}", spec.env_name()),
+                spec.ident().to_string(),
+            );
+            out.insert(
+                format!("SPK_PKG_{}_VERSION", spec.env_name()),
                 spec.version().to_string(),
             );
             out.insert(
-                format!("SPK_PKG_{}_BUILD", spec.name()),
+                format!("SPK_PKG_{}_BUILD", spec.env_name()),
                 spec.ident().build().to_string(),
             );
             out.insert(
-                format!("SPK_PKG_{}_VERSION_MAJOR", spec.name()),
+                format!("SPK_PKG_{}_VERSION_MAJOR", spec.env_name()),
                 spec.version().major().to_string(),
             );
             out.insert(
-                format!("SPK_PKG_{}_VERSION_MINOR", spec.name()),
+                format!("SPK_PKG_{}_VERSION_MINOR", spec.env_name()),
                 spec.version().minor().to_string(),
             );
             out.insert(
-                format!("SPK_PKG_{}_VERSION_PATCH", spec.name()),
+                format!("SPK_PKG_{}_VERSION_PATCH", spec.env_name()),
                 spec.version().patch().to_string(),
             );
             out.insert(
-                format!("SPK_PKG_{}_VERSION_BASE", spec.name()),
+                format!("SPK_PKG_{}_VERSION_BASE", spec.env_name()),
                 spec.version()
                     .parts
                     .iter()


### PR DESCRIPTION
`Solution::to_environment` is generating illegal package name environment variables with "-". A new method is added on `Named` trait to replace "-" to "_" 

Closes: [#541](https://github.com/imageworks/spk/issues/541)