### PR TITLE
Add rust edition to .rustfmt.toml

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,3 +1,4 @@
+edition = "2021"
 
 use_field_init_shorthand = true
 


### PR DESCRIPTION
This is needed in here for tools that run `rustfmt` directly instead of `cargo fmt`.