### PR TITLE
Fix spk export failing if builds are missing

### DIFF
--- a/crates/spk-cli/group3/src/cmd_export.rs
+++ b/crates/spk-cli/group3/src/cmd_export.rs
@@ -10,6 +10,10 @@ use colored::Colorize;
 use spk_cli_common::{flags, CommandArgs, Run};
 use spk_storage::{self as storage};
 
+#[cfg(test)]
+#[path = "./cmd_export_test.rs"]
+mod cmd_export_test;
+
 /// Export a package as a tar file
 #[derive(Args)]
 pub struct Export {

--- a/crates/spk-cli/group3/src/cmd_export_test.rs
+++ b/crates/spk-cli/group3/src/cmd_export_test.rs
@@ -1,0 +1,124 @@
+use rstest::rstest;
+use spfs::config::Remote;
+use spfs::RemoteAddress;
+use spk_build::{BinaryPackageBuilder, BuildSource};
+use spk_schema::foundation::option_map;
+use spk_schema::{recipe, Package};
+use spk_storage::fixtures::*;
+
+#[rstest]
+#[tokio::test]
+async fn test_export_works_with_missing_builds() {
+    let mut rt = spfs_runtime().await;
+
+    // exporting requires a configured "origin" repo.
+    let remote_repo = spfsrepo().await;
+    rt.add_remote_repo(
+        "origin",
+        Remote::Address(RemoteAddress {
+            address: remote_repo.address().clone(),
+        }),
+    )
+    .unwrap();
+
+    let spec = recipe!(
+        {
+            "pkg": "spk-export-test/0.0.1",
+            "build": {
+                "options": [
+                    {"var": "color"},
+                ],
+                "script": "touch /spfs/file.txt",
+            },
+        }
+    );
+    rt.tmprepo.publish_recipe(&spec).await.unwrap();
+    let (blue_spec, _) = BinaryPackageBuilder::from_recipe(spec.clone())
+        .with_source(BuildSource::LocalPath(".".into()))
+        .build_and_publish(option_map! {"color" => "blue"}, &*rt.tmprepo)
+        .await
+        .unwrap();
+    let (red_spec, _) = BinaryPackageBuilder::from_recipe(spec)
+        .with_source(BuildSource::LocalPath(".".into()))
+        .build_and_publish(option_map! {"color" => "red"}, &*rt.tmprepo)
+        .await
+        .unwrap();
+
+    // Now that these two builds are created, remove the `spk/pkg` tags for one
+    // of them. The publish is still expected to succeed; it should publish
+    // the remaining valid build.
+    match &*rt.tmprepo {
+        spk_storage::RepositoryHandle::SPFS(spfs) => {
+            for spec in [
+                format!("{}", blue_spec.ident().build()),
+                format!("{}/build", blue_spec.ident().build()),
+                format!("{}/run", blue_spec.ident().build()),
+            ] {
+                let tag = spfs::tracking::TagSpec::parse(format!(
+                    "spk/pkg/spk-export-test/0.0.1/{spec}",
+                ))
+                .unwrap();
+                spfs.remove_tag_stream(&tag).await.unwrap();
+            }
+        }
+        _ => panic!("only implemented for spfs repos"),
+    }
+
+    let filename = rt.tmpdir.path().join("archive.spk");
+    filename.ensure();
+    spk_storage::export_package(
+        red_spec.ident().clone().to_version().to_any(None),
+        &filename,
+    )
+    .await
+    .expect("failed to export");
+    let mut actual = Vec::new();
+    let mut tarfile = tar::Archive::new(std::fs::File::open(&filename).unwrap());
+    for entry in tarfile.entries().unwrap() {
+        let filename = entry.unwrap().path().unwrap().to_string_lossy().to_string();
+        if filename.contains('/') && !filename.contains("tags") {
+            // ignore specific object data for this test
+            continue;
+        }
+        actual.push(filename);
+    }
+    actual.sort();
+    assert_eq!(
+        actual,
+        vec![
+            "VERSION".to_string(),
+            "objects".to_string(),
+            "payloads".to_string(),
+            "renders".to_string(),
+            "tags".to_string(),
+            "tags/spk".to_string(),
+            "tags/spk/pkg".to_string(),
+            "tags/spk/pkg/spk-export-test".to_string(),
+            "tags/spk/pkg/spk-export-test/0.0.1".to_string(),
+            format!(
+                "tags/spk/pkg/spk-export-test/0.0.1/{}",
+                red_spec.ident().build()
+            ),
+            format!(
+                "tags/spk/pkg/spk-export-test/0.0.1/{}.tag",
+                red_spec.ident().build()
+            ),
+            format!(
+                "tags/spk/pkg/spk-export-test/0.0.1/{}/build.tag",
+                red_spec.ident().build()
+            ),
+            format!(
+                "tags/spk/pkg/spk-export-test/0.0.1/{}/run.tag",
+                red_spec.ident().build()
+            ),
+            "tags/spk/spec".to_string(),
+            "tags/spk/spec/spk-export-test".to_string(),
+            "tags/spk/spec/spk-export-test/0.0.1".to_string(),
+            "tags/spk/spec/spk-export-test/0.0.1.tag".to_string(),
+            format!(
+                "tags/spk/spec/spk-export-test/0.0.1/{}.tag",
+                red_spec.ident().build()
+            ),
+        ]
+    );
+}


### PR DESCRIPTION
In our origin repo there are some traces of a package that may have been partually published, where there are "spec build" tags but no "pkg build" tags, as in:

    spfs/tags/spk/spec/pkg-name/1.0.0/6XFZP6SR.tag (exists)
    spfs/tags/spk/pkg/pkg-name (does not exist)

A _new_ build of this package failed to `spk export` due to these remnants found in the origin repo:

     INFO exporting pkg=pkg-name/1.0.0
     INFO exporting pkg=pkg-name/1.0.0/src
     INFO exporting pkg=pkg-name/1.0.0/5MDZ2ADM
     WARN Ensure that you are specifying at least a package and
     WARN version number when exporting from the local repository
    ERROR Package not found: pkg-name/1.0.0/6XFZP6SR

This commit takes a minimally invasive approach of ignoring PackageNotFoundError when these are generated about specific builds, as in builds that exist as far as `list_package_builds` is concerned, but fail to be loaded. It will still hard error if one attempts to export a specific build that does not exist.

We don't think that we should have to manually remove the "spec build" tags from our origin repo in order for `spk export` to work.