### PR TITLE
Remove duplicate reporting of entries in render report

### DIFF
--- a/crates/spfs/src/storage/fs/renderer.rs
+++ b/crates/spfs/src/storage/fs/renderer.rs
@@ -375,7 +375,7 @@ where
     }
 
     #[async_recursion::async_recursion]
-    pub async fn render_into_dir_fd<Fd>(
+    async fn render_into_dir_fd<Fd>(
         &self,
         root_dir_fd: Fd,
         tree: graph::Tree,
@@ -403,7 +403,6 @@ where
         let root_dir_fd = root_dir_fd.as_raw_fd();
         let mut stream = futures::stream::iter(entries)
             .then(move |entry| {
-                self.reporter.visit_entry(&entry);
                 let fut = async move {
                     let mut root_path = PathBuf::from(&entry.name);
                     match entry.kind {


### PR DESCRIPTION
The renderer was reporting the same entries multiple times, causing the progress bars to only ever get halfway before completing. 

I also removed the `pub` from render_into_dir_fd` because now that function relies on being called from the render_into_dir function in order for the report to be filled properly.