### PR TITLE
Change statsd configuration to be optional

### DIFF
--- a/crates/spk-cli/cmd-env/src/cmd_env.rs
+++ b/crates/spk-cli/cmd-env/src/cmd_env.rs
@@ -92,8 +92,9 @@ impl Run for Env {
         // possibly long running, command/env (e.g. shell or application).
         #[cfg(feature = "statsd")]
         {
-            let statsd_client = get_metrics_client();
-            statsd_client.record_duration_from_start(&SPK_RUN_TIME_METRIC);
+            if let Some(statsd_client) = get_metrics_client() {
+                statsd_client.record_duration_from_start(&SPK_RUN_TIME_METRIC);
+            }
         }
 
         command

--- a/crates/spk-cli/common/src/flags.rs
+++ b/crates/spk-cli/common/src/flags.rs
@@ -161,8 +161,9 @@ impl Runtime {
         // the run time for the current spk run before it is replaced.
         #[cfg(feature = "statsd")]
         {
-            let statsd_client = get_metrics_client();
-            statsd_client.record_duration_from_start(&SPK_RUN_TIME_METRIC);
+            if let Some(statsd_client) = get_metrics_client() {
+                statsd_client.record_duration_from_start(&SPK_RUN_TIME_METRIC);
+            }
         }
 
         nix::unistd::execvp(&spfs, args.as_slice())

--- a/crates/spk-solve/src/io.rs
+++ b/crates/spk-solve/src/io.rs
@@ -1100,7 +1100,9 @@ impl DecisionFormatter {
 
     #[cfg(feature = "statsd")]
     fn send_solver_start_metrics(&self, runtime: &SolverRuntime) {
-        let statsd_client = get_metrics_client();
+        let Some(statsd_client) = get_metrics_client() else {
+            return;
+        };
 
         statsd_client.incr(&SPK_SOLVER_RUN_COUNT_METRIC);
 
@@ -1111,13 +1113,17 @@ impl DecisionFormatter {
 
     #[cfg(feature = "statsd")]
     fn send_solver_end_metrics(&self, solve_time: Duration) {
-        let statsd_client = get_metrics_client();
+        let Some(statsd_client) = get_metrics_client() else {
+            return;
+        };
         statsd_client.timer(&SPK_SOLVER_RUN_TIME_METRIC, solve_time);
     }
 
     #[cfg(feature = "statsd")]
     fn send_solution_metrics(&self, solution: &Solution) {
-        let statsd_client = get_metrics_client();
+        let Some(statsd_client) = get_metrics_client() else {
+            return;
+        };
         let pipeline = statsd_client.start_a_pipeline();
 
         // If the metrics client didn't make a statsd connection, it

--- a/crates/spk/src/cli.rs
+++ b/crates/spk/src/cli.rs
@@ -56,7 +56,9 @@ impl Opt {
         #[cfg(feature = "statsd")]
         let statsd_client = {
             let client = get_metrics_client();
-            client.incr(&SPK_RUN_COUNT_METRIC);
+            if let Some(client) = client {
+                client.incr(&SPK_RUN_COUNT_METRIC)
+            }
             client
         };
 
@@ -64,7 +66,9 @@ impl Opt {
         if let Err(err) = res {
             eprintln!("{}", err.to_string().red());
             #[cfg(feature = "statsd")]
-            statsd_client.incr(&SPK_ERROR_COUNT_METRIC);
+            if let Some(client) = statsd_client {
+                client.incr(&SPK_ERROR_COUNT_METRIC)
+            }
             return Ok(1);
         }
 
@@ -74,7 +78,9 @@ impl Opt {
         let result = self.cmd.run().await;
 
         #[cfg(feature = "statsd")]
-        statsd_client.record_duration_from_start(&SPK_RUN_TIME_METRIC);
+        if let Some(client) = statsd_client {
+            client.record_duration_from_start(&SPK_RUN_TIME_METRIC)
+        }
 
         #[cfg(feature = "sentry")]
         if let Err(ref err) = result {
@@ -134,7 +140,9 @@ impl Opt {
 
         #[cfg(feature = "statsd")]
         if result.is_err() {
-            statsd_client.incr(&SPK_ERROR_COUNT_METRIC);
+            if let Some(client) = statsd_client {
+                client.incr(&SPK_ERROR_COUNT_METRIC)
+            }
         }
 
         result


### PR DESCRIPTION
Wrap METRICS_CLIENT in an Option so that if there is no configuration in the environment (at build time), the statsd functionality is disabled, rather than it being a compile error.

This change is to stop seeing build errors show up in the IDE if configured with `--all-features` enabled.