### PR TITLE
Rework render_blob_without_permit to take a permit

### DIFF
--- a/crates/spfs/src/storage/fs/renderer.rs
+++ b/crates/spfs/src/storage/fs/renderer.rs
@@ -166,6 +166,9 @@ struct BlobSemaphore(Arc<Semaphore>);
 struct BlobSemaphorePermit<'a>(tokio::sync::SemaphorePermit<'a>);
 
 impl BlobSemaphore {
+    /// Acquires a permit from the blob semaphore.
+    ///
+    /// Wrapper around [`tokio::sync::Semaphore::acquire`].
     async fn acquire(&self) -> BlobSemaphorePermit<'_> {
         BlobSemaphorePermit(
             self.0


### PR DESCRIPTION
Remove use of unsafe and instead require a permit to call this function, renaming it to render_blob_with_permit. Define new types to "enforce" that this method is called with a permit specifically from the blob semaphore, so callers can't call it if they've acquired the wrong semaphore.