### PR TITLE
Fix spk build, variants, and OverlayFsWithFuse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3187,6 +3187,7 @@ dependencies = [
  "tonic-build",
  "tracing",
  "tracing-subscriber",
+ "ulid",
  "url",
  "uuid",
  "walkdir",
@@ -4592,6 +4593,15 @@ name = "ucd-trie"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89570599c4fe5585de2b388aab47e99f7fa4e9238a1399f707a02e356058141c"
+
+[[package]]
+name = "ulid"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a3aaa69b04e5b66cc27309710a569ea23593612387d67daaf102e73aa974fd"
+dependencies = [
+ "rand 0.8.5",
+]
 
 [[package]]
 name = "uname"

--- a/crates/spfs/Cargo.toml
+++ b/crates/spfs/Cargo.toml
@@ -73,6 +73,7 @@ tokio-stream = { version = "0.1", features = ["net", "fs"] }
 tokio-util = { version = "0.7.3", features = ["compat", "io"] }
 tonic = "0.8"
 tracing = { workspace = true }
+ulid = "1.0"
 url = { version = "2.2", features = ["serde"] }
 uuid = { version = "1.1", features = ["v4"] }
 walkdir = "2.3"

--- a/crates/spfs/src/status.rs
+++ b/crates/spfs/src/status.rs
@@ -148,6 +148,12 @@ pub async fn reinitialize_runtime(rt: &mut runtime::Runtime) -> Result<RenderSum
         }
         #[cfg(feature = "fuse-backend")]
         runtime::MountBackend::OverlayFsWithFuse => {
+            // Switch to using a different lower_dir otherwise if we use the
+            // same one as the previous runtime when it lazy unmounts it will
+            // unmount our active lower_dir.
+            rt.rotate_lower_dir().await?;
+            rt.save_state_to_storage().await?;
+
             with_root.mount_fuse_lower_dir(rt).await?;
             with_root
                 .mount_env_overlayfs(rt, &render_result.paths_rendered)


### PR DESCRIPTION
Building an spk package that has multiple variants would fail when using `OverlayFsWithFuse`. The first variant would build successfully but the second variant would fail to launch the build script because the package's src directory under /spfs was missing.

The cause is a more general problem with `reinitialize_runtime` when using `OverlayFsWithFuse`. `OverlayFsWithFuse` mounts the fuse filesystem at `'/tmp/spfs-runtime/lower'` and then points to the directory when it mounts the overlayfs filesytem at `'/spfs'`. `reinitialize_runtime` sets up new mounts, including a new spfs-fuse process. However, the old spfs-fuse process will lazily unmount itself. Since the old and new spfs-fuse process lifetimes overlap, the new mount will be unmounted, leaving the overlayfs with an empty directory as its lower dir.

To avoid this problem, `reinitialize_runtime` when running in `OverlayFsWithFuse` mode will not reuse the same lower_dir path, but instead will generate a new unique directory on every reinitialization.

Signed-off-by: J Robert Ray <jrray@imageworks.com>