### PR TITLE
Add sleep to runtime cleanup test

### DIFF
--- a/crates/spfs/tests/integration/unprivileged/test_runtime_cleanup.sh
+++ b/crates/spfs/tests/integration/unprivileged/test_runtime_cleanup.sh
@@ -38,6 +38,7 @@ spfs run - -- spfs run - -- spfs run - -- spfs run - -- sleep 8 &
 # when runtimes are stacked, the commands each move into
 # a new namespace and so the outer runtimes become empty
 # and can be cleaned up immediately
+sleep 4
 assert_runtime_count 1
 wait
 assert_runtime_count 0


### PR DESCRIPTION
Trying to avoid spurious failures of this test.