### PR TITLE
Add sccache for compile caching

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,6 +37,11 @@ jobs:
         run: |
           mkdir -p .cargo
           cat << EOF > .cargo/config.toml
+          [build]
+          # Disable incremental compilation to lower disk usage, and sccache
+          # can't cache incremental compiles.
+          incremental = false
+
           [profile.dev]
           # Disable debug information to lower disk usage.
           debug = false


### PR DESCRIPTION
https://github.com/Mozilla-Actions/sccache-action

Despite the recent change to make all build steps use the same set of features, many crates can be observed getting recompiled. Experiment with sccache to see if it can do a better job of speeding up builds compared to rust-cache.