### PR TITLE
Replace libc file modes with cross-platform crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3118,6 +3118,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ulid",
+ "unix_mode",
  "url",
  "uuid",
  "walkdir",

--- a/crates/spfs/Cargo.toml
+++ b/crates/spfs/Cargo.toml
@@ -74,6 +74,7 @@ tokio-util = { version = "0.7.3", features = ["compat", "io"] }
 tonic = "0.8"
 tracing = { workspace = true }
 ulid = "1.0"
+unix_mode = "0.1.3"
 url = { version = "2.2", features = ["serde"] }
 uuid = { version = "1.1", features = ["v4"] }
 walkdir = "2.3"

--- a/crates/spfs/src/graph/entry.rs
+++ b/crates/spfs/src/graph/entry.rs
@@ -31,15 +31,15 @@ impl Entry {
     }
 
     pub fn is_symlink(&self) -> bool {
-        (libc::S_IFMT & self.mode) == libc::S_IFLNK
+        unix_mode::is_symlink(self.mode)
     }
 
     pub fn is_dir(&self) -> bool {
-        (libc::S_IFMT & self.mode) == libc::S_IFDIR
+        unix_mode::is_dir(self.mode)
     }
 
     pub fn is_regular_file(&self) -> bool {
-        (libc::S_IFMT & self.mode) == libc::S_IFREG
+        unix_mode::is_file(self.mode)
     }
 }
 

--- a/crates/spfs/src/storage/repository_test.rs
+++ b/crates/spfs/src/storage/repository_test.rs
@@ -97,10 +97,7 @@ async fn test_commit_mode_fs(tmpdir: tempfile::TempDir) {
         .expect("failed to render manifest");
     let rendered_symlink = rendered_dir.join(symlink_path);
     let rendered_mode = rendered_symlink.symlink_metadata().unwrap().mode();
-    assert!(
-        (libc::S_IFMT & rendered_mode) == libc::S_IFLNK,
-        "should be a symlink"
-    );
+    assert!(unix_mode::is_symlink(rendered_mode), "should be a symlink");
 
     let symlink_entry = manifest
         .get_path(symlink_path)
@@ -108,7 +105,7 @@ async fn test_commit_mode_fs(tmpdir: tempfile::TempDir) {
     let symlink_blob = tmprepo.payloads.build_digest_path(&symlink_entry.object);
     let blob_mode = symlink_blob.symlink_metadata().unwrap().mode();
     assert!(
-        (libc::S_IFMT & blob_mode) != libc::S_IFLNK,
+        !unix_mode::is_symlink(blob_mode),
         "stored blob should not be a symlink"
     )
 }

--- a/crates/spfs/src/tracking/entry.rs
+++ b/crates/spfs/src/tracking/entry.rs
@@ -174,13 +174,13 @@ impl PartialOrd for Entry {
 
 impl<T> Entry<T> {
     pub fn is_symlink(&self) -> bool {
-        (libc::S_IFMT & self.mode) == libc::S_IFLNK
+        unix_mode::is_symlink(self.mode)
     }
     pub fn is_dir(&self) -> bool {
-        (libc::S_IFMT & self.mode) == libc::S_IFDIR
+        unix_mode::is_dir(self.mode)
     }
     pub fn is_regular_file(&self) -> bool {
-        (libc::S_IFMT & self.mode) == libc::S_IFREG
+        unix_mode::is_file(self.mode)
     }
 
     pub fn iter_entries(&self) -> impl Iterator<Item = super::manifest::ManifestNode<'_, T>> {


### PR DESCRIPTION
The Unix file mode constants are not available when building on Windows, but the `unix_mode` crate can be used on either platform