### PR TITLE
Bugfix: spk bake outputs layers for requested components not all components

### DIFF
--- a/crates/spk-cli/group1/src/cmd_bake.rs
+++ b/crates/spk-cli/group1/src/cmd_bake.rs
@@ -170,7 +170,23 @@ impl Bake {
             PackageSource::Repository {
                 repo: _,
                 components,
-            } => components.clone(),
+            } => {
+                let mut requested_components = resolved.request.pkg.components.clone();
+                if requested_components.remove(&Component::All) {
+                    components.clone()
+                } else {
+                    components
+                        .iter()
+                        .filter_map(|(c, l)| {
+                            if requested_components.contains(c) {
+                                Some((c.clone(), *l))
+                            } else {
+                                None
+                            }
+                        })
+                        .collect::<HashMap<Component, Digest>>()
+                }
+            }
             PackageSource::SpkInternalTest => {
                 // Internal test builds don't have a layer of
                 // their own so they can be skipped over.


### PR DESCRIPTION
This fixes a bug found in `spk bake` where it would output layers for all the components of the resolved packages regardless of which components were part of the requests.  The fix filters the components to those present in the request when getting the layers for the components before output. This only affected `spk bake` and makes it consistent with the results in `spk env` for the same requests.

Before the fix (somepackage has run, build, docs, and extras components):
```sh
> spk bake katana:run/=4.5.6 -f yaml
...
- spfs_layer: UGN4TOZVJOFVAXW37SIRYC2QBGXIBLKMKAY2XSQRAUNO7ZQQCD6Q====
  spk_package: katana/4.5.6/PECFYOVO
  spk_components:
    - extras
  spk_requester: command line
  spfs_repo_name: origin
- spfs_layer: FG4IYOUBAA6RUFK3JQFH5EPF4K3E3577E5Y3YNCHWY3BHJOCUFAA====
  spk_package: katana/4.5.6/PECFYOVO
  spk_components:
    - build
  spk_requester: command line
  spfs_repo_name: origin
- spfs_layer: J4UN3PDDAJRJ3IS4VNJPS6W35UXBRV4LE5X7LBP7TKWCRS3OADDA====
  spk_package: katana/4.5.6/PECFYOVO
  spk_components:
    - docs
  spk_requester: command line
  spfs_repo_name: origin
- spfs_layer: P25B3SCSHBMM7PHVHPR3AMVASATEARKIMMQH7GURV5BXTBWGQETQ====
  spk_package: katana/4.5.6/PECFYOVO
  spk_components:
    - run
  spk_requester: command line
  spfs_repo_name: origin
```
After the fix:
```sh
...
- spfs_layer: P25B3SCSHBMM7PHVHPR3AMVASATEARKIMMQH7GURV5BXTBWGQETQ====
  spk_package: katana/4.5.6/PECFYOVO
  spk_components:
    - run
  spk_requester: command line
  spfs_repo_name: origin
```