### PR TITLE
Remove hard-coded spfs crate version

### DIFF
--- a/crates/spk-build/Cargo.toml
+++ b/crates/spk-build/Cargo.toml
@@ -20,7 +20,7 @@ relative-path = "1.3"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_yaml = "0.8.17"
-spfs = { version = '0.34.6', path = "../spfs" }
+spfs = { path = "../spfs" }
 spk-exec = { path = "../spk-exec" }
 spk-solve = { path = "../spk-solve" }
 spk-schema = { path = "../spk-schema" }

--- a/crates/spk-cli/cmd-debug/Cargo.toml
+++ b/crates/spk-cli/cmd-debug/Cargo.toml
@@ -9,7 +9,7 @@ anyhow = "1.0"
 async-trait = "0.1"
 clap = { workspace = true, features = ["derive", "env"] }
 futures = { workspace = true }
-spfs = { version = '0.34.6', path = "../../spfs" }
+spfs = { path = "../../spfs" }
 spk-cli-common = { path = '../common' }
 spk-exec = { path = '../../spk-exec' }
 spk-schema = { path = '../../spk-schema' }

--- a/crates/spk-cli/cmd-du/Cargo.toml
+++ b/crates/spk-cli/cmd-du/Cargo.toml
@@ -12,7 +12,7 @@ clap = { workspace = true }
 colored = { workspace = true }
 futures = "0.3.9"
 itertools = "0.10"
-spfs = { version = '0.34.6', path = "../../spfs" }
+spfs = { path = "../../spfs" }
 spk-build = { path = '../../spk-build' }
 spk-cli-common = { path = '../common' }
 spk-solve = { path = '../../spk-solve' }

--- a/crates/spk-cli/cmd-env/Cargo.toml
+++ b/crates/spk-cli/cmd-env/Cargo.toml
@@ -11,7 +11,7 @@ statsd = ["dep:statsd"]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 clap = { workspace = true }
-spfs = { version = '0.34.6', path = "../../spfs" }
+spfs = { path = "../../spfs" }
 spk-cli-common = { path = '../common' }
 spk-exec = { path = '../../spk-exec' }
 spk-solve = { path = '../../spk-solve' }

--- a/crates/spk-cli/cmd-render/Cargo.toml
+++ b/crates/spk-cli/cmd-render/Cargo.toml
@@ -8,7 +8,7 @@ version = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 clap = { workspace = true }
-spfs = { version = '0.34.6', path = "../../spfs" }
+spfs = { path = "../../spfs" }
 spk-cli-common = { path = '../common' }
 spk-exec = { path = '../../spk-exec' }
 spk-storage = { path = '../../spk-storage' }

--- a/crates/spk-cli/cmd-test/Cargo.toml
+++ b/crates/spk-cli/cmd-test/Cargo.toml
@@ -8,7 +8,7 @@ version = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 clap = { workspace = true }
-spfs = { version = '0.34.6', path = "../../spfs" }
+spfs = { path = "../../spfs" }
 spk-build = { path = '../../spk-build' }
 spk-cli-common = { path = '../common' }
 spk-exec = { path = '../../spk-exec' }

--- a/crates/spk-cli/common/Cargo.toml
+++ b/crates/spk-cli/common/Cargo.toml
@@ -30,7 +30,7 @@ serde_yaml = "0.8.17"
 sentry = { workspace = true, optional = true }
 sentry-anyhow = { workspace = true, optional = true }
 sentry-tracing = { workspace = true, optional = true }
-spfs = { version = '0.34.6', path = "../../spfs" }
+spfs = { path = "../../spfs" }
 spk-build = { path = '../../spk-build' }
 spk-exec = { path = '../../spk-exec' }
 spk-solve = { path = '../../spk-solve' }

--- a/crates/spk-cli/group1/Cargo.toml
+++ b/crates/spk-cli/group1/Cargo.toml
@@ -17,7 +17,7 @@ itertools = "0.10"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_yaml = "0.8.17"
-spfs = { version = '0.34.6', path = "../../spfs" }
+spfs = { path = "../../spfs" }
 spk-cli-common = { path = '../common' }
 spk-solve = { path = '../../spk-solve' }
 spk-schema = { path = '../../spk-schema' }

--- a/crates/spk-cli/group2/Cargo.toml
+++ b/crates/spk-cli/group2/Cargo.toml
@@ -12,7 +12,7 @@ colored = { workspace = true }
 itertools = "0.10"
 nom = { workspace = true }
 nom-supreme = { workspace = true }
-spfs = { version = '0.34.6', path = "../../spfs" }
+spfs = { path = "../../spfs" }
 spk-cli-common = { path = '../common' }
 spk-solve = { path = '../../spk-solve' }
 spk-schema = { path = '../../spk-schema' }

--- a/crates/spk-cli/group4/Cargo.toml
+++ b/crates/spk-cli/group4/Cargo.toml
@@ -11,7 +11,7 @@ clap = { workspace = true }
 colored = { workspace = true }
 futures = { workspace = true }
 serde_yaml = "0.8.17"
-spfs = { version = '0.34.6', path = "../../spfs" }
+spfs = { path = "../../spfs" }
 spk-cli-common = { path = '../common' }
 spk-schema = { path = '../../spk-schema' }
 tokio = { workspace = true, features = ["rt"] }

--- a/crates/spk-exec/Cargo.toml
+++ b/crates/spk-exec/Cargo.toml
@@ -15,7 +15,7 @@ migration-to-components = [
 async-stream = "0.3"
 futures = { workspace = true }
 relative-path = "1.3"
-spfs = { version = '0.34.6', path = "../spfs" }
+spfs = { path = "../spfs" }
 spk-schema = { path = '../spk-schema' }
 spk-storage = { path = "../spk-storage" }
 spk-solve = { path = "../spk-solve" }

--- a/crates/spk-launcher/Cargo.toml
+++ b/crates/spk-launcher/Cargo.toml
@@ -9,6 +9,6 @@ edition = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 nix = { workspace = true }
-spfs = { version = '0.34.6', path = "../spfs" }
+spfs = { path = "../spfs" }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["rt"] }

--- a/crates/spk-schema/Cargo.toml
+++ b/crates/spk-schema/Cargo.toml
@@ -20,7 +20,7 @@ relative-path = "1.3"
 serde = { workspace = true, features = ["derive"] }
 serde_yaml = "0.8.17"
 serde_json = { workspace = true }
-spfs = { version = '0.34.6', path = "../spfs" }
+spfs = { path = "../spfs" }
 shellexpand = "3.1.0"
 spk-schema-foundation = { path = "./crates/foundation" }
 spk-schema-ident = { path = "./crates/ident" }

--- a/crates/spk-schema/crates/foundation/Cargo.toml
+++ b/crates/spk-schema/crates/foundation/Cargo.toml
@@ -27,7 +27,7 @@ ring = "0.16.15"
 rstest = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_yaml = "0.8.17"
-spfs = { version = '0.34.6', path = "../../../spfs" }
+spfs = { path = "../../../spfs" }
 sys-info = "0.9.0"
 tempfile = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/spk-schema/crates/validators/Cargo.toml
+++ b/crates/spk-schema/crates/validators/Cargo.toml
@@ -22,7 +22,7 @@ ring = "0.16.15"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_yaml = "0.8.17"
-spfs = { version = '0.34.6', path = "../../../spfs" }
+spfs = { path = "../../../spfs" }
 spk-schema-foundation = { path = "../foundation" }
 spk-schema-ident = { path = "../ident" }
 sys-info = "0.9.0"

--- a/crates/spk-solve/Cargo.toml
+++ b/crates/spk-solve/Cargo.toml
@@ -34,7 +34,7 @@ rug = "1.17.0"
 serde_json = { workspace = true }
 sentry = { workspace = true, optional = true }
 signal-hook = "0.3"
-spfs = { version = '0.34.6', path = "../spfs" }
+spfs = { path = "../spfs" }
 spk-config = { path = "../spk-config" }
 spk-solve-graph = { path = "./crates/graph" }
 spk-solve-package-iterator = { path = "./crates/package-iterator" }

--- a/crates/spk-solve/crates/graph/Cargo.toml
+++ b/crates/spk-solve/crates/graph/Cargo.toml
@@ -24,7 +24,7 @@ itertools = "0.10"
 once_cell = { workspace = true }
 priority-queue = "1.2"
 serde_json = { workspace = true }
-spfs = { version = '0.34.6', path = "../../../spfs" }
+spfs = { path = "../../../spfs" }
 spk-solve-package-iterator = { path = "../package-iterator" }
 spk-solve-solution = { path = "../solution" }
 spk-schema = { path = "../../../spk-schema" }

--- a/crates/spk-solve/crates/solution/Cargo.toml
+++ b/crates/spk-solve/crates/solution/Cargo.toml
@@ -13,7 +13,7 @@ migration-to-components = [
 [dependencies]
 colored = { workspace = true }
 console =  { workspace = true }
-spfs = { version = '0.34.6', path = "../../../spfs" }
+spfs = { path = "../../../spfs" }
 spk-schema = { path = "../../../spk-schema" }
 spk-storage = { path = "../../../spk-storage" }
 thiserror = { workspace = true }

--- a/crates/spk-solve/crates/validation/Cargo.toml
+++ b/crates/spk-solve/crates/validation/Cargo.toml
@@ -19,7 +19,7 @@ enum_dispatch = "0.3.8"
 futures = { workspace = true }
 itertools = "0.10"
 once_cell = { workspace = true }
-spfs = { version = '0.34.6', path = "../../../spfs" }
+spfs = { path = "../../../spfs" }
 spk-solve-graph = { path = "../graph" }
 spk-solve-solution = { path = "../solution" }
 spk-schema = { path = "../../../spk-schema" }

--- a/crates/spk-storage/Cargo.toml
+++ b/crates/spk-storage/Cargo.toml
@@ -34,7 +34,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_yaml = "0.8.17"
 sentry = { workspace = true, optional = true }
-spfs = { version = '0.34.6', path = "../spfs" }
+spfs = { path = "../spfs" }
 spk-schema = { path = "../spk-schema" }
 sys-info = "0.9.0"
 tar = "0.4.30"


### PR DESCRIPTION
It is redundant (in a sense) to specify the version number in these dependency entries, and having these causes a large diff when bumping the version number of the spfs crate.