### PR TITLE
Use sccache for coverage.yml

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,6 +19,10 @@ jobs:
     container:
       image: xd009642/tarpaulin:0.26.0
       options: --security-opt seccomp=unconfined --privileged
+    env:
+      # Enable sccache for rust
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
     steps:
       - name: Setup spfs repos
         run: |
@@ -39,10 +43,23 @@ jobs:
           # spfs "custom build command" needs rustfmt? (protobufs?)
           rustup component add rustfmt
       - uses: actions/checkout@v3
-      - uses: Swatinem/rust-cache@v2
-      - name: Install spfs
+      - name: Configure cargo
         run: |
-          make install-debug-spfs
+          mkdir -p .cargo
+          cat << EOF > .cargo/config.toml
+          [build]
+          # Disable incremental compilation to lower disk usage, and sccache
+          # can't cache incremental compiles.
+          incremental = false
+
+          [profile.dev]
+          # Disable debug information to lower disk usage.
+          debug = false
+          EOF
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.3
+      - name: Install spfs
+        run: make install-debug-spfs FEATURES=server,spfs/server
       - name: Generate code coverage
         run: |
           # Enable migration-to-components feature here so that the test suite

--- a/crates/spk-build/src/build/binary.rs
+++ b/crates/spk-build/src/build/binary.rs
@@ -77,7 +77,7 @@ pub enum BuildSource {
     LocalPath(PathBuf),
 }
 
-/// A pair of packages that are in conlict for some reason,
+/// A pair of packages that are in conflict for some reason,
 /// e.g. because they both provide one or more of the same files.
 #[derive(Eq, Hash, PartialEq)]
 struct ConflictingPackagePair(BuildIdent, BuildIdent);


### PR DESCRIPTION
The coverage job is now also failing with out of disk space errors. Switch to sccache like was done for the rust job, to reduce disk usage (hopefully!).

Include a spelling correction so there is a change to a source file so the coverage job will run, to verify this change.