### PR TITLE
Make range_indent parsing function a combinable parser

### DIFF
--- a/crates/spk-schema/crates/ident/src/parsing/parsing_test.rs
+++ b/crates/spk-schema/crates/ident/src/parsing/parsing_test.rs
@@ -521,7 +521,7 @@ proptest! {
 #[test]
 fn parse_range_ident_with_basic_errors() {
     let empty = HashSet::new();
-    let r = crate::parsing::range_ident::<(_, ErrorKind)>(&empty, "pkg-name");
+    let r = crate::parsing::range_ident::<(_, ErrorKind)>(&empty)("pkg-name");
     assert!(r.is_ok(), "{}", r.unwrap_err());
 }
 

--- a/crates/spk-schema/crates/ident/src/range_ident.rs
+++ b/crates/spk-schema/crates/ident/src/range_ident.rs
@@ -7,6 +7,7 @@ use std::fmt::Write;
 use std::str::FromStr;
 
 use itertools::Itertools;
+use nom::combinator::all_consuming;
 use serde::{Deserialize, Serialize};
 use spk_schema_foundation::ident_build::Build;
 use spk_schema_foundation::ident_component::{Component, Components};
@@ -310,12 +311,14 @@ impl FromStr for RangeIdent {
     type Err = crate::Error;
 
     fn from_str(s: &str) -> crate::Result<Self> {
-        crate::parsing::range_ident::<nom_supreme::error::ErrorTree<_>>(&KNOWN_REPOSITORY_NAMES, s)
-            .map(|(_, ident)| ident)
-            .map_err(|err| match err {
-                nom::Err::Error(e) | nom::Err::Failure(e) => crate::Error::String(e.to_string()),
-                nom::Err::Incomplete(_) => unreachable!(),
-            })
+        all_consuming(crate::parsing::range_ident::<
+            nom_supreme::error::ErrorTree<_>,
+        >(&KNOWN_REPOSITORY_NAMES))(s)
+        .map(|(_, ident)| ident)
+        .map_err(|err| match err {
+            nom::Err::Error(e) | nom::Err::Failure(e) => crate::Error::String(e.to_string()),
+            nom::Err::Incomplete(_) => unreachable!(),
+        })
     }
 }
 


### PR DESCRIPTION
This tidy up changes `range_indent` parsing function into a more combinable parser by making it return a parsing function, and by removing its use of the `all_consuming` combinator. The existing code that uses `range_ident` is updated to wrap it in `all_consuming` when needed.

This makes it easier to use to create other parsers, e.g. a parser for a list of RangeIdents. 