### PR TITLE
Fix test_runtime_cleanup.sh spurious failure

### DIFF
--- a/crates/spfs/tests/integration/unprivileged/test_runtime_cleanup.sh
+++ b/crates/spfs/tests/integration/unprivileged/test_runtime_cleanup.sh
@@ -21,12 +21,15 @@ get_spfs_monitor_count() {
 }
 
 wait_for_spfs_monitor_count() {
+    expected_count=$1
+    sleep_duration=${2:-2}
+
     set +x
-    if test $(get_spfs_monitor_count) -ne $1; then
+    if test $(get_spfs_monitor_count) -ne $expected_count; then
         echo waiting for monitors...
     fi
-    until test $(get_spfs_monitor_count) -eq $1; do sleep 2; done
-    sleep 2;
+    until test $(get_spfs_monitor_count) -eq $expected_count; do sleep $sleep_duration; done
+    sleep $sleep_duration;
     set -x
 }
 
@@ -56,11 +59,17 @@ spfs run - -- spfs run - -- spfs run - -- spfs run - -- sleep 8 &
 # and can be cleaned up immediately
 
 # wait for them all to spin up
-sleep 4
+sleep 1
 
-# the outer runtimes are cleaned up
-wait_for_spfs_monitor_count 1
-assert_runtime_count 1
+# the outer runtimes are cleaned up. Retry aggressively to
+# not miss the window where the count is 1.
+wait_for_spfs_monitor_count 1 0.1
+# don't `assert_runtime_count 1` here because there is a
+# race between seeing the monitor count as 1 and that
+# monitor exiting and removing the runtime. It is possible
+# the runtime count is now 0. The assert that the runtime
+# count is 0 below will prove that this runtime was cleaned
+# too.
 
 # then the one remaining runtime is cleaned up
 wait_for_spfs_monitor_count 0


### PR DESCRIPTION
Yet another way this test spuriously fails. The latest was it finding 2 runtime instead of 1 at the place where the test has now been modified.