### PR TITLE
Make 'spk env package.yaml@build' start an editable /spfs environment

### DIFF
--- a/crates/spk-cli/cmd-env/src/cmd_env.rs
+++ b/crates/spk-cli/cmd-env/src/cmd_env.rs
@@ -50,8 +50,6 @@ impl Run for Env {
             .runtime
             .ensure_active_runtime(&["env", "run", "shell"])
             .await?;
-        rt.status.editable =
-            self.runtime.editable() || self.requests.any_build_stage_requests(&self.requested)?;
 
         let mut solver = self.solver.get_solver(&self.options).await?;
 
@@ -67,6 +65,9 @@ impl Run for Env {
         let (solution, _) = formatter.run_and_print_resolve(&solver).await?;
 
         let solution = build_required_packages(&solution).await?;
+
+        rt.status.editable =
+            self.runtime.editable() || self.requests.any_build_stage_requests(&self.requested)?;
         setup_runtime(&mut rt, &solution).await?;
 
         let env = solution.to_environment(Some(std::env::vars()));

--- a/crates/spk-cli/common/src/flags.rs
+++ b/crates/spk-cli/common/src/flags.rs
@@ -478,6 +478,8 @@ impl Requests {
         Ok(out)
     }
 
+    /// Returns Ok(true) if the requests contain any request with a
+    /// @build stage specified, otherwise it returns Ok(false).
     pub fn any_build_stage_requests<I, S>(&self, requests: I) -> Result<bool>
     where
         I: IntoIterator<Item = S>,


### PR DESCRIPTION
This makes `spk env package.yaml@build` command start an editable spfs runtime environment.

It splits up an existing parsing and package spec/recipe loading function into 2 functions to allow the check for `@build` requests to use the same parsing for stages.

Closes: #841 
