### PR TITLE
Add missing cfg feature for fuse code

### DIFF
--- a/crates/spfs/src/env.rs
+++ b/crates/spfs/src/env.rs
@@ -450,6 +450,7 @@ where
         self.mount_fuse_onto(rt, SPFS_DIR).await
     }
 
+    #[cfg(feature = "fuse-backend")]
     async fn mount_fuse_onto<P>(&self, rt: &runtime::Runtime, path: P) -> Result<()>
     where
         P: AsRef<std::ffi::OsStr>,


### PR DESCRIPTION
This missing cfg would cause compile errors when compiling without the fuse-backend feature enabled.