### PR TITLE
Fix lost deletion error in remove_package_from_storage

### DIFF
--- a/crates/spk-storage/src/storage/spfs.rs
+++ b/crates/spk-storage/src/storage/spfs.rs
@@ -569,7 +569,15 @@ impl Storage for SPFSRepository {
             (Err(err), _) => Err(err),
             (_, Err(err)) => Err(err),
         })
-        .map(|_| ())
+        .and_then(|deleted_something| {
+            if deleted_something {
+                Ok(())
+            } else {
+                Err(Error::SpkValidatorsError(
+                    spk_schema::validators::Error::PackageNotFoundError(pkg.to_any()),
+                ))
+            }
+        })
     }
 }
 


### PR DESCRIPTION
Rather than discarding the Ok value after this fold, check if it is
Ok(false) and return a PackageNotFoundError instead.

Signed-off-by: J Robert Ray <jrray@jrray.org>