### PR TITLE
Support double underscores for env overrides

### DIFF
--- a/crates/spfs/src/config.rs
+++ b/crates/spfs/src/config.rs
@@ -527,6 +527,13 @@ pub fn load_config() -> Result<Config> {
         .add_source(File::new(&format!("{}.conf", user_config.display()), Ini).required(false))
         // the user config can also be in any support format: toml, yaml, json, ini, etc
         .add_source(File::with_name(&format!("{}", user_config.display())).required(false))
+        // Note: if a var using single underscores is set, it will have precedence
+        .add_source(
+            Environment::with_prefix("SPFS")
+                .prefix_separator("_")
+                .separator("__"),
+        )
+        // for backwards compatibility with vars not using double underscores
         .add_source(Environment::with_prefix("SPFS").separator("_"))
         .build()?;
 


### PR DESCRIPTION
The `config` crate's stance on handling env overrides for nested structs that have field names with underscores is to set the separator to "__", as in:

    # unambiguously specify spfs::Config::SubStruct::example_field
    export SPFS_SUBSTRUCT__EXAMPLE_FIELD="..."

Support this while maintaining backwards compatibility by adding two `Environment::with_prefix` sources. The one that looks for "__" is last so it takes precedence.

Add a test to verify the precedence behavior and confirm backwards compatibility with the single underscore names. `$SPFS_STORAGE_ROOT` will still be recognized.

Spk's config has been updated to behave the same way, but **not in a backward compatible way**. Since the spk config file is relatively new there is an assumption that there aren't any entrenched use cases that were depending on the custom env injection found in spk's config.rs.

Using double underscores will handle nested structs of any depth and so it is a slight win over the custom code that only handles one level of nesting, and behavior consistency between spfs and spk is important.