### PR TITLE
Add missing tracing-subscriber feature

### DIFF
--- a/crates/spfs/Cargo.toml
+++ b/crates/spfs/Cargo.toml
@@ -95,7 +95,7 @@ tonic-build = "0.8"
 criterion = { version = "0.3", features = ["async_tokio", "html_reports"] }
 rstest = { version = "0.15.0", default_features = false }
 serial_test = "0.8.0"
-tracing-subscriber = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [[bench]]
 name = "spfs_bench"


### PR DESCRIPTION
The spfs crate uses `with_env_filter` which comes from the `env-filter` feature, but it wasn't being specified. `cargo test -p spfs ...` could fail to compile.