### PR TITLE
Add env var to suppress overlayfs param warning

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,6 +20,7 @@ jobs:
       image: xd009642/tarpaulin:0.26.0
       options: --security-opt seccomp=unconfined --privileged
     env:
+      SPFS_SUPPRESS_OVERLAYFS_PARAMS_WARNING: "1"
       # Enable sccache for rust
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: "sccache"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,6 +40,7 @@ jobs:
       SPFS_MONITOR_DISABLE_CNPROC: "1"
       # Define a local origin repo for tests to use
       SPFS_REMOTE_origin_ADDRESS: "file:///tmp/spfs-repos/origin"
+      SPFS_SUPPRESS_OVERLAYFS_PARAMS_WARNING: "1"
       # Enable sccache for rust
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: "sccache"

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ cargo_packages_arg := $(if $(CRATES),-p=$(CRATES))
 cargo_packages_arg := $(subst $(comma), -p=,$(cargo_packages_arg))
 cargo_packages_arg := $(if $(cargo_packages_arg),$(cargo_packages_arg),--workspace)
 
+# Suppress this warning to not muddle the test output.
+export SPFS_SUPPRESS_OVERLAYFS_PARAMS_WARNING = 1
+
 # Create a file called "config.mak" to configure variables.
 -include config.mak
 

--- a/crates/spfs/src/runtime/overlayfs.rs
+++ b/crates/spfs/src/runtime/overlayfs.rs
@@ -28,8 +28,13 @@ pub fn is_removed_entry(meta: &std::fs::Metadata) -> bool {
 #[cached::proc_macro::once(sync_writes = true)]
 pub fn overlayfs_available_options() -> HashSet<String> {
     query_overlayfs_available_options().unwrap_or_else(|err| {
-        tracing::warn!("Failed to detect supported overlayfs params: {err}");
-        tracing::warn!(" > Falling back to the most conservative set, which is undesirable");
+        if std::env::var("SPFS_SUPPRESS_OVERLAYFS_PARAMS_WARNING").is_err() {
+            tracing::warn!("Failed to detect supported overlayfs params: {err}");
+            tracing::warn!(" > Falling back to the most conservative set, which is undesirable");
+            tracing::warn!(
+                " > To suppress this warning, set SPFS_SUPPRESS_OVERLAYFS_PARAMS_WARNING=1"
+            );
+        }
         Default::default()
     })
 }


### PR DESCRIPTION
When running the test suite, this warning dominates the test output for some of the tests:

```
test build::binary::binary_test::test_build_bad_options ... ok
 WARN Failed to detect supported overlayfs params: OverlayFS kernel module does not appear to be installed
 WARN  > Falling back to the most conservative set, which is undesirable
 WARN Failed to detect supported overlayfs params: OverlayFS kernel module does not appear to be installed
 WARN  > Falling back to the most conservative set, which is undesirable
+ touch /spfs/dep-file
 WARN Failed to detect supported overlayfs params: OverlayFS kernel module does not appear to be installed
 WARN  > Falling back to the most conservative set, which is undesirable
 WARN Failed to detect supported overlayfs params: OverlayFS kernel module does not appear to be installed
 WARN  > Falling back to the most conservative set, which is undesirable
 WARN Failed to detect supported overlayfs params: OverlayFS kernel module does not appear to be installed
 WARN  > Falling back to the most conservative set, which is undesirable
+ touch /spfs/dep-file
 WARN Failed to detect supported overlayfs params: OverlayFS kernel module does not appear to be installed
 WARN  > Falling back to the most conservative set, which is undesirable
 WARN Failed to detect supported overlayfs params: OverlayFS kernel module does not appear to be installed
 WARN  > Falling back to the most conservative set, which is undesirable
 WARN Failed to detect supported overlayfs params: OverlayFS kernel module does not appear to be installed
 WARN  > Falling back to the most conservative set, which is undesirable
+ touch /spfs/top-file
 WARN Failed to detect supported overlayfs params: OverlayFS kernel module does not appear to be installed
 WARN  > Falling back to the most conservative set, which is undesirable
 WARN Failed to detect supported overlayfs params: OverlayFS kernel module does not appear to be installed
 WARN  > Falling back to the most conservative set, which is undesirable
 WARN Failed to detect supported overlayfs params: OverlayFS kernel module does not appear to be installed
 WARN  > Falling back to the most conservative set, which is undesirable
+ touch /spfs/top-file
 WARN Failed to detect supported overlayfs params: OverlayFS kernel module does not appear to be installed
 WARN  > Falling back to the most conservative set, which is undesirable
 WARN Failed to detect supported overlayfs params: OverlayFS kernel module does not appear to be installed
 WARN  > Falling back to the most conservative set, which is undesirable
 ```