### PR TITLE
Add lazy filesystem repositories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
+name = "arc-swap"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
+
+[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3093,6 +3099,7 @@ dependencies = [
 name = "spfs"
 version = "0.34.6"
 dependencies = [
+ "arc-swap",
  "async-compression",
  "async-recursion",
  "async-stream",
@@ -3287,6 +3294,7 @@ version = "0.34.6"
 dependencies = [
  "anyhow",
  "clap 4.3.0",
+ "futures",
  "serde_json",
  "spfs",
  "spfs-cli-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ version = "0.36.0"
 
 [workspace.dependencies]
 anyhow = "1.0"
+arc-swap = "1.6.0"
 async-trait = "0.1"
 cached = "0.42.0"
 chrono = { version = "0.4.19", features = ["serde"] }

--- a/crates/spfs-cli/cmd-render/Cargo.toml
+++ b/crates/spfs-cli/cmd-render/Cargo.toml
@@ -14,6 +14,7 @@ sentry = ["spfs-cli-common/sentry"]
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
+futures = { workspace = true }
 serde_json = { workspace = true }
 spfs = { path = "../../spfs" }
 spfs-cli-common = { path = "../common" }

--- a/crates/spfs-cli/cmd-render/src/cmd_render.rs
+++ b/crates/spfs-cli/cmd-render/src/cmd_render.rs
@@ -53,7 +53,7 @@ impl CmdRender {
     pub async fn run(&mut self, config: &spfs::Config) -> Result<i32> {
         let env_spec = spfs::tracking::EnvSpec::parse(&self.reference)?;
         let (repo, origin, remotes) = tokio::try_join!(
-            config.get_local_repository(),
+            config.get_opened_local_repository(),
             config.get_remote("origin"),
             config.list_remotes()
         )?;

--- a/crates/spfs-vfs/src/fuse.rs
+++ b/crates/spfs-vfs/src/fuse.rs
@@ -354,6 +354,10 @@ impl Filesystem {
         for repo in self.repos.iter() {
             match &**repo {
                 spfs::storage::RepositoryHandle::FS(fs_repo) => {
+                    let Ok(fs_repo) = fs_repo.opened().await else {
+                        reply.error(libc::ENOENT);
+                        return;
+                    };
                     let payload_path = fs_repo.payloads.build_digest_path(digest);
                     match std::fs::OpenOptions::new().read(true).open(payload_path) {
                         Ok(file) => {

--- a/crates/spfs/Cargo.toml
+++ b/crates/spfs/Cargo.toml
@@ -16,6 +16,7 @@ server = ["hyper/server", "tokio-util/codec", "tokio-util/io-util"]
 fuse-backend = ["dep:fuser"]
 
 [dependencies]
+arc-swap = { workspace = true }
 async-compression = { version = "0.3.15", features = ["tokio", "bzip2"] }
 async-trait = "0.1.52"
 async-recursion = "1.0"

--- a/crates/spfs/src/clean_test.rs
+++ b/crates/spfs/src/clean_test.rs
@@ -252,8 +252,9 @@ async fn test_clean_manifest_renders(tmpdir: tempfile::TempDir) {
         RepositoryHandle::FS(fs) => fs,
         _ => panic!("Unexpected tmprepo type!"),
     };
+    let fs_repo = fs_repo.opened().await.unwrap();
 
-    storage::fs::Renderer::new(fs_repo)
+    storage::fs::Renderer::new(&*fs_repo)
         .render_manifest(&graph::Manifest::from(&manifest), None)
         .await
         .unwrap();

--- a/crates/spfs/src/resolve.rs
+++ b/crates/spfs/src/resolve.rs
@@ -338,7 +338,8 @@ pub(crate) async fn resolve_and_render_overlay_dirs(
     skip_runtime_save: bool,
 ) -> Result<RenderResult> {
     let config = get_config()?;
-    let (repo, remotes) = tokio::try_join!(config.get_local_repository(), config.list_remotes())?;
+    let (repo, remotes) =
+        tokio::try_join!(config.get_opened_local_repository(), config.list_remotes())?;
     let fallback_repo = FallbackProxy::new(repo, remotes);
 
     let manifests = resolve_overlay_dirs(runtime, &fallback_repo, skip_runtime_save).await?;

--- a/crates/spfs/src/resolve_test.rs
+++ b/crates/spfs/src/resolve_test.rs
@@ -40,9 +40,9 @@ async fn test_auto_merge_layers(tmpdir: tempfile::TempDir) {
     // This test must use the "local" repository for spfs-render to succeed.
     let config = crate::get_config().expect("get config");
     let fs_repo = config
-        .get_local_repository()
+        .get_opened_local_repository()
         .await
-        .expect("get local repository");
+        .expect("open local repository");
     let repo = Arc::new(fs_repo.clone().into());
     let mut layers = Vec::with_capacity(NUM_LAYERS);
     for num in 0..NUM_LAYERS {

--- a/crates/spfs/src/storage/fallback/repository_test.rs
+++ b/crates/spfs/src/storage/fallback/repository_test.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
+use std::sync::Arc;
+
 use rstest::rstest;
 
 use crate::fixtures::*;
@@ -12,12 +14,16 @@ use crate::prelude::*;
 async fn test_proxy_payload_repair(tmpdir: tempfile::TempDir) {
     init_logging();
 
-    let primary = crate::storage::fs::FSRepository::create(tmpdir.path().join("primary"))
-        .await
-        .unwrap();
-    let secondary = crate::storage::fs::FSRepository::create(tmpdir.path().join("secondary"))
-        .await
-        .unwrap();
+    let primary = Arc::new(
+        crate::storage::fs::OpenFsRepository::create(tmpdir.path().join("primary"))
+            .await
+            .unwrap(),
+    );
+    let secondary = Arc::new(
+        crate::storage::fs::OpenFsRepository::create(tmpdir.path().join("secondary"))
+            .await
+            .unwrap(),
+    );
 
     let digest = primary
         .commit_blob(Box::pin(b"some data".as_slice()))

--- a/crates/spfs/src/storage/fs/mod.rs
+++ b/crates/spfs/src/storage/fs/mod.rs
@@ -31,4 +31,10 @@ pub use renderer::{
     DEFAULT_MAX_CONCURRENT_BLOBS,
     DEFAULT_MAX_CONCURRENT_BRANCHES,
 };
-pub use repository::{read_last_migration_version, Config, FSRepository, RenderStore};
+pub use repository::{
+    read_last_migration_version,
+    Config,
+    FSRepository,
+    OpenFsRepository,
+    RenderStore,
+};

--- a/crates/spfs/src/storage/fs/payloads.rs
+++ b/crates/spfs/src/storage/fs/payloads.rs
@@ -5,15 +5,54 @@
 use std::io::ErrorKind;
 use std::pin::Pin;
 
-use futures::Stream;
+use futures::future::ready;
+use futures::{Stream, StreamExt, TryFutureExt};
 
-use super::FSRepository;
+use super::{FSRepository, OpenFsRepository};
 use crate::storage::prelude::*;
 use crate::tracking::BlobRead;
 use crate::{encoding, Error, Result};
 
 #[async_trait::async_trait]
 impl crate::storage::PayloadStorage for FSRepository {
+    async fn has_payload(&self, digest: encoding::Digest) -> bool {
+        let Ok(opened) = self.opened().await else {
+            return false;
+        };
+        opened.has_payload(digest).await
+    }
+
+    fn iter_payload_digests(&self) -> Pin<Box<dyn Stream<Item = Result<encoding::Digest>> + Send>> {
+        self.opened()
+            .and_then(|opened| ready(Ok(opened.iter_payload_digests())))
+            .try_flatten_stream()
+            .boxed()
+    }
+
+    async unsafe fn write_data(
+        &self,
+        reader: Pin<Box<dyn BlobRead>>,
+    ) -> Result<(encoding::Digest, u64)> {
+        let opened = self.opened().await?;
+        // Safety: we are simply deferring this function to the inner
+        // one and so the same safety rules apply to our caller
+        unsafe { opened.write_data(reader).await }
+    }
+
+    async fn open_payload(
+        &self,
+        digest: encoding::Digest,
+    ) -> Result<(Pin<Box<dyn BlobRead>>, std::path::PathBuf)> {
+        self.opened().await?.open_payload(digest).await
+    }
+
+    async fn remove_payload(&self, digest: encoding::Digest) -> Result<()> {
+        self.opened().await?.remove_payload(digest).await
+    }
+}
+
+#[async_trait::async_trait]
+impl crate::storage::PayloadStorage for OpenFsRepository {
     async fn has_payload(&self, digest: encoding::Digest) -> bool {
         let path = self.payloads.build_digest_path(&digest);
         tokio::fs::symlink_metadata(path).await.is_ok()

--- a/crates/spfs/src/storage/fs/renderer_unix.rs
+++ b/crates/spfs/src/storage/fs/renderer_unix.rs
@@ -23,7 +23,12 @@ use tokio::sync::Semaphore;
 use crate::encoding::{self, Encodable};
 use crate::runtime::makedirs_with_perms;
 use crate::storage::fs::render_reporter::RenderBlobResult;
-use crate::storage::fs::{FSRepository, ManifestRenderPath, RenderReporter, SilentRenderReporter};
+use crate::storage::fs::{
+    ManifestRenderPath,
+    OpenFsRepository,
+    RenderReporter,
+    SilentRenderReporter,
+};
 use crate::storage::prelude::*;
 use crate::storage::LocalRepository;
 use crate::{get_config, graph, tracking, Error, Result};
@@ -47,7 +52,7 @@ pub enum RenderType {
     Copy,
 }
 
-impl FSRepository {
+impl OpenFsRepository {
     fn get_render_storage(&self) -> Result<&crate::storage::fs::FSHashStore> {
         match &self.renders {
             Some(render_store) => Ok(&render_store.renders),
@@ -152,7 +157,7 @@ impl FSRepository {
     }
 }
 
-impl ManifestRenderPath for FSRepository {
+impl ManifestRenderPath for OpenFsRepository {
     fn manifest_render_path(&self, manifest: &graph::Manifest) -> Result<PathBuf> {
         Ok(self
             .get_render_storage()?

--- a/crates/spfs/src/storage/fs/renderer_win.rs
+++ b/crates/spfs/src/storage/fs/renderer_win.rs
@@ -13,7 +13,7 @@ use tokio::sync::Semaphore;
 
 use crate::encoding::{self, Encodable};
 use crate::runtime::makedirs_with_perms;
-use crate::storage::fs::{FSRepository, RenderReporter, SilentRenderReporter};
+use crate::storage::fs::{OpenFsRepository, RenderReporter, SilentRenderReporter};
 use crate::storage::prelude::*;
 use crate::storage::LocalRepository;
 use crate::{graph, tracking, Error, Result};
@@ -37,7 +37,7 @@ pub enum RenderType {
     Copy,
 }
 
-impl FSRepository {
+impl OpenFsRepository {
     fn get_render_storage(&self) -> Result<&crate::storage::fs::FSHashStore> {
         match &self.renders {
             Some(render_store) => Ok(&render_store.renders),

--- a/crates/spfs/src/storage/mod.rs
+++ b/crates/spfs/src/storage/mod.rs
@@ -18,6 +18,8 @@ pub mod proxy;
 pub mod rpc;
 pub mod tar;
 
+use std::sync::Arc;
+
 pub use blob::BlobStorage;
 pub use layer::LayerStorage;
 pub use manifest::ManifestStorage;
@@ -80,6 +82,16 @@ impl std::ops::DerefMut for RepositoryHandle {
 impl From<fs::FSRepository> for RepositoryHandle {
     fn from(repo: fs::FSRepository) -> Self {
         RepositoryHandle::FS(repo)
+    }
+}
+impl From<fs::OpenFsRepository> for RepositoryHandle {
+    fn from(repo: fs::OpenFsRepository) -> Self {
+        RepositoryHandle::FS(repo.into())
+    }
+}
+impl From<Arc<fs::OpenFsRepository>> for RepositoryHandle {
+    fn from(repo: Arc<fs::OpenFsRepository>) -> Self {
+        RepositoryHandle::FS(repo.into())
     }
 }
 impl From<tar::TarRepository> for RepositoryHandle {

--- a/crates/spfs/src/storage/repository_test.rs
+++ b/crates/spfs/src/storage/repository_test.rs
@@ -86,12 +86,12 @@ async fn test_commit_mode_fs(tmpdir: tempfile::TempDir) {
         .expect("failed to commit dir");
 
     // Safety: tmprepo was created as an FSRepository
-    let tmprepo = match unsafe { &*Arc::into_raw(tmprepo) } {
-        RepositoryHandle::FS(fs) => fs,
+    let tmprepo = match &*tmprepo {
+        RepositoryHandle::FS(fs) => fs.opened().await.unwrap(),
         _ => panic!("Unexpected tmprepo type!"),
     };
 
-    let rendered_dir = fs::Renderer::new(tmprepo)
+    let rendered_dir = fs::Renderer::new(&*tmprepo)
         .render_manifest(&Manifest::from(&manifest), None)
         .await
         .expect("failed to render manifest");

--- a/crates/spk-cli/cmd-render/src/cmd_render.rs
+++ b/crates/spk-cli/cmd-render/src/cmd_render.rs
@@ -69,7 +69,7 @@ impl Run for Render {
         tracing::info!("Rendering into dir: {path:?}");
         let config = spfs::load_config().context("Failed to load spfs config")?;
         let local = config
-            .get_local_repository()
+            .get_opened_local_repository()
             .await
             .context("Failed to open local spfs repo")?;
 


### PR DESCRIPTION
Just like lazy gRPC repositories, this allows for creating an instance of a filesystem repository that may or may not exist yet. These repositories have an inner state that must be 'opened' in order to be used and can fail later on when they are accessed if this is the case.

The `OpenFsRepository` type is a new addition which skips the lazy validation and acts like the previous repository implementation. This opened type must be used for local filesystem renders and other runtime-related setup functions that would have be done on the normal `FSRepository` before.

This ended up being a little bit of a crazy game of wrappers, but hopefully the whole thing doesn't seem convoluted.

The error that you get when calling into a closed repo that can't open is the same as it was before since we are handling that in some places already - typically a file not found. There could be a benefit to creating a specific error for this, but I think that can be taken as a separate task, if so.

