### PR TITLE
Rename Acronyms

### DIFF
--- a/crates/spfs/benches/spfs_bench.rs
+++ b/crates/spfs/benches/spfs_bench.rs
@@ -44,7 +44,7 @@ pub fn commit_benchmark(c: &mut Criterion) {
         .expect("create a temp directory for spfs repo");
     let repo: Arc<RepositoryHandle> = Arc::new(
         tokio_runtime
-            .block_on(spfs::storage::fs::FSRepository::create(
+            .block_on(spfs::storage::fs::FsRepository::create(
                 repo_path.path().join("repo"),
             ))
             .expect("create spfs repo")

--- a/crates/spfs/src/bootstrap_test.rs
+++ b/crates/spfs/src/bootstrap_test.rs
@@ -37,7 +37,7 @@ async fn test_shell_initialization_startup_scripts(
     };
     let root = tmpdir.path().to_string_lossy().to_string();
     let repo = crate::storage::RepositoryHandle::from(
-        crate::storage::fs::FSRepository::create(&root)
+        crate::storage::fs::FsRepository::create(&root)
             .await
             .unwrap(),
     );
@@ -109,7 +109,7 @@ async fn test_shell_initialization_no_startup_scripts(shell: &str, tmpdir: tempf
     };
     let root = tmpdir.path().to_string_lossy().to_string();
     let repo = crate::storage::RepositoryHandle::from(
-        crate::storage::fs::FSRepository::create(&root)
+        crate::storage::fs::FsRepository::create(&root)
             .await
             .unwrap(),
     );

--- a/crates/spfs/src/clean.rs
+++ b/crates/spfs/src/clean.rs
@@ -657,7 +657,7 @@ where
         let removed = result.removed_proxies.entry(username).or_default();
 
         // the hash store is used to nicely iterate all stored digests
-        let proxy_storage = storage::fs::FSHashStore::open_unchecked(proxy_path);
+        let proxy_storage = storage::fs::FsHashStore::open_unchecked(proxy_path);
         let mut stream = proxy_storage
             .iter()
             .try_filter_map(|digest| {

--- a/crates/spfs/src/clean_test.rs
+++ b/crates/spfs/src/clean_test.rs
@@ -225,7 +225,7 @@ async fn test_clean_untagged_objects_layers_platforms(#[future] tmprepo: TempRep
 async fn test_clean_manifest_renders(tmpdir: tempfile::TempDir) {
     init_logging();
     let tmprepo = Arc::new(
-        storage::fs::FSRepository::create(tmpdir.path())
+        storage::fs::FsRepository::create(tmpdir.path())
             .await
             .unwrap()
             .into(),

--- a/crates/spfs/src/commit_test.rs
+++ b/crates/spfs/src/commit_test.rs
@@ -15,7 +15,7 @@ use crate::Error;
 async fn test_commit_empty(tmpdir: tempfile::TempDir) {
     let root = tmpdir.path().to_string_lossy().to_string();
     let repo = Arc::new(crate::storage::RepositoryHandle::from(
-        crate::storage::fs::FSRepository::create(root)
+        crate::storage::fs::FsRepository::create(root)
             .await
             .unwrap(),
     ));

--- a/crates/spfs/src/config.rs
+++ b/crates/spfs/src/config.rs
@@ -177,7 +177,7 @@ impl RemoteConfig {
     /// Open a handle to a repository using this configuration
     pub async fn open(&self) -> Result<storage::RepositoryHandle> {
         Ok(match self.clone() {
-            Self::Fs(config) => storage::fs::FSRepository::from_config(config).await?.into(),
+            Self::Fs(config) => storage::fs::FsRepository::from_config(config).await?.into(),
             Self::Tar(config) => storage::tar::TarRepository::from_config(config)
                 .await?
                 .into(),
@@ -342,7 +342,7 @@ impl Config {
     ///
     /// The returned repo is guaranteed to be created, valid and open already. Ie
     /// the local repository is not allowed to be lazily opened.
-    pub async fn get_local_repository(&self) -> Result<storage::fs::FSRepository> {
+    pub async fn get_local_repository(&self) -> Result<storage::fs::FsRepository> {
         self.get_opened_local_repository().await.map(Into::into)
     }
 

--- a/crates/spfs/src/config_test.rs
+++ b/crates/spfs/src/config_test.rs
@@ -39,7 +39,7 @@ async fn test_config_get_remote() {
         .tempdir()
         .unwrap();
     let remote = tmpdir.path().join("remote");
-    let _ = crate::storage::fs::FSRepository::create(&remote)
+    let _ = crate::storage::fs::FsRepository::create(&remote)
         .await
         .unwrap();
 

--- a/crates/spfs/src/error.rs
+++ b/crates/spfs/src/error.rs
@@ -106,7 +106,7 @@ pub enum Error {
 
     #[cfg(unix)]
     #[error("OverlayFS kernel module does not appear to be installed")]
-    OverlayFSNotInstalled,
+    OverlayFsNotInstalled,
 
     #[error("{}, and {} more errors during clean", errors.get(0).unwrap(), errors.len() - 1)]
     IncompleteClean { errors: Vec<Self> },

--- a/crates/spfs/src/fixtures.rs
+++ b/crates/spfs/src/fixtures.rs
@@ -118,7 +118,7 @@ pub async fn tmprepo(kind: &str) -> TempRepo {
     let tmpdir = tmpdir();
     match kind {
         "fs" => {
-            let repo = spfs::storage::fs::FSRepository::create(tmpdir.path().join("repo"))
+            let repo = spfs::storage::fs::FsRepository::create(tmpdir.path().join("repo"))
                 .await
                 .unwrap()
                 .into();
@@ -135,7 +135,7 @@ pub async fn tmprepo(kind: &str) -> TempRepo {
         "rpc" => {
             use crate::storage::prelude::*;
             let repo = std::sync::Arc::new(spfs::storage::RepositoryHandle::FS(
-                spfs::storage::fs::FSRepository::create(tmpdir.path().join("repo"))
+                spfs::storage::fs::FsRepository::create(tmpdir.path().join("repo"))
                     .await
                     .unwrap(),
             ));

--- a/crates/spfs/src/runtime/overlayfs.rs
+++ b/crates/spfs/src/runtime/overlayfs.rs
@@ -47,7 +47,7 @@ fn query_overlayfs_available_options() -> Result<HashSet<String>> {
         .map_err(|err| Error::process_spawn_error("/sbin/modinfo", err, None))?;
 
     if output.status.code().unwrap_or(1) != 0 {
-        return Err(Error::OverlayFSNotInstalled);
+        return Err(Error::OverlayFsNotInstalled);
     }
 
     parse_modinfo_params(&mut BufReader::new(output.stdout.as_slice()))

--- a/crates/spfs/src/runtime/storage_test.rs
+++ b/crates/spfs/src/runtime/storage_test.rs
@@ -26,7 +26,7 @@ fn test_config_serialization() {
 async fn test_storage_create_runtime(tmpdir: tempfile::TempDir) {
     let root = tmpdir.path().to_string_lossy().to_string();
     let repo = crate::storage::RepositoryHandle::from(
-        crate::storage::fs::FSRepository::create(root)
+        crate::storage::fs::FsRepository::create(root)
             .await
             .unwrap(),
     );
@@ -46,7 +46,7 @@ async fn test_storage_create_runtime(tmpdir: tempfile::TempDir) {
 async fn test_storage_remove_runtime(tmpdir: tempfile::TempDir) {
     let root = tmpdir.path().to_string_lossy().to_string();
     let repo = crate::storage::RepositoryHandle::from(
-        crate::storage::fs::FSRepository::create(root)
+        crate::storage::fs::FsRepository::create(root)
             .await
             .unwrap(),
     );
@@ -67,7 +67,7 @@ async fn test_storage_remove_runtime(tmpdir: tempfile::TempDir) {
 async fn test_storage_iter_runtimes(tmpdir: tempfile::TempDir) {
     let root = tmpdir.path().to_string_lossy().to_string();
     let repo = crate::storage::RepositoryHandle::from(
-        crate::storage::fs::FSRepository::create(root)
+        crate::storage::fs::FsRepository::create(root)
             .await
             .unwrap(),
     );
@@ -119,7 +119,7 @@ async fn test_storage_iter_runtimes(tmpdir: tempfile::TempDir) {
 async fn test_runtime_reset(tmpdir: tempfile::TempDir) {
     let root = tmpdir.path().to_string_lossy().to_string();
     let repo = crate::storage::RepositoryHandle::from(
-        crate::storage::fs::FSRepository::create(root)
+        crate::storage::fs::FsRepository::create(root)
             .await
             .unwrap(),
     );

--- a/crates/spfs/src/storage/fallback/repository.rs
+++ b/crates/spfs/src/storage/fallback/repository.rs
@@ -11,7 +11,7 @@ use relative_path::RelativePath;
 
 use crate::config::ToAddress;
 use crate::prelude::*;
-use crate::storage::fs::{FSHashStore, ManifestRenderPath, OpenFsRepository, RenderStore};
+use crate::storage::fs::{FsHashStore, ManifestRenderPath, OpenFsRepository, RenderStore};
 use crate::storage::tag::TagSpecAndTagStream;
 use crate::storage::{EntryType, LocalRepository};
 use crate::tracking::BlobRead;
@@ -351,7 +351,7 @@ impl Repository for FallbackProxy {
 
 impl LocalRepository for FallbackProxy {
     #[inline]
-    fn payloads(&self) -> &FSHashStore {
+    fn payloads(&self) -> &FsHashStore {
         self.primary.payloads()
     }
 

--- a/crates/spfs/src/storage/fs/database.rs
+++ b/crates/spfs/src/storage/fs/database.rs
@@ -17,7 +17,7 @@ use crate::graph::Object;
 use crate::{encoding, graph, Error, Result};
 
 #[async_trait::async_trait]
-impl DatabaseView for super::FSRepository {
+impl DatabaseView for super::FsRepository {
     async fn has_object(&self, digest: encoding::Digest) -> bool {
         let Ok(opened) = self.opened().await else {
             return false;
@@ -56,7 +56,7 @@ impl DatabaseView for super::FSRepository {
 }
 
 #[async_trait::async_trait]
-impl graph::Database for super::FSRepository {
+impl graph::Database for super::FsRepository {
     async fn write_object(&self, obj: &graph::Object) -> Result<()> {
         self.opened().await?.write_object(obj).await
     }

--- a/crates/spfs/src/storage/fs/hash_store.rs
+++ b/crates/spfs/src/storage/fs/hash_store.rs
@@ -35,7 +35,7 @@ pub(crate) enum PersistableObject {
     },
 }
 
-pub struct FSHashStore {
+pub struct FsHashStore {
     root: PathBuf,
     /// permissions used when creating new directories
     pub directory_permissions: u32,
@@ -43,7 +43,7 @@ pub struct FSHashStore {
     pub file_permissions: u32,
 }
 
-impl FSHashStore {
+impl FsHashStore {
     pub fn open<P: AsRef<Path>>(root: P) -> Result<Self> {
         let root = root.as_ref();
         Ok(Self::open_unchecked(

--- a/crates/spfs/src/storage/fs/hash_store_test.rs
+++ b/crates/spfs/src/storage/fs/hash_store_test.rs
@@ -14,7 +14,7 @@ use crate::storage::fs::hash_store::PersistableObject;
 #[tokio::test]
 async fn test_hash_store_iter_states(tmpdir: tempfile::TempDir) {
     init_logging();
-    let store = super::FSHashStore::open(tmpdir.path()).unwrap();
+    let store = super::FsHashStore::open(tmpdir.path()).unwrap();
     let mut stream = Box::pin(store.iter());
     while stream.next().await.is_some() {
         panic!("empty hash store should not yield any digests");
@@ -33,7 +33,7 @@ macro_rules! digest {
 #[tokio::test]
 async fn test_hash_store_find_digest(tmpdir: tempfile::TempDir) {
     init_logging();
-    let store = super::FSHashStore::open(tmpdir.path()).unwrap();
+    let store = super::FsHashStore::open(tmpdir.path()).unwrap();
     let content = ["AAA", "ABC", "ABD", "BBB", "BCD", "CCC", "EEE"];
     for s in content {
         store

--- a/crates/spfs/src/storage/fs/mod.rs
+++ b/crates/spfs/src/storage/fs/mod.rs
@@ -16,7 +16,7 @@ mod tag;
 pub mod migrations;
 mod render_reporter;
 
-pub use hash_store::FSHashStore;
+pub use hash_store::FsHashStore;
 pub use manifest_render_path::ManifestRenderPath;
 pub use render_reporter::{
     ConsoleRenderReporter,
@@ -34,7 +34,7 @@ pub use renderer::{
 pub use repository::{
     read_last_migration_version,
     Config,
-    FSRepository,
+    FsRepository,
     OpenFsRepository,
     RenderStore,
 };

--- a/crates/spfs/src/storage/fs/payloads.rs
+++ b/crates/spfs/src/storage/fs/payloads.rs
@@ -8,13 +8,13 @@ use std::pin::Pin;
 use futures::future::ready;
 use futures::{Stream, StreamExt, TryFutureExt};
 
-use super::{FSRepository, OpenFsRepository};
+use super::{FsRepository, OpenFsRepository};
 use crate::storage::prelude::*;
 use crate::tracking::BlobRead;
 use crate::{encoding, Error, Result};
 
 #[async_trait::async_trait]
-impl crate::storage::PayloadStorage for FSRepository {
+impl crate::storage::PayloadStorage for FsRepository {
     async fn has_payload(&self, digest: encoding::Digest) -> bool {
         let Ok(opened) = self.opened().await else {
             return false;

--- a/crates/spfs/src/storage/fs/renderer_test.rs
+++ b/crates/spfs/src/storage/fs/renderer_test.rs
@@ -10,7 +10,7 @@ use super::was_render_completed;
 use crate::encoding::Encodable;
 use crate::fixtures::*;
 use crate::graph::Manifest;
-use crate::storage::fs::{FSRepository, OpenFsRepository};
+use crate::storage::fs::{FsRepository, OpenFsRepository};
 use crate::storage::{Repository, RepositoryHandle};
 use crate::tracking;
 
@@ -54,7 +54,7 @@ async fn test_render_manifest(tmpdir: tempfile::TempDir) {
 #[tokio::test]
 async fn test_render_manifest_with_repo(tmpdir: tempfile::TempDir) {
     let tmprepo = Arc::new(
-        FSRepository::create(tmpdir.path().join("repo"))
+        FsRepository::create(tmpdir.path().join("repo"))
             .await
             .unwrap()
             .into(),
@@ -71,7 +71,7 @@ async fn test_render_manifest_with_repo(tmpdir: tempfile::TempDir) {
         .unwrap();
     let manifest = Manifest::from(&expected_manifest);
 
-    // Safety: tmprepo was created as an FSRepository
+    // Safety: tmprepo was created as an FsRepository
     let tmprepo = match &*tmprepo {
         RepositoryHandle::FS(fs) => fs.opened().await.unwrap(),
         _ => panic!("Unexpected tmprepo type!"),

--- a/crates/spfs/src/storage/fs/renderer_unix.rs
+++ b/crates/spfs/src/storage/fs/renderer_unix.rs
@@ -53,7 +53,7 @@ pub enum RenderType {
 }
 
 impl OpenFsRepository {
-    fn get_render_storage(&self) -> Result<&crate::storage::fs::FSHashStore> {
+    fn get_render_storage(&self) -> Result<&crate::storage::fs::FsHashStore> {
         match &self.renders {
             Some(render_store) => Ok(&render_store.renders),
             None => Err(Error::NoRenderStorage(self.address())),

--- a/crates/spfs/src/storage/fs/renderer_win.rs
+++ b/crates/spfs/src/storage/fs/renderer_win.rs
@@ -38,7 +38,7 @@ pub enum RenderType {
 }
 
 impl OpenFsRepository {
-    fn get_render_storage(&self) -> Result<&crate::storage::fs::FSHashStore> {
+    fn get_render_storage(&self) -> Result<&crate::storage::fs::FsHashStore> {
         match &self.renders {
             Some(render_store) => Ok(&render_store.renders),
             None => Err(Error::NoRenderStorage(self.address())),

--- a/crates/spfs/src/storage/fs/tag.rs
+++ b/crates/spfs/src/storage/fs/tag.rs
@@ -18,7 +18,7 @@ use futures::{Future, Stream, StreamExt, TryFutureExt};
 use relative_path::RelativePath;
 use tokio::io::{AsyncRead, AsyncSeek, AsyncWriteExt, ReadBuf};
 
-use super::{FSRepository, OpenFsRepository};
+use super::{FsRepository, OpenFsRepository};
 use crate::storage::tag::{EntryType, TagSpecAndTagStream, TagStream};
 use crate::storage::TagStorage;
 use crate::{encoding, tracking, Error, Result};
@@ -26,7 +26,7 @@ use crate::{encoding, tracking, Error, Result};
 const TAG_EXT: &str = "tag";
 
 #[async_trait::async_trait]
-impl TagStorage for FSRepository {
+impl TagStorage for FsRepository {
     fn ls_tags(
         &self,
         path: &RelativePath,

--- a/crates/spfs/src/storage/mod.rs
+++ b/crates/spfs/src/storage/mod.rs
@@ -34,7 +34,7 @@ pub use self::config::{FromConfig, FromUrl};
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
 pub enum RepositoryHandle {
-    FS(fs::FSRepository),
+    FS(fs::FsRepository),
     Tar(tar::TarRepository),
     Rpc(rpc::RpcRepository),
     FallbackProxy(Box<fallback::FallbackProxy>),
@@ -79,8 +79,8 @@ impl std::ops::DerefMut for RepositoryHandle {
     }
 }
 
-impl From<fs::FSRepository> for RepositoryHandle {
-    fn from(repo: fs::FSRepository) -> Self {
+impl From<fs::FsRepository> for RepositoryHandle {
+    fn from(repo: fs::FsRepository) -> Self {
         RepositoryHandle::FS(repo)
     }
 }

--- a/crates/spfs/src/storage/proxy/repository_test.rs
+++ b/crates/spfs/src/storage/proxy/repository_test.rs
@@ -12,10 +12,10 @@ use crate::prelude::*;
 async fn test_proxy_payload_read_through(tmpdir: tempfile::TempDir) {
     init_logging();
 
-    let primary = crate::storage::fs::FSRepository::create(tmpdir.path().join("primary"))
+    let primary = crate::storage::fs::FsRepository::create(tmpdir.path().join("primary"))
         .await
         .unwrap();
-    let secondary = crate::storage::fs::FSRepository::create(tmpdir.path().join("secondary"))
+    let secondary = crate::storage::fs::FsRepository::create(tmpdir.path().join("secondary"))
         .await
         .unwrap();
 
@@ -40,10 +40,10 @@ async fn test_proxy_payload_read_through(tmpdir: tempfile::TempDir) {
 async fn test_proxy_object_read_through(tmpdir: tempfile::TempDir) {
     init_logging();
 
-    let primary = crate::storage::fs::FSRepository::create(tmpdir.path().join("primary"))
+    let primary = crate::storage::fs::FsRepository::create(tmpdir.path().join("primary"))
         .await
         .unwrap();
-    let secondary = crate::storage::fs::FSRepository::create(tmpdir.path().join("secondary"))
+    let secondary = crate::storage::fs::FsRepository::create(tmpdir.path().join("secondary"))
         .await
         .unwrap();
 
@@ -68,10 +68,10 @@ async fn test_proxy_object_read_through(tmpdir: tempfile::TempDir) {
 async fn test_proxy_tag_read_through(tmpdir: tempfile::TempDir) {
     init_logging();
 
-    let primary = crate::storage::fs::FSRepository::create(tmpdir.path().join("primary"))
+    let primary = crate::storage::fs::FsRepository::create(tmpdir.path().join("primary"))
         .await
         .unwrap();
-    let secondary = crate::storage::fs::FSRepository::create(tmpdir.path().join("secondary"))
+    let secondary = crate::storage::fs::FsRepository::create(tmpdir.path().join("secondary"))
         .await
         .unwrap();
 

--- a/crates/spfs/src/storage/repository.rs
+++ b/crates/spfs/src/storage/repository.rs
@@ -9,7 +9,7 @@ use encoding::Encodable;
 use graph::Blob;
 use tokio_stream::StreamExt;
 
-use super::fs::{FSHashStore, RenderStore};
+use super::fs::{FsHashStore, RenderStore};
 use crate::tracking::{self, BlobRead};
 use crate::{encoding, graph, Error, Result};
 
@@ -123,7 +123,7 @@ impl<T: Repository> Repository for &T {
 /// payloads and renders, e.g., local repositories.
 pub trait LocalRepository {
     /// Return the payload storage type
-    fn payloads(&self) -> &FSHashStore;
+    fn payloads(&self) -> &FsHashStore;
 
     /// If supported, returns the type responsible for locally rendered manifests
     ///

--- a/crates/spfs/src/storage/repository_test.rs
+++ b/crates/spfs/src/storage/repository_test.rs
@@ -65,7 +65,7 @@ async fn test_commit_mode_fs(tmpdir: tempfile::TempDir) {
     init_logging();
     let dir = tmpdir.path();
     let tmprepo = Arc::new(
-        fs::FSRepository::create(dir.join("repo"))
+        fs::FsRepository::create(dir.join("repo"))
             .await
             .unwrap()
             .into(),
@@ -85,7 +85,7 @@ async fn test_commit_mode_fs(tmpdir: tempfile::TempDir) {
         .await
         .expect("failed to commit dir");
 
-    // Safety: tmprepo was created as an FSRepository
+    // Safety: tmprepo was created as an FsRepository
     let tmprepo = match &*tmprepo {
         RepositoryHandle::FS(fs) => fs.opened().await.unwrap(),
         _ => panic!("Unexpected tmprepo type!"),

--- a/crates/spfs/src/storage/tag_test.rs
+++ b/crates/spfs/src/storage/tag_test.rs
@@ -10,7 +10,7 @@ use rstest::rstest;
 use tokio_stream::StreamExt;
 
 use crate::fixtures::*;
-use crate::storage::fs::FSRepository;
+use crate::storage::fs::FsRepository;
 use crate::storage::{EntryType, TagStorage};
 use crate::{encoding, tracking, Result};
 
@@ -109,7 +109,7 @@ async fn test_tag_no_duplication(
 #[rstest]
 #[tokio::test]
 async fn test_tag_permissions(tmpdir: tempfile::TempDir) {
-    let storage = FSRepository::create(tmpdir.path().join("repo"))
+    let storage = FsRepository::create(tmpdir.path().join("repo"))
         .await
         .unwrap();
     let spec = tracking::TagSpec::parse("hello").unwrap();

--- a/crates/spfs/src/storage/tar/repository.rs
+++ b/crates/spfs/src/storage/tar/repository.rs
@@ -53,7 +53,7 @@ pub struct TarRepository {
     up_to_date: AtomicBool,
     archive: std::path::PathBuf,
     repo_dir: tempfile::TempDir,
-    repo: crate::storage::fs::FSRepository,
+    repo: crate::storage::fs::FsRepository,
 }
 
 #[async_trait::async_trait]
@@ -126,7 +126,7 @@ impl TarRepository {
             up_to_date: AtomicBool::new(false),
             archive: path,
             repo_dir: tmpdir,
-            repo: crate::storage::fs::FSRepository::create(&repo_path).await?,
+            repo: crate::storage::fs::FsRepository::create(&repo_path).await?,
         })
     }
 

--- a/crates/spfs/src/sync_test.rs
+++ b/crates/spfs/src/sync_test.rs
@@ -270,11 +270,11 @@ async fn test_sync_through_tar(
 #[fixture]
 async fn config(tmpdir: tempfile::TempDir) -> (tempfile::TempDir, Config) {
     let repo_path = tmpdir.path().join("repo");
-    crate::storage::fs::FSRepository::create(&repo_path)
+    crate::storage::fs::FsRepository::create(&repo_path)
         .await
         .expect("failed to make repo for test");
     let origin_path = tmpdir.path().join("origin");
-    crate::storage::fs::FSRepository::create(&origin_path)
+    crate::storage::fs::FsRepository::create(&origin_path)
         .await
         .expect("failed to make repo for test");
     let mut conf = Config::default();

--- a/crates/spk-build/src/build/binary.rs
+++ b/crates/spk-build/src/build/binary.rs
@@ -335,7 +335,7 @@ where
 
         while let Some(entry) = entries.next().await {
             let (path, entry, resolved_layer) = match entry {
-                Err(spk_exec::Error::NonSPFSLayerInResolvedLayers) => continue,
+                Err(spk_exec::Error::NonSpfsLayerInResolvedLayers) => continue,
                 Err(err) => return Err(err.into()),
                 Ok(entry) => entry,
             };

--- a/crates/spk-exec/src/error.rs
+++ b/crates/spk-exec/src/error.rs
@@ -9,7 +9,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("non-SPFS layer encountered in resolved layers")]
-    NonSPFSLayerInResolvedLayers,
+    NonSpfsLayerInResolvedLayers,
     #[error(transparent)]
     SPFS(#[from] spfs::Error),
     #[error(transparent)]

--- a/crates/spk-exec/src/exec.rs
+++ b/crates/spk-exec/src/exec.rs
@@ -56,7 +56,7 @@ impl ResolvedLayers {
                             _ => continue,
                         }
                     }
-                    _ => Err(Error::NonSPFSLayerInResolvedLayers)?,
+                    _ => Err(Error::NonSpfsLayerInResolvedLayers)?,
                 };
                 let unlock = manifest.to_tracking_manifest();
                 let walker = unlock.walk();

--- a/crates/spk-storage/src/fixtures.rs
+++ b/crates/spk-storage/src/fixtures.rs
@@ -106,7 +106,7 @@ pub async fn make_repo(kind: RepoKind) -> TempRepo {
     let repo = match kind {
         RepoKind::Spfs => {
             let storage_root = tmpdir.path().join("repo");
-            let spfs_repo = spfs::storage::fs::FSRepository::create(&storage_root)
+            let spfs_repo = spfs::storage::fs::FsRepository::create(&storage_root)
                 .await
                 .expect("failed to establish temporary local repo for test");
             let written = spfs_repo

--- a/crates/spk-storage/src/lib.rs
+++ b/crates/spk-storage/src/lib.rs
@@ -21,6 +21,6 @@ pub use storage::{
     Repository,
     RepositoryHandle,
     RuntimeRepository,
-    SPFSRepository,
+    SpfsRepository,
     Storage,
 };

--- a/crates/spk-storage/src/storage/archive.rs
+++ b/crates/spk-storage/src/storage/archive.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 
 use spk_schema::{AnyIdent, BuildIdent, VersionIdent};
 
-use super::{Repository, SPFSRepository};
+use super::{Repository, SpfsRepository};
 use crate::{Error, Result};
 
 pub async fn export_package<I, P>(pkg: I, filename: P) -> Result<()>
@@ -42,7 +42,7 @@ where
         super::remote_repository("origin"),
     );
     let local_repo = local_repo?;
-    let mut target_repo = super::SPFSRepository::try_from((
+    let mut target_repo = super::SpfsRepository::try_from((
         "archive",
         spfs::storage::RepositoryHandle::from(
             spfs::storage::tar::TarRepository::create(&filename).await?,
@@ -172,8 +172,8 @@ where
 
 async fn copy_any(
     pkg: AnyIdent,
-    src_repo: &SPFSRepository,
-    dst_repo: &SPFSRepository,
+    src_repo: &SpfsRepository,
+    dst_repo: &SpfsRepository,
 ) -> Result<()> {
     match pkg.into_inner() {
         (base, None) => copy_recipe(&base, src_repo, dst_repo).await,
@@ -185,8 +185,8 @@ async fn copy_any(
 
 async fn copy_recipe(
     pkg: &VersionIdent,
-    src_repo: &SPFSRepository,
-    dst_repo: &SPFSRepository,
+    src_repo: &SpfsRepository,
+    dst_repo: &SpfsRepository,
 ) -> Result<()> {
     let spec = src_repo.read_recipe(pkg).await?;
     tracing::info!(%pkg, "exporting");
@@ -196,8 +196,8 @@ async fn copy_recipe(
 
 async fn copy_package(
     pkg: &BuildIdent,
-    src_repo: &SPFSRepository,
-    dst_repo: &SPFSRepository,
+    src_repo: &SpfsRepository,
+    dst_repo: &SpfsRepository,
 ) -> Result<()> {
     let spec = src_repo.read_package(pkg).await?;
     let components = src_repo.read_components(pkg).await?;

--- a/crates/spk-storage/src/storage/handle.rs
+++ b/crates/spk-storage/src/storage/handle.rs
@@ -11,7 +11,7 @@ type Handle = dyn Repository<Recipe = SpecRecipe, Package = Spec>;
 #[derive(Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[allow(clippy::large_enum_variant)]
 pub enum RepositoryHandle {
-    SPFS(super::SPFSRepository),
+    SPFS(super::SpfsRepository),
     Mem(super::MemRepository<SpecRecipe>),
     Runtime(super::RuntimeRepository),
 }
@@ -73,8 +73,8 @@ impl std::ops::DerefMut for RepositoryHandle {
     }
 }
 
-impl From<super::SPFSRepository> for RepositoryHandle {
-    fn from(repo: super::SPFSRepository) -> Self {
+impl From<super::SpfsRepository> for RepositoryHandle {
+    fn from(repo: super::SpfsRepository) -> Self {
         RepositoryHandle::SPFS(repo)
     }
 }

--- a/crates/spk-storage/src/storage/mod.rs
+++ b/crates/spk-storage/src/storage/mod.rs
@@ -15,4 +15,4 @@ pub use mem::MemRepository;
 pub use repository::{CachePolicy, Repository, Storage};
 pub use runtime::{find_path_providers, pretty_print_filepath, RuntimeRepository};
 
-pub use self::spfs::{local_repository, remote_repository, SPFSRepository};
+pub use self::spfs::{local_repository, remote_repository, SpfsRepository};

--- a/crates/spk-storage/src/storage/spfs.rs
+++ b/crates/spk-storage/src/storage/spfs.rs
@@ -39,7 +39,7 @@ const REPO_METADATA_TAG: &str = "spk/repo";
 const REPO_VERSION: &str = "1.0.0";
 
 #[derive(Debug)]
-pub struct SPFSRepository {
+pub struct SpfsRepository {
     address: url::Url,
     name: RepositoryNameBuf,
     inner: spfs::storage::RepositoryHandle,
@@ -47,33 +47,33 @@ pub struct SPFSRepository {
     caches: CachesForAddress,
 }
 
-impl std::hash::Hash for SPFSRepository {
+impl std::hash::Hash for SpfsRepository {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.address.hash(state);
     }
 }
 
-impl Ord for SPFSRepository {
+impl Ord for SpfsRepository {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.address.cmp(&other.address)
     }
 }
 
-impl PartialOrd for SPFSRepository {
+impl PartialOrd for SpfsRepository {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl PartialEq for SPFSRepository {
+impl PartialEq for SpfsRepository {
     fn eq(&self, other: &Self) -> bool {
         self.address == other.address
     }
 }
 
-impl Eq for SPFSRepository {}
+impl Eq for SpfsRepository {}
 
-impl std::ops::Deref for SPFSRepository {
+impl std::ops::Deref for SpfsRepository {
     type Target = spfs::storage::RepositoryHandle;
 
     fn deref(&self) -> &Self::Target {
@@ -81,13 +81,13 @@ impl std::ops::Deref for SPFSRepository {
     }
 }
 
-impl std::ops::DerefMut for SPFSRepository {
+impl std::ops::DerefMut for SpfsRepository {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
 
-impl<S: AsRef<str>, T: Into<spfs::storage::RepositoryHandle>> TryFrom<(S, T)> for SPFSRepository {
+impl<S: AsRef<str>, T: Into<spfs::storage::RepositoryHandle>> TryFrom<(S, T)> for SpfsRepository {
     type Error = crate::Error;
 
     fn try_from(name_and_repo: (S, T)) -> Result<Self> {
@@ -103,7 +103,7 @@ impl<S: AsRef<str>, T: Into<spfs::storage::RepositoryHandle>> TryFrom<(S, T)> fo
     }
 }
 
-impl SPFSRepository {
+impl SpfsRepository {
     pub async fn new(name: &str, address: &str) -> Result<Self> {
         let inner = spfs::open_repository(address).await?;
         let address = inner.address();
@@ -117,7 +117,7 @@ impl SPFSRepository {
     }
 }
 
-impl std::ops::Drop for SPFSRepository {
+impl std::ops::Drop for SpfsRepository {
     fn drop(&mut self) {
         // Safety: We only put valid `Box` pointers into `self.cache_policy`.
         unsafe {
@@ -215,7 +215,7 @@ impl std::fmt::Debug for CachesForAddress {
 }
 
 #[async_trait::async_trait]
-impl Storage for SPFSRepository {
+impl Storage for SpfsRepository {
     type Recipe = SpecRecipe;
     type Package = Spec;
 
@@ -582,7 +582,7 @@ impl Storage for SPFSRepository {
 }
 
 #[async_trait::async_trait]
-impl Repository for SPFSRepository {
+impl Repository for SpfsRepository {
     fn address(&self) -> &url::Url {
         &self.address
     }
@@ -835,7 +835,7 @@ impl Repository for SPFSRepository {
     }
 }
 
-impl SPFSRepository {
+impl SpfsRepository {
     fn cached_result_permitted(&self) -> bool {
         // Safety: We only put valid `Box` pointers into `self.cache_policy`.
         unsafe { *self.cache_policy.load(Ordering::Relaxed) }.cached_result_permitted()
@@ -1057,12 +1057,12 @@ impl StoredPackage {
 }
 
 /// Return the local packages repository used for development.
-pub async fn local_repository() -> Result<SPFSRepository> {
+pub async fn local_repository() -> Result<SpfsRepository> {
     let config = spfs::get_config()?;
     let repo = config.get_local_repository().await?;
     let inner: spfs::prelude::RepositoryHandle = repo.into();
     let address = inner.address();
-    Ok(SPFSRepository {
+    Ok(SpfsRepository {
         caches: CachesForAddress::new(&address),
         address,
         name: "local".try_into()?,
@@ -1074,11 +1074,11 @@ pub async fn local_repository() -> Result<SPFSRepository> {
 /// Return the remote repository of the given name.
 ///
 /// If not name is specified, return the default spfs repository.
-pub async fn remote_repository<S: AsRef<str>>(name: S) -> Result<SPFSRepository> {
+pub async fn remote_repository<S: AsRef<str>>(name: S) -> Result<SpfsRepository> {
     let config = spfs::get_config()?;
     let inner = config.get_remote(&name).await?;
     let address = inner.address();
-    Ok(SPFSRepository {
+    Ok(SpfsRepository {
         caches: CachesForAddress::new(&address),
         address,
         name: name.as_ref().try_into()?,

--- a/crates/spk-storage/src/storage/spfs_test.rs
+++ b/crates/spk-storage/src/storage/spfs_test.rs
@@ -7,7 +7,7 @@ use spk_schema::foundation::fixtures::*;
 use spk_schema::foundation::version::Version;
 use spk_schema::BuildIdent;
 
-use super::SPFSRepository;
+use super::SpfsRepository;
 use crate::storage::{CachePolicy, Repository};
 
 #[rstest]
@@ -27,9 +27,9 @@ fn test_repo_version_is_valid() {
 async fn test_metadata_io(tmpdir: tempfile::TempDir) {
     init_logging();
     let repo_root = tmpdir.path();
-    let repo = SPFSRepository::try_from((
+    let repo = SpfsRepository::try_from((
         "test-repo",
-        spfs::storage::fs::FSRepository::create(repo_root)
+        spfs::storage::fs::FsRepository::create(repo_root)
             .await
             .unwrap(),
     ))
@@ -47,9 +47,9 @@ async fn test_upgrade_sets_version(tmpdir: tempfile::TempDir) {
     init_logging();
     let current_version = Version::from_str(super::REPO_VERSION).unwrap();
     let repo_root = tmpdir.path();
-    let repo = SPFSRepository::try_from((
+    let repo = SpfsRepository::try_from((
         "test-repo",
-        spfs::storage::fs::FSRepository::create(repo_root)
+        spfs::storage::fs::FsRepository::create(repo_root)
             .await
             .unwrap(),
     ))
@@ -70,10 +70,10 @@ async fn test_upgrade_sets_version(tmpdir: tempfile::TempDir) {
 async fn test_upgrade_changes_tags(tmpdir: tempfile::TempDir) {
     init_logging();
     let repo_root = tmpdir.path();
-    let spfs_repo = spfs::storage::fs::FSRepository::create(repo_root)
+    let spfs_repo = spfs::storage::fs::FsRepository::create(repo_root)
         .await
         .unwrap();
-    let repo = SPFSRepository::new("test-repo", &format!("file://{}", repo_root.display()))
+    let repo = SpfsRepository::new("test-repo", &format!("file://{}", repo_root.display()))
         .await
         .unwrap();
 


### PR DESCRIPTION
Cleanup that builds on #875 - something that I've wanted to do for a while.

This is the [recommended](https://rust-lang.github.io/api-guidelines/naming.html) style in rust, which is using a single upper case letter at the start of the acronym instead of capitalizing the entire thing