### PR TITLE
Replace `Entry::default` with explicit methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3136,6 +3136,7 @@ dependencies = [
  "serde_qs",
  "serial_test",
  "spfs-encoding",
+ "static_assertions",
  "strum",
  "tar",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ sentry-tracing = { version = "0.27.0" }
 serde = "1.0"
 serde_json = "1.0"
 serde_yaml = "0.9.25"
+static_assertions = "1.1"
 strip-ansi-escapes = "0.1.1"
 strum = { version = "0.24", features = ["derive"] }
 thiserror = "1.0"

--- a/crates/spfs/Cargo.toml
+++ b/crates/spfs/Cargo.toml
@@ -97,6 +97,7 @@ criterion = { version = "0.3", features = ["async_tokio", "html_reports"] }
 rstest = { version = "0.15.0", default_features = false }
 serial_test = "0.8.0"
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
+static_assertions = { workspace = true }
 
 [[bench]]
 name = "spfs_bench"

--- a/crates/spfs/src/graph/manifest.rs
+++ b/crates/spfs/src/graph/manifest.rs
@@ -144,7 +144,7 @@ impl Manifest {
 
     /// Convert this manifest into a more workable form for editing.
     pub fn to_tracking_manifest(&self) -> tracking::Manifest {
-        let mut root = tracking::Entry::default();
+        let mut root = tracking::Entry::empty_dir_with_open_perms();
 
         fn iter_tree(source: &Manifest, tree: &Tree, parent: &mut tracking::Entry) {
             for entry in tree.entries.iter() {
@@ -152,9 +152,12 @@ impl Manifest {
                     kind: entry.kind,
                     mode: entry.mode,
                     size: entry.size,
-                    ..Default::default()
+                    entries: Default::default(),
+                    object: entry.object,
+                    user_data: (),
                 };
                 if let tracking::EntryKind::Tree = entry.kind {
+                    new_entry.object = encoding::NULL_DIGEST.into();
                     iter_tree(
                         source,
                         source
@@ -162,8 +165,6 @@ impl Manifest {
                             .expect("manifest is internally inconsistent (missing child tree)"),
                         &mut new_entry,
                     )
-                } else {
-                    new_entry.object = entry.object;
                 }
                 parent.entries.insert(entry.name.clone(), new_entry);
             }

--- a/crates/spfs/src/storage/manifest_test.rs
+++ b/crates/spfs/src/storage/manifest_test.rs
@@ -75,7 +75,7 @@ async fn test_manifest_parity(
     diffs.retain(|d| !d.mode.is_unchanged());
 
     for diff in diffs.iter() {
-        println!("{diff}, {:?}", diff.mode);
+        println!("{diff}, {:#?}", diff.mode);
     }
     assert!(diffs.is_empty(), "Should read out the way it went in");
 }

--- a/crates/spfs/src/tracking/diff_test.rs
+++ b/crates/spfs/src/tracking/diff_test.rs
@@ -7,14 +7,14 @@ use rstest::rstest;
 
 use super::{compute_diff, Diff, DiffMode};
 use crate::fixtures::*;
-use crate::tracking::{compute_manifest, Manifest};
+use crate::tracking::{compute_manifest, Entry, Manifest};
 
 #[rstest]
 fn test_diff_str() {
     let display = format!(
         "{}",
         Diff {
-            mode: DiffMode::Added(Default::default()),
+            mode: DiffMode::Added(Entry::<()>::empty_dir_with_open_perms()),
             path: "some_path".into(),
         }
     );

--- a/crates/spfs/src/tracking/entry_test.rs
+++ b/crates/spfs/src/tracking/entry_test.rs
@@ -1,0 +1,28 @@
+// Copyright (c) Sony Pictures Imageworks, et al.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/imageworks/spk
+
+use rstest::rstest;
+
+use super::Entry;
+
+#[rstest]
+fn test_empty_dir_is_dir() {
+    let entry = Entry::<()>::empty_dir_with_open_perms();
+    assert!(entry.is_dir());
+}
+
+#[rstest]
+fn test_empty_file_is_file() {
+    let entry = Entry::<()>::empty_file_with_open_perms();
+    assert!(entry.is_regular_file());
+}
+
+#[rstest]
+fn test_entry_has_no_default() {
+    // we do not want to have any "Default" impl for entry because
+    // it would be ambiguous in terms of aligning mode bits and entry
+    // kind. Instead, explicit creation methods exist for creating
+    // entries of various types with reasonable default field values.
+    static_assertions::assert_not_impl_all!(Entry<()>: Default);
+}

--- a/crates/spfs/src/tracking/manifest_test.rs
+++ b/crates/spfs/src/tracking/manifest_test.rs
@@ -108,11 +108,11 @@ async fn test_layer_manifests_removal() {
     let mut a = Manifest::<()>::default();
     a.mkfile("a_only").unwrap();
 
-    let mut b = Manifest::default();
+    let mut b = Manifest::<()>::default();
     let node = b.mkfile("a_only").unwrap();
     node.kind = EntryKind::Mask;
 
-    let mut c = Manifest::default();
+    let mut c = Manifest::<()>::default();
     c.update(&a);
     assert!(c.get_path("/a_only").unwrap().kind.is_blob());
     c.update(&b);

--- a/crates/spk-build/src/build/sources_test.rs
+++ b/crates/spk-build/src/build/sources_test.rs
@@ -20,7 +20,10 @@ fn test_validate_sources_changeset_not_in_dir() {
     let res = validate_source_changeset(
         vec![spfs::tracking::Diff {
             path: "/file.txt".into(),
-            mode: spfs::tracking::DiffMode::Changed(Default::default(), Default::default()),
+            mode: spfs::tracking::DiffMode::Changed(
+                spfs::tracking::Entry::empty_file_with_open_perms(),
+                spfs::tracking::Entry::empty_file_with_open_perms(),
+            ),
         }],
         "/some/dir",
     );
@@ -32,7 +35,9 @@ fn test_validate_sources_changeset_ok() {
     let res = validate_source_changeset(
         vec![spfs::tracking::Diff {
             path: "/some/dir/file.txt".into(),
-            mode: spfs::tracking::DiffMode::Added(Default::default()),
+            mode: spfs::tracking::DiffMode::Added(
+                spfs::tracking::Entry::empty_file_with_open_perms(),
+            ),
         }],
         "/some/dir",
     );

--- a/crates/spk-schema/src/v0/validators_test.rs
+++ b/crates/spk-schema/src/v0/validators_test.rs
@@ -18,7 +18,10 @@ fn test_validate_build_changeset_modified() {
     let res = must_not_alter_existing_files(
         &vec![spfs::tracking::Diff {
             path: "/spfs/file.txt".into(),
-            mode: spfs::tracking::DiffMode::Changed(Default::default(), Default::default()),
+            mode: spfs::tracking::DiffMode::Changed(
+                spfs::tracking::Entry::empty_file_with_open_perms(),
+                spfs::tracking::Entry::empty_file_with_open_perms(),
+            ),
         }],
         "/spfs",
     );
@@ -36,7 +39,10 @@ fn test_validate_build_changeset_collected() {
         spec.install.components.iter().map(|c| &c.files),
         &vec![spfs::tracking::Diff {
             path: "/spfs/file.txt".into(),
-            mode: spfs::tracking::DiffMode::Changed(Default::default(), Default::default()),
+            mode: spfs::tracking::DiffMode::Changed(
+                spfs::tracking::Entry::empty_file_with_open_perms(),
+                spfs::tracking::Entry::empty_file_with_open_perms(),
+            ),
         }],
     );
     assert!(


### PR DESCRIPTION
There was a bug where mkdirs was creating entries that looked liked files. When building from a filesystem the error gets overwritten with the appropriate mode later on but it shows up in api-based manifest construction.

Instead of a Default implementation that obscures the details of what is being created, use explicit methods that can build specific entry types.