### PR TITLE
Add depth numbers to 'TRY' lines, and put solver time in "Took too long..." warnings

### DIFF
--- a/crates/spk-solve/src/io.rs
+++ b/crates/spk-solve/src/io.rs
@@ -279,10 +279,17 @@ where
                     }
 
                     if self.verbosity > 1 {
-                        let fill: String = ".".repeat(self.level as usize);
+                        let prefix: String = if self.verbosity > 2 && self.level > 5 {
+                            let level_text = self.level.to_string();
+                            let prefix_width = level_text.len() + 1;
+                            let padding = ".".repeat(self.level as usize - prefix_width);
+                            format!("{level_text} {padding}")
+                        } else {
+                            ".".repeat(self.level as usize)
+                        };
                         for note in decision.notes.iter() {
                             self.output_queue
-                                .push_back(format!("{} {}", fill, format_note(note)));
+                                .push_back(format!("{prefix} {}", format_note(note)));
                         }
                     }
 
@@ -1022,7 +1029,8 @@ impl DecisionFormatter {
 
         if solve_time > Duration::from_secs(self.settings.long_solves_threshold) {
             tracing::warn!(
-                "Solve took longer than acceptable time (>{} secs) to finish",
+                "Solve took {:.3} secs to finish. Longer than the acceptable <{} secs",
+                solve_time.as_secs_f64(),
                 self.settings.long_solves_threshold
             );
 


### PR DESCRIPTION
This makes two changes to solver output:

1. It adds level depth numbers to solver 'TRY' lines output when they get deep enough and verbosity is high enough: `v > 2` and `depth > 5`. This brings them inline with depth numbering on other solver lines.
1. it adds the solve time to "Solver took too long to finish" warning messages. 

We recently hit a situations debugging large solves where both these pieces of information would have been beneficial to have.

Examples:
```sh
# Before theese changes
...
................................ TRY boost-python/1.76.0 - version too low for >= 1.80.0
................................ TRY boost-python/1.73.0 - version too low for >= 1.80.0
...
 WARN Solve took longer than acceptable time (>15 secs) to finish
...

# After these changes
...
32 ............................. TRY boost-python/1.76.0 - version too low for >= 1.80.0
32 ............................. TRY boost-python/1.73.0 - version too low for >= 1.80.0
...
 WARN Solve took 37.593 secs to finish. Longer than the acceptable <15 secs
...
```