### PR TITLE
Expose all env ops publically

### DIFF
--- a/crates/spk-build/src/build/binary.rs
+++ b/crates/spk-build/src/build/binary.rs
@@ -813,20 +813,12 @@ where
         let mut sh_file = std::fs::File::create(&startup_file_sh)
             .map_err(|err| Error::FileOpenError(startup_file_sh.to_owned(), err))?;
         for op in ops {
-            if op.priority().ne(&0) {
+            if let Some(priority) = op.priority() {
                 let original_startup_file_sh_name = startup_file_sh.clone();
                 let original_startup_file_csh_name = startup_file_csh.clone();
 
-                startup_file_sh.set_file_name(format!(
-                    "{}_spk_{}.sh",
-                    op.priority(),
-                    package.name()
-                ));
-                startup_file_csh.set_file_name(format!(
-                    "{}_spk_{}.csh",
-                    op.priority(),
-                    package.name()
-                ));
+                startup_file_sh.set_file_name(format!("{priority:02}_spk_{}.sh", package.name()));
+                startup_file_csh.set_file_name(format!("{priority:02}_spk_{}.csh", package.name()));
 
                 std::fs::rename(original_startup_file_sh_name, &startup_file_sh)
                     .map_err(|err| Error::FileWriteError(startup_file_sh.to_owned(), err))?;

--- a/crates/spk-schema/src/lib.rs
+++ b/crates/spk-schema/src/lib.rs
@@ -33,7 +33,7 @@ pub use component_spec::{ComponentFileMatchMode, ComponentSpec};
 pub use component_spec_list::ComponentSpecList;
 pub use deprecate::{Deprecate, DeprecateMut};
 pub use embedded_packages_list::EmbeddedPackagesList;
-pub use environ::{AppendEnv, EnvOp, OpKind, PrependEnv, SetEnv};
+pub use environ::{AppendEnv, EnvComment, EnvOp, EnvPriority, OpKind, PrependEnv, SetEnv};
 pub use error::{Error, Result};
 pub use input_variant::InputVariant;
 pub use install_spec::InstallSpec;


### PR DESCRIPTION
Updates the operation names to flow better as an API, and uses them publicly. 

This also uses `Option<u8>` to better denote a priority that is not specified (so that zero can be used).

Finally, this pads the generated filename to two digits in order to ensure more reliable sorting when values greater than 10 are used.