### PR TITLE
Workaround hang when running spfs-fuse

### DIFF
--- a/crates/spfs/src/env.rs
+++ b/crates/spfs/src/env.rs
@@ -479,6 +479,12 @@ where
             // The command logs all output to stderr, and should never hold onto
             // a handle to this process' stdout as it can cause hanging
             cmd.stdout(std::process::Stdio::null());
+            // Allowing stderr to be inherited causes this process to hang
+            // forever reading from that pipe, even after the child processes
+            // has exited (cause unknown).
+            // TODO: find a way to still see stderr output from the child
+            // process without it hanging.
+            cmd.stderr(std::process::Stdio::null());
             tracing::debug!("{cmd:?}");
             match cmd.status() {
                 Err(err) => return Err(Error::process_spawn_error("mount", err, None)),


### PR DESCRIPTION
If stderr is not detached, the following code will hang indefinitely, blocked on a read() on a pipe.

    #!/usr/bin/env python

    import subprocess

    env_cmd = [
             "spfs commit platform --tag spfs-hang-test",
          ]

    subprocess.run(env_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

To induce the hang, this must be run in a spfs environment using OverlayFsWithFuse and with a modified runtime, as in:

    env SPFS_FILESYSTEM_BACKEND=OverlayFsWithFuse spfs run -- - bash
    $ touch /spfs/foo

An issue will be created with further details on what has been attempted to try to solve this problem.