### PR TITLE
Add ESRCH to ignore list in find_other_processes

### DIFF
--- a/crates/spfs/src/monitor.rs
+++ b/crates/spfs/src/monitor.rs
@@ -421,6 +421,7 @@ async fn find_other_processes_in_mount_namespace(ns: &std::path::Path) -> Result
         let found_ns = match tokio::fs::read_link(&link_path).await {
             Ok(p) => p,
             Err(err) => match err.os_error() {
+                Some(libc::ESRCH) => continue,
                 Some(libc::ENOENT) => continue,
                 Some(libc::ENOTDIR) => continue,
                 Some(libc::EACCES) => continue,


### PR DESCRIPTION
As seen in sentry:

    RuntimeReadError("/proc/167367/ns/mnt", Os { code: 3, kind: Uncategorized, message: "No such process" })

ESRCH (code 3) is what we're seeing if the process disappeared. This error is making the while loop in `wait_for_empty_runtime` (monitor.rs:197) exit prematurely.