### PR TITLE
Bugfix for 'ps_startup_file' field stopping all runtimes loading in sites with existings spfs installs

### DIFF
--- a/crates/spfs/src/runtime/storage.rs
+++ b/crates/spfs/src/runtime/storage.rs
@@ -125,7 +125,7 @@ pub struct Config {
     /// be accessed or used by any other processes on the local machine
     pub work_dir: PathBuf,
     /// The location of the startup script for powershell-based shells
-    #[serde(default)]
+    #[serde(default)] // for backwards-compatibility with existing runtimes
     pub ps_startup_file: PathBuf,
     /// The location of the startup script for sh-based shells
     pub sh_startup_file: PathBuf,


### PR DESCRIPTION
This fixes bug where `ps_startup_file` field stops all runtimes from loading in sites with existings spfs installs.

A new field 'ps_startup_file' was added to runtime config's as non-optional and without a default `serde` setting (it's part of the windows support). The trouble is this causes any runtime created without it to fail to load, such as older existing durable runtimes and even new runtimes created from older spfs version installations called from newer spk/spfs commands.

This adds the serde defeault setting for the field, which allows for backwards compatibility with older runtimes. 