### PR TITLE
Make RemoteConfig fields public

### DIFF
--- a/crates/spfs/src/config.rs
+++ b/crates/spfs/src/config.rs
@@ -145,9 +145,9 @@ pub struct RemoteAddress {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RemoteConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    when: Option<tracking::TimeSpec>,
+    pub when: Option<tracking::TimeSpec>,
     #[serde(flatten)]
-    inner: RepositoryConfig,
+    pub inner: RepositoryConfig,
 }
 
 impl ToAddress for RemoteConfig {


### PR DESCRIPTION
This follows the pattern of the rest of the module and is necessary for us as API consumers