### PR TITLE
Fix test_validate_build_changeset_collected

### DIFF
--- a/crates/spk-schema/src/v0/validators_test.rs
+++ b/crates/spk-schema/src/v0/validators_test.rs
@@ -39,8 +39,7 @@ fn test_validate_build_changeset_collected() {
         spec.install.components.iter().map(|c| &c.files),
         &vec![spfs::tracking::Diff {
             path: "/spfs/file.txt".into(),
-            mode: spfs::tracking::DiffMode::Changed(
-                spfs::tracking::Entry::empty_file_with_open_perms(),
+            mode: spfs::tracking::DiffMode::Added(
                 spfs::tracking::Entry::empty_file_with_open_perms(),
             ),
         }],


### PR DESCRIPTION
As currently written, `must_collect_all_files` will always return an error if the given list of files is empty. Because this test provides an empty list of files, the test passes but for the wrong reason.

In #866, `must_collect_all_files` is changed so there must be at least one `DiffMode::Added` entry in the provided slice of diffs to generate an error (note that `must_collect_all_files` filters out any diffs that aren't `DiffMode::Added` and only validates that all _added_ files are collected).

Since `must_collect_all_files` only cares about `DiffMode::Added` diffs, start using that type of diff for the test data. This change makes the test continue to pass after the changes in #866.