### PR TITLE
Align spfs/spk version to 0.38.0

### DIFF
--- a/.site/spi/spk.spec
+++ b/.site/spi/spk.spec
@@ -21,7 +21,7 @@ BuildRequires: spdev >= 0.28.2
 Requires: bash
 Requires: fuse
 Obsoletes: spfs
-Provides: spfs = 0.34.6
+Provides: spfs = 0.38.0
 
 %define debug_package %{nil}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3297,7 +3297,7 @@ dependencies = [
 
 [[package]]
 name = "spfs"
-version = "0.34.6"
+version = "0.38.0"
 dependencies = [
  "arc-swap",
  "async-compression",
@@ -3370,7 +3370,7 @@ dependencies = [
 
 [[package]]
 name = "spfs-cli-clean"
-version = "0.34.6"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "spfs-cli-common"
-version = "0.34.6"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "clap 4.4.7",
@@ -3406,7 +3406,7 @@ dependencies = [
 
 [[package]]
 name = "spfs-cli-enter"
-version = "0.34.6"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "clap 4.4.7",
@@ -3420,7 +3420,7 @@ dependencies = [
 
 [[package]]
 name = "spfs-cli-fuse"
-version = "0.34.6"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "clap 4.4.7",
@@ -3438,7 +3438,7 @@ dependencies = [
 
 [[package]]
 name = "spfs-cli-join"
-version = "0.34.6"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "clap 4.4.7",
@@ -3451,7 +3451,7 @@ dependencies = [
 
 [[package]]
 name = "spfs-cli-main"
-version = "0.34.6"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3482,7 +3482,7 @@ dependencies = [
 
 [[package]]
 name = "spfs-cli-monitor"
-version = "0.34.6"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "clap 4.4.7",
@@ -3496,7 +3496,7 @@ dependencies = [
 
 [[package]]
 name = "spfs-cli-render"
-version = "0.34.6"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "clap 4.4.7",
@@ -3512,7 +3512,7 @@ dependencies = [
 
 [[package]]
 name = "spfs-cli-winfsp"
-version = "0.34.6"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "clap 4.4.7",
@@ -3534,7 +3534,7 @@ dependencies = [
 
 [[package]]
 name = "spfs-encoding"
-version = "0.34.6"
+version = "0.38.0"
 dependencies = [
  "data-encoding",
  "rand 0.8.5",
@@ -3547,7 +3547,7 @@ dependencies = [
 
 [[package]]
 name = "spfs-vfs"
-version = "0.34.6"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4005,7 +4005,7 @@ dependencies = [
 
 [[package]]
 name = "spk-launcher"
-version = "0.33.6"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "nix 0.26.4",

--- a/crates/spfs-cli/cmd-clean/Cargo.toml
+++ b/crates/spfs-cli/cmd-clean/Cargo.toml
@@ -2,7 +2,7 @@
 authors = { workspace = true }
 edition = { workspace = true }
 name = "spfs-cli-clean"
-version = "0.34.6"
+version = { workspace = true }
 
 [[bin]]
 name = "spfs-clean"

--- a/crates/spfs-cli/cmd-enter/Cargo.toml
+++ b/crates/spfs-cli/cmd-enter/Cargo.toml
@@ -2,7 +2,7 @@
 authors = { workspace = true }
 edition = { workspace = true }
 name = "spfs-cli-enter"
-version = "0.34.6"
+version = { workspace = true }
 
 [[bin]]
 name = "spfs-enter"

--- a/crates/spfs-cli/cmd-fuse/Cargo.toml
+++ b/crates/spfs-cli/cmd-fuse/Cargo.toml
@@ -2,7 +2,7 @@
 authors = { workspace = true }
 edition = { workspace = true }
 name = "spfs-cli-fuse"
-version = "0.34.6"
+version = { workspace = true }
 
 [[bin]]
 name = "spfs-fuse"

--- a/crates/spfs-cli/cmd-join/Cargo.toml
+++ b/crates/spfs-cli/cmd-join/Cargo.toml
@@ -2,7 +2,7 @@
 authors = { workspace = true }
 edition = { workspace = true }
 name = "spfs-cli-join"
-version = "0.34.6"
+version = { workspace = true }
 
 [[bin]]
 name = "spfs-join"

--- a/crates/spfs-cli/cmd-monitor/Cargo.toml
+++ b/crates/spfs-cli/cmd-monitor/Cargo.toml
@@ -2,7 +2,7 @@
 authors = { workspace = true }
 edition = { workspace = true }
 name = "spfs-cli-monitor"
-version = "0.34.6"
+version = { workspace = true }
 
 [[bin]]
 name = "spfs-monitor"

--- a/crates/spfs-cli/cmd-render/Cargo.toml
+++ b/crates/spfs-cli/cmd-render/Cargo.toml
@@ -2,7 +2,7 @@
 authors = { workspace = true }
 edition = { workspace = true }
 name = "spfs-cli-render"
-version = "0.34.6"
+version = { workspace = true }
 
 [[bin]]
 name = "spfs-render"

--- a/crates/spfs-cli/cmd-winfsp/Cargo.toml
+++ b/crates/spfs-cli/cmd-winfsp/Cargo.toml
@@ -2,7 +2,7 @@
 authors = { workspace = true }
 edition = { workspace = true }
 name = "spfs-cli-winfsp"
-version = "0.34.6"
+version = { workspace = true }
 
 [[bin]]
 name = "spfs-winfsp"

--- a/crates/spfs-cli/common/Cargo.toml
+++ b/crates/spfs-cli/common/Cargo.toml
@@ -2,7 +2,7 @@
 authors = { workspace = true }
 edition = { workspace = true }
 name = "spfs-cli-common"
-version = "0.34.6"
+version = { workspace = true }
 
 [features]
 sentry = [

--- a/crates/spfs-cli/main/Cargo.toml
+++ b/crates/spfs-cli/main/Cargo.toml
@@ -3,7 +3,7 @@ authors = { workspace = true }
 default-run = "spfs"
 edition = { workspace = true }
 name = "spfs-cli-main"
-version = "0.34.6"
+version = { workspace = true }
 
 [[bin]]
 name = "spfs"

--- a/crates/spfs-encoding/Cargo.toml
+++ b/crates/spfs-encoding/Cargo.toml
@@ -2,7 +2,7 @@
 authors = { workspace = true }
 edition = { workspace = true }
 name = "spfs-encoding"
-version = "0.34.6"
+version = { workspace = true }
 
 [dependencies]
 data-encoding = "2.3"

--- a/crates/spfs-vfs/Cargo.toml
+++ b/crates/spfs-vfs/Cargo.toml
@@ -2,7 +2,7 @@
 authors = { workspace = true }
 edition = { workspace = true }
 name = "spfs-vfs"
-version = "0.34.6"
+version = { workspace = true }
 
 [features]
 default = []

--- a/crates/spfs/Cargo.toml
+++ b/crates/spfs/Cargo.toml
@@ -2,7 +2,7 @@
 authors = { workspace = true }
 edition = { workspace = true }
 name = "spfs"
-version = "0.34.6"
+version = { workspace = true }
 
 [features]
 default = []

--- a/crates/spk-launcher/Cargo.toml
+++ b/crates/spk-launcher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = { workspace = true }
 name = "spk-launcher"
-version = "0.33.6"
+version = { workspace = true }
 edition = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/spk-solve/crates/solution/Cargo.toml
+++ b/crates/spk-solve/crates/solution/Cargo.toml
@@ -14,7 +14,7 @@ migration-to-components = [
 colored = { workspace = true }
 console =  { workspace = true }
 itertools = "0.10"
-spfs = { version = '0.34.6', path = "../../../spfs" }
+spfs = { path = "../../../spfs" }
 spk-schema = { path = "../../../spk-schema" }
 spk-storage = { path = "../../../spk-storage" }
 thiserror = { workspace = true }

--- a/spfs.spec
+++ b/spfs.spec
@@ -1,5 +1,5 @@
 Name: spfs
-Version: 0.34.6
+Version: 0.38.0
 Release: 1
 Summary: Filesystem isolation, capture, and distribution.
 License: NONE

--- a/spk.spec
+++ b/spk.spec
@@ -21,7 +21,7 @@ Requires: bash
 Requires: fuse
 Requires: rsync
 Obsoletes: spfs
-Provides: spfs = 0.34.6
+Provides: spfs = 0.38.0
 
 %define debug_package %{nil}
 


### PR DESCRIPTION
Use 'workspace = true' in all the spfs/spk crates to have a single place to maintain the version number.

Remove any requirements for an explicit version of spfs in the inter-crate dependencies.