### PR TITLE
Clarify directionality of layer stacks

### DIFF
--- a/crates/spfs-cli/main/src/cmd_info.rs
+++ b/crates/spfs-cli/main/src/cmd_info.rs
@@ -109,8 +109,8 @@ impl CmdInfo {
                     "refs:".bright_blue(),
                     self.format_digest(obj.digest()?, repo).await?
                 );
-                println!("{}", "stack:".bright_blue());
-                for reference in obj.stack {
+                println!("{}:", "stack (top-down)".bright_blue());
+                for reference in obj.stack.to_top_down() {
                     println!("  - {}", self.format_digest(reference, repo).await?);
                 }
             }
@@ -187,16 +187,12 @@ impl CmdInfo {
     async fn print_global_info(&self, repo: &spfs::storage::RepositoryHandle) -> Result<()> {
         let runtime = spfs::active_runtime().await?;
 
-        println!("{}", "Active Runtime:".green());
-        println!(" {}: {}", "id:".bright_blue(), runtime.name());
-        println!(
-            " {}: {}",
-            "editable:".bright_blue(),
-            runtime.status.editable
-        );
-        println!("{}", "stack".bright_blue());
-        for digest in runtime.status.stack.iter() {
-            print!("  - {}, ", self.format_digest(*digest, repo).await?);
+        println!("{}:", "Active Runtime".green());
+        println!(" {}: {}", "id".bright_blue(), runtime.name());
+        println!(" {}: {}", "editable".bright_blue(), runtime.status.editable);
+        println!("{}:", "stack (top-down)".bright_blue());
+        for digest in runtime.status.stack.to_top_down() {
+            print!("  - {}, ", self.format_digest(digest, repo).await?);
             let object = repo.read_ref(digest.to_string().as_str()).await?;
             println!(
                 "Size: {}",

--- a/crates/spfs-cli/main/src/cmd_reset.rs
+++ b/crates/spfs-cli/main/src/cmd_reset.rs
@@ -39,7 +39,7 @@ impl CmdReset {
         )?;
         if let Some(env_spec) = &self.reference {
             runtime.reset::<&str>(&[])?;
-            runtime.status.stack.truncate(0);
+            runtime.status.stack.clear();
             if env_spec.is_empty() {
                 self.edit = true;
             } else {

--- a/crates/spfs-cli/main/src/cmd_run.rs
+++ b/crates/spfs-cli/main/src/cmd_run.rs
@@ -101,7 +101,7 @@ impl CmdRun {
 
             let start_time = Instant::now();
             let origin = config.get_remote("origin").await?;
-            let references_to_sync = EnvSpec::from_iter(runtime.status.stack.iter().copied());
+            let references_to_sync = EnvSpec::from_iter(runtime.status.stack.iter_bottom_up());
             let _synced = self
                 .sync
                 .get_syncer(&origin, &repo)

--- a/crates/spfs-encoding/src/hash.rs
+++ b/crates/spfs-encoding/src/hash.rs
@@ -185,6 +185,17 @@ where
     fn decode(reader: &mut impl std::io::BufRead) -> std::result::Result<Self, Self::Error>;
 }
 
+impl<T> Encodable for &T
+where
+    T: Encodable,
+{
+    type Error = T::Error;
+
+    fn encode(&self, writer: &mut impl Write) -> std::result::Result<(), Self::Error> {
+        (**self).encode(writer)
+    }
+}
+
 impl Encodable for String {
     type Error = Error;
 
@@ -492,18 +503,6 @@ impl Encodable for Digest {
 impl Decodable for Digest {
     fn decode(reader: &mut impl std::io::BufRead) -> Result<Self> {
         binary::read_digest(reader)
-    }
-}
-
-impl Encodable for &Digest {
-    type Error = Error;
-
-    fn encode(&self, writer: &mut impl Write) -> Result<()> {
-        binary::write_digest(writer, self)
-    }
-
-    fn digest(&self) -> Result<Digest> {
-        Ok(*self.to_owned())
     }
 }
 

--- a/crates/spfs/src/check.rs
+++ b/crates/spfs/src/check.rs
@@ -313,8 +313,8 @@ where
     pub async fn check_platform(&self, platform: graph::Platform) -> Result<CheckPlatformResult> {
         let futures: FuturesUnordered<_> = platform
             .stack
-            .iter()
-            .map(|d| self.check_digest(*d))
+            .iter_bottom_up()
+            .map(|d| self.check_digest(d))
             .collect();
         let results = futures.try_collect().await?;
         let res = CheckPlatformResult {

--- a/crates/spfs/src/clean_test.rs
+++ b/crates/spfs/src/clean_test.rs
@@ -196,7 +196,7 @@ async fn test_clean_untagged_objects_layers_platforms(#[future] tmprepo: TempRep
         .await
         .unwrap();
     let platform = tmprepo
-        .create_platform(vec![layer.digest().unwrap()])
+        .create_platform(layer.digest().unwrap().into())
         .await
         .unwrap();
 
@@ -244,7 +244,7 @@ async fn test_clean_manifest_renders(tmpdir: tempfile::TempDir) {
         .await
         .unwrap();
     let _platform = tmprepo
-        .create_platform(vec![layer.digest().unwrap()])
+        .create_platform(layer.digest().unwrap().into())
         .await
         .unwrap();
 

--- a/crates/spfs/src/commit.rs
+++ b/crates/spfs/src/commit.rs
@@ -191,7 +191,9 @@ where
             .repo
             .create_layer(&graph::Manifest::from(&manifest))
             .await?;
-        runtime.push_digest(layer.digest()?);
+        if !runtime.push_digest(layer.digest()?) {
+            return Err(Error::NothingToCommit);
+        }
         runtime.status.editable = false;
         runtime.save_state_to_storage().await?;
         remount_runtime(runtime).await?;

--- a/crates/spfs/src/env_win.rs
+++ b/crates/spfs/src/env_win.rs
@@ -33,8 +33,7 @@ impl RuntimeConfigurator {
         let env_spec = rt
             .status
             .stack
-            .iter()
-            .copied()
+            .iter_bottom_up()
             .collect::<EnvSpec>()
             .to_string();
 

--- a/crates/spfs/src/find_path.rs
+++ b/crates/spfs/src/find_path.rs
@@ -54,8 +54,8 @@ pub async fn find_path_providers_in_spfs_runtime(
     let mut found: Vec<ObjectPath> = Vec::new();
 
     if let Ok(runtime) = status::active_runtime().await {
-        for digest in runtime.status.stack.iter() {
-            let item = repo.read_object(*digest).await?;
+        for digest in runtime.status.stack.iter_bottom_up() {
+            let item = repo.read_object(digest).await?;
             let file_data = find_path_in_spfs_item(filepath, &item, repo).await?;
             if !file_data.is_empty() {
                 found.extend(file_data);
@@ -82,8 +82,8 @@ async fn find_path_in_spfs_item(
 
     match obj {
         Object::Platform(obj) => {
-            for reference in obj.stack.iter() {
-                let item = repo.read_object(*reference).await?;
+            for reference in obj.stack.iter_bottom_up() {
+                let item = repo.read_object(reference).await?;
                 let paths_to_file = find_path_in_spfs_item(filepath, &item, repo).await?;
                 for path in paths_to_file {
                     let mut new_path: ObjectPath = Vec::new();

--- a/crates/spfs/src/fixtures.rs
+++ b/crates/spfs/src/fixtures.rs
@@ -257,3 +257,12 @@ fn generate_subtree(root: &std::path::Path, max_depth: i32) {
         }
     }
 }
+
+pub fn random_digest() -> crate::encoding::Digest {
+    let mut hasher = crate::encoding::Hasher::new_sync();
+    let mut rng = rand::thread_rng();
+    let mut buf = vec![0; 64];
+    rng.fill(buf.as_mut_slice());
+    hasher.update(buf.as_slice());
+    hasher.digest()
+}

--- a/crates/spfs/src/graph/mod.rs
+++ b/crates/spfs/src/graph/mod.rs
@@ -11,6 +11,7 @@ mod layer;
 mod manifest;
 mod object;
 mod platform;
+pub mod stack;
 mod tree;
 
 pub use blob::Blob;
@@ -26,4 +27,5 @@ pub use layer::Layer;
 pub use manifest::Manifest;
 pub use object::{Object, ObjectKind};
 pub use platform::Platform;
+pub use stack::Stack;
 pub use tree::Tree;

--- a/crates/spfs/src/graph/object.rs
+++ b/crates/spfs/src/graph/object.rs
@@ -59,13 +59,13 @@ impl Object {
             for object in items_to_process.iter() {
                 match object {
                     Object::Platform(object) => {
-                        for reference in object.stack.iter() {
-                            let item = repo.read_ref(reference.to_string().as_str()).await?;
+                        for digest in object.stack.iter_bottom_up() {
+                            let item = repo.read_object(digest).await?;
                             next_iter_objects.push(item);
                         }
                     }
                     Object::Layer(object) => {
-                        let item = repo.read_ref(object.manifest.to_string().as_str()).await?;
+                        let item = repo.read_object(object.manifest).await?;
                         next_iter_objects.push(item);
                     }
                     Object::Manifest(object) => {

--- a/crates/spfs/src/graph/platform_test.rs
+++ b/crates/spfs/src/graph/platform_test.rs
@@ -12,7 +12,7 @@ use crate::encoding::{Decodable, Encodable};
 fn test_platform_encoding() {
     let layers: Vec<encoding::Digest> =
         vec![encoding::EMPTY_DIGEST.into(), encoding::NULL_DIGEST.into()];
-    let expected = Platform::new(layers.iter()).unwrap();
+    let expected = Platform::from_iter(layers);
 
     let mut stream = Vec::new();
     expected.encode(&mut stream).unwrap();

--- a/crates/spfs/src/graph/stack.rs
+++ b/crates/spfs/src/graph/stack.rs
@@ -1,0 +1,186 @@
+// Copyright (c) Sony Pictures Imageworks, et al.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/imageworks/spk
+
+use encoding::Digest;
+
+use crate::{encoding, Error, Result};
+
+#[cfg(test)]
+#[path = "./stack_test.rs"]
+mod stack_test;
+
+/// A stack is an ordered set of layers with the conceptual top
+/// layer overriding and shadowing entries in the lower ones.
+// A crude linked list is used to make pushing more efficient since
+// we remove duplicates during this process and there is rarely
+// a need to lookup items by index, only iterate through them all
+#[derive(Default, Clone, Eq, PartialEq)]
+pub struct Stack {
+    /// The bottom of the layer stack
+    bottom: Option<Box<Entry>>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct Entry {
+    value: Digest,
+    next: Option<Box<Entry>>,
+}
+
+impl Entry {
+    fn new(value: Digest) -> Box<Self> {
+        Box::new(Self { value, next: None })
+    }
+}
+
+impl std::fmt::Debug for Stack {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_list().entries(self.iter_bottom_up()).finish()
+    }
+}
+
+impl Stack {
+    pub fn from_encodable<E, I>(items: I) -> Result<Self>
+    where
+        E: encoding::Encodable,
+        Error: std::convert::From<E::Error>,
+        I: IntoIterator<Item = E>,
+    {
+        let mut stack = Self { bottom: None };
+        for item in items.into_iter() {
+            stack.push(item.digest()?);
+        }
+        Ok(stack)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.bottom.is_none()
+    }
+
+    pub fn clear(&mut self) {
+        self.bottom.take();
+    }
+
+    /// Add an item to the top of the stack.
+    ///
+    /// If the digest already exists in this stack, the previous
+    /// one is removed from it's position.
+    ///
+    /// False is returned if no change was made to the stack
+    /// because the digest was already at the top.
+    pub fn push(&mut self, digest: Digest) -> bool {
+        let mut node = &mut self.bottom;
+
+        // remove any node that contains the same digest value
+        // as we walk to the end of the stack
+        loop {
+            match node {
+                n @ None => {
+                    let _ = n.insert(Entry::new(digest));
+                    break;
+                }
+                Some(entry) if entry.value == digest => {
+                    // if this is already the last node, then
+                    // report that no change is needed
+                    if entry.next.is_none() {
+                        return false;
+                    }
+                    // replace this node with it's next entry,
+                    // removing it from the stack
+                    let replace = entry.next.take();
+                    *node = replace;
+                }
+                Some(entry) => {
+                    node = &mut entry.next;
+                }
+            };
+        }
+        true
+    }
+
+    /// Iterate the stack lazily from bottom to top
+    pub fn iter_bottom_up(&self) -> Iter<'_> {
+        Iter(self.bottom.as_deref())
+    }
+
+    /// Return the digests in this stack in
+    /// reverse (top-down) order.
+    ///
+    /// This must traverse the entire stack and perform a reversal.
+    /// Prefer [`Self::iter_bottom_up`] whenever possible.
+    pub fn to_top_down(&self) -> Vec<Digest> {
+        let mut entries = self.iter_bottom_up().collect::<Vec<_>>();
+        entries.reverse();
+        entries
+    }
+}
+
+impl From<Digest> for Stack {
+    fn from(value: Digest) -> Self {
+        Self {
+            bottom: Some(Entry::new(value)),
+        }
+    }
+}
+
+impl FromIterator<Digest> for Stack {
+    fn from_iter<T: IntoIterator<Item = Digest>>(iter: T) -> Self {
+        let mut stack = Self::default();
+        stack.extend(iter);
+        stack
+    }
+}
+
+impl Extend<Digest> for Stack {
+    fn extend<T: IntoIterator<Item = Digest>>(&mut self, iter: T) {
+        for item in iter.into_iter() {
+            self.push(item);
+        }
+    }
+}
+
+impl<'a> Extend<&'a Digest> for Stack {
+    fn extend<T: IntoIterator<Item = &'a Digest>>(&mut self, iter: T) {
+        self.extend(iter.into_iter().copied())
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Stack {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        let s = Vec::<Digest>::deserialize(deserializer)?;
+        // for historical reasons, and to remain backward-compatible,
+        // stacks are stored in reverse (top-down) order
+        Ok(Self::from_iter(s.into_iter().rev()))
+    }
+}
+
+impl serde::Serialize for Stack {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        // for historical reasons, and to remain backward-compatible, platform
+        // stacks are stored in reverse (top-down) order. Unfortunately, this makes
+        // serialization a little costly for large stacks
+        serializer.collect_seq(self.to_top_down())
+    }
+}
+
+pub struct Iter<'a>(Option<&'a Entry>);
+
+impl<'a> Iterator for Iter<'a> {
+    type Item = Digest;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.0.take() {
+            Some(current) => {
+                self.0 = current.next.as_deref();
+                Some(current.value)
+            }
+            None => None,
+        }
+    }
+}

--- a/crates/spfs/src/graph/stack_test.rs
+++ b/crates/spfs/src/graph/stack_test.rs
@@ -1,0 +1,44 @@
+// Copyright (c) Sony Pictures Imageworks, et al.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/imageworks/spk
+
+use rstest::rstest;
+
+use super::Stack;
+use crate::fixtures::*;
+
+#[rstest]
+fn test_stack_deduplication() {
+    let expected = [
+        random_digest(),
+        random_digest(),
+        random_digest(),
+        random_digest(),
+    ];
+
+    let stack = Stack::from_iter([
+        expected[0],
+        expected[0],
+        expected[1],
+        expected[2],
+        expected[2],
+        expected[1],
+        expected[2],
+        expected[1],
+        expected[0],
+        expected[3],
+        expected[0],
+        expected[3],
+        // anything previous should be irrelevant
+        // to the final order of these layers being
+        // added to the stack, since they each replace
+        // previous occurrences of themselves
+        expected[0],
+        expected[1],
+        expected[2],
+        expected[3],
+    ]);
+
+    let actual = stack.iter_bottom_up().collect::<Vec<_>>();
+    assert_eq!(actual, expected);
+}

--- a/crates/spfs/src/proto/conversions.rs
+++ b/crates/spfs/src/proto/conversions.rs
@@ -181,20 +181,21 @@ impl TryFrom<super::Object> for graph::Object {
 impl From<&graph::Platform> for super::Platform {
     fn from(source: &graph::Platform) -> Self {
         Self {
-            stack: source.stack.iter().map(Into::into).collect(),
+            stack: source.stack.iter_bottom_up().map(Into::into).collect(),
         }
     }
 }
 
 impl TryFrom<super::Platform> for graph::Platform {
     type Error = Error;
+
     fn try_from(source: super::Platform) -> Result<Self> {
         Ok(Self {
             stack: source
                 .stack
                 .into_iter()
                 .map(TryInto::try_into)
-                .collect::<Result<Vec<_>>>()?,
+                .collect::<Result<_>>()?,
         })
     }
 }

--- a/crates/spfs/src/prune_test.rs
+++ b/crates/spfs/src/prune_test.rs
@@ -192,13 +192,3 @@ async fn test_prune_tags(#[future] tmprepo: TempRepo) {
         panic!("should not have any pruned tag left")
     }
 }
-
-fn random_digest() -> encoding::Digest {
-    use rand::Rng;
-    let mut hasher = encoding::Hasher::new_sync();
-    let mut rng = rand::thread_rng();
-    let mut buf = vec![0; 64];
-    rng.fill(buf.as_mut_slice());
-    hasher.update(buf.as_slice());
-    hasher.digest()
-}

--- a/crates/spfs/src/resolve_test.rs
+++ b/crates/spfs/src/resolve_test.rs
@@ -16,17 +16,16 @@ use crate::{encoding, graph};
 async fn test_stack_to_layers_dedupe(#[future] tmprepo: TempRepo) {
     let repo = tmprepo.await;
     let layer = graph::Layer::new(encoding::EMPTY_DIGEST.into());
-    let platform = graph::Platform::new(vec![layer.clone(), layer.clone()].into_iter()).unwrap();
-    let stack = vec![layer.digest().unwrap(), platform.digest().unwrap()];
+    let platform = graph::Platform::from_encodable([&layer, &layer]).unwrap();
+    let mut stack = graph::Stack::from_encodable([&layer]).unwrap();
+    stack.push(platform.digest().unwrap());
     repo.write_object(&graph::Object::Layer(layer))
         .await
         .unwrap();
     repo.write_object(&graph::Object::Platform(platform))
         .await
         .unwrap();
-    let resolved = resolve_stack_to_layers(stack.into_iter(), Some(&repo))
-        .await
-        .unwrap();
+    let resolved = resolve_stack_to_layers(&stack, Some(&repo)).await.unwrap();
     assert_eq!(resolved.len(), 1, "should deduplicate layers in resolve");
 }
 

--- a/crates/spfs/src/runtime/storage_test.rs
+++ b/crates/spfs/src/runtime/storage_test.rs
@@ -139,7 +139,8 @@ fn test_live_layer_deserialize_unknown_version() {
 #[rstest]
 fn test_config_serialization() {
     let mut expected = Data::new("spfs-testing");
-    expected.status.stack = vec![encoding::NULL_DIGEST.into(), encoding::EMPTY_DIGEST.into()];
+    expected.status.stack.push(encoding::NULL_DIGEST.into());
+    expected.status.stack.push(encoding::EMPTY_DIGEST.into());
     let data = serde_json::to_string_pretty(&expected).expect("failed to serialize config");
     let actual: Data = serde_json::from_str(&data).expect("failed to deserialize config data");
 

--- a/crates/spfs/src/status.rs
+++ b/crates/spfs/src/status.rs
@@ -69,7 +69,7 @@ pub async fn get_runtime_backing_repo(
 ///
 /// The returned manifest DOES NOT include any active changes to the runtime.
 pub async fn compute_runtime_manifest(rt: &runtime::Runtime) -> Result<tracking::Manifest> {
-    let spec = rt.status.stack.iter().cloned().collect();
+    let spec = rt.status.stack.iter_bottom_up().collect();
     super::compute_environment_manifest(&spec, &get_runtime_backing_repo(rt).await?).await
 }
 

--- a/crates/spfs/src/storage/fs/renderer_unix.rs
+++ b/crates/spfs/src/storage/fs/renderer_unix.rs
@@ -251,15 +251,11 @@ where
 
     /// Render all layers in the given env to the render storage of the underlying
     /// repository, returning the paths to all relevant layers in the appropriate order.
-    pub async fn render<I, D>(
+    pub async fn render(
         &self,
-        stack: I,
+        stack: &graph::Stack,
         render_type: Option<RenderType>,
-    ) -> Result<Vec<PathBuf>>
-    where
-        I: Iterator<Item = D> + Send,
-        D: AsRef<encoding::Digest> + Send,
-    {
+    ) -> Result<Vec<PathBuf>> {
         let layers = crate::resolve::resolve_stack_to_layers_with_repo(stack, self.repo).await?;
         let mut futures = futures::stream::FuturesOrdered::new();
         for layer in layers {
@@ -282,14 +278,13 @@ where
         render_type: RenderType,
     ) -> Result<()> {
         let env_spec = env_spec.into();
-        let mut stack = Vec::new();
+        let mut stack = graph::Stack::default();
         for target in env_spec.iter() {
             let target = target.to_string();
             let obj = self.repo.read_ref(target.as_str()).await?;
             stack.push(obj.digest()?);
         }
-        let layers =
-            crate::resolve::resolve_stack_to_layers_with_repo(stack.iter(), self.repo).await?;
+        let layers = crate::resolve::resolve_stack_to_layers_with_repo(&stack, self.repo).await?;
         let mut manifests = Vec::with_capacity(layers.len());
         for layer in layers {
             manifests.push(self.repo.read_manifest(layer.manifest).await?);

--- a/crates/spfs/src/storage/pinned/tag_test.rs
+++ b/crates/spfs/src/storage/pinned/tag_test.rs
@@ -8,7 +8,6 @@ use chrono::Utc;
 use futures::{StreamExt, TryStreamExt};
 use relative_path::RelativePath;
 use rstest::rstest;
-use spfs_encoding as encoding;
 
 use super::PinnedRepository;
 use crate::fixtures::*;
@@ -155,14 +154,4 @@ async fn test_pinned_visibility() {
         HashSet::from([spec1.to_string(), spec2.to_string()]),
         "should not show entries for tags that don't exist yet"
     );
-}
-
-fn random_digest() -> encoding::Digest {
-    use rand::Rng;
-    let mut hasher = encoding::Hasher::<std::io::Sink>::default();
-    let mut rng = rand::thread_rng();
-    let mut buf = vec![0; 64];
-    rng.fill(buf.as_mut_slice());
-    hasher.update(buf.as_slice());
-    hasher.digest()
 }

--- a/crates/spfs/src/storage/platform.rs
+++ b/crates/spfs/src/storage/platform.rs
@@ -38,8 +38,8 @@ pub trait PlatformStorage: graph::Database + Sync + Send {
 
     /// Create and storage a new platform for the given platform.
     /// Layers are ordered bottom to top.
-    async fn create_platform(&self, layers: Vec<encoding::Digest>) -> Result<graph::Platform> {
-        let platform = graph::Platform::new(layers.into_iter())?;
+    async fn create_platform(&self, layers: graph::Stack) -> Result<graph::Platform> {
+        let platform = graph::Platform::from(layers);
         let storable = graph::Object::Platform(platform);
         self.write_object(&storable).await?;
         if let graph::Object::Platform(platform) = storable {

--- a/crates/spfs/src/sync.rs
+++ b/crates/spfs/src/sync.rs
@@ -293,8 +293,8 @@ where
         self.reporter.visit_platform(&platform);
 
         let mut futures = FuturesUnordered::new();
-        for digest in &platform.stack {
-            futures.push(self.sync_digest(*digest));
+        for digest in platform.stack.iter_bottom_up() {
+            futures.push(self.sync_digest(digest));
         }
         let mut results = Vec::with_capacity(futures.len());
         while let Some(result) = futures.try_next().await? {

--- a/crates/spfs/src/sync_test.rs
+++ b/crates/spfs/src/sync_test.rs
@@ -104,7 +104,7 @@ async fn test_sync_ref(
         .await
         .unwrap();
     let platform = repo_a
-        .create_platform(vec![layer.digest().unwrap()])
+        .create_platform(layer.digest().unwrap().into())
         .await
         .unwrap();
     let tag = tracking::TagSpec::parse("testing").unwrap();
@@ -171,7 +171,7 @@ async fn test_sync_missing_from_source(
         .await
         .unwrap();
     let platform = repo_b
-        .create_platform(vec![layer.digest().unwrap()])
+        .create_platform(layer.digest().unwrap().into())
         .await
         .unwrap();
     let tag = tracking::TagSpec::parse("testing").unwrap();
@@ -240,7 +240,7 @@ async fn test_sync_through_tar(
         .await
         .unwrap();
     let platform = repo_a
-        .create_platform(vec![layer.digest().unwrap()])
+        .create_platform(layer.digest().unwrap().into())
         .await
         .unwrap();
     let tag = tracking::TagSpec::parse("testing").unwrap();

--- a/crates/spk-cli/cmd-du/src/cmd_du.rs
+++ b/crates/spk-cli/cmd-du/src/cmd_du.rs
@@ -345,13 +345,13 @@ impl<T: Output> Du<T> {
                                     for object in items_to_process.iter() {
                                         match object {
                                             Object::Platform(object) => {
-                                                for reference in object.stack.iter() {
-                                                    item = repo.read_ref(reference.to_string().as_str()).await?;
+                                                for digest in object.stack.iter_bottom_up() {
+                                                    item = repo.read_object(digest).await?;
                                                     next_iter_objects.push(item);
                                                 }
                                             }
                                             Object::Layer(object) => {
-                                                item = repo.read_ref(object.manifest.to_string().as_str()).await?;
+                                                item = repo.read_object(object.manifest).await?;
                                                 next_iter_objects.push(item);
                                             }
                                             Object::Manifest(object) => {

--- a/crates/spk-cli/group1/src/cmd_bake.rs
+++ b/crates/spk-cli/group1/src/cmd_bake.rs
@@ -160,8 +160,9 @@ impl Bake {
         // Get the layer(s) for the packages mapping from their source repos
         let layers_to_packages = get_spfs_layers_to_packages(&items)?;
 
-        // Keep the runtime stack order with the first layer at the
-        // bottom. Usually the runtime layers match will the current
+        // Reverse the runtime stack order with the first layer at the
+        // top to remain consistent with other console-based output.
+        // Usually, the runtime layers match will the current
         // environment's packages. However, additional layers may have
         // been added to the runtime (see get_stack() call above).
         // Those layers are included, but we don't know what package
@@ -169,10 +170,10 @@ impl Bake {
         //
         // Note: this may not interact well with spfs run's layer
         // merging for overlay fs mount commands.
-        let mut layers: Vec<BakeLayer> = Vec::with_capacity(runtime.status.stack.len());
-        for layer in runtime.status.stack.iter() {
+        let mut layers: Vec<BakeLayer> = Vec::new();
+        for layer in runtime.status.stack.to_top_down() {
             let (spk_package, mut components) =
-                if let Some(LayerPackageAndComponents(sr, c)) = layers_to_packages.get(layer) {
+                if let Some(LayerPackageAndComponents(sr, c)) = layers_to_packages.get(&layer) {
                     (
                         if self.verbose > NO_VERBOSITY {
                             remove_ansi_escapes(sr.format_as_installed_package())

--- a/crates/spk-exec/src/exec.rs
+++ b/crates/spk-exec/src/exec.rs
@@ -193,7 +193,7 @@ pub async fn setup_current_runtime(solution: &Solution) -> Result<()> {
 pub async fn setup_runtime(rt: &mut spfs::runtime::Runtime, solution: &Solution) -> Result<()> {
     let stack =
         resolve_runtime_layers(rt.config.mount_backend.requires_localization(), solution).await?;
-    rt.status.stack = stack;
+    rt.status.stack = spfs::graph::Stack::from_iter(stack);
     rt.save_state_to_storage().await?;
     spfs::remount_runtime(rt).await?;
     Ok(())

--- a/crates/spk-storage/src/storage/runtime.rs
+++ b/crates/spk-storage/src/storage/runtime.rs
@@ -501,7 +501,7 @@ async fn find_layer_by_filename<S: AsRef<str>>(path: S) -> Result<spfs::encoding
     let runtime = spfs::active_runtime().await?;
     let repo = spfs::get_runtime_backing_repo(&runtime).await?;
 
-    let layers = spfs::resolve_stack_to_layers(runtime.status.stack.iter(), Some(&repo)).await?;
+    let layers = spfs::resolve_stack_to_layers(&runtime.status.stack, Some(&repo)).await?;
     for layer in layers.iter().rev() {
         let manifest = repo
             .read_manifest(layer.manifest)
@@ -536,7 +536,7 @@ async fn find_layers_by_filenames<S: AsRef<str>>(
     let mut results = Vec::new();
     results.resize_with(paths.len(), Default::default);
 
-    let layers = spfs::resolve_stack_to_layers(runtime.status.stack.iter(), Some(&repo)).await?;
+    let layers = spfs::resolve_stack_to_layers(&runtime.status.stack, Some(&repo)).await?;
     for layer in layers.iter().rev() {
         let manifest = repo
             .read_manifest(layer.manifest)


### PR DESCRIPTION
It looks like at some point we started mounting stacks upside-down. Based on how we push digests to the runtime stacks, the first entry was meant to be the topmost one, but that is not consistent with how we set up the overlay command:

https://github.com/imageworks/spk/blob/3dd88255fbdd7d068c74d7929d01cced8e38cad5/crates/spfs/src/resolve.rs#L248