### PR TITLE
sentry-miette update for sentry error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,9 +105,6 @@ name = "anyhow"
 version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
-dependencies = [
- "backtrace",
-]
 
 [[package]]
 name = "anymap2"
@@ -3047,17 +3044,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sentry-anyhow"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d3479158a7396b4dfd346a1944d523427a225ff3c39102e8e985bc21cdfea8"
-dependencies = [
- "anyhow",
- "sentry-backtrace",
- "sentry-core",
-]
-
-[[package]]
 name = "sentry-backtrace"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3093,6 +3079,14 @@ dependencies = [
  "sentry-types",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "sentry-miette"
+version = "0.1.0"
+dependencies = [
+ "miette",
+ "sentry",
 ]
 
 [[package]]
@@ -3453,7 +3447,7 @@ dependencies = [
  "miette",
  "once_cell",
  "sentry",
- "sentry-anyhow",
+ "sentry-miette",
  "sentry-tracing",
  "serde_json",
  "spfs",
@@ -3647,7 +3641,7 @@ dependencies = [
  "colored",
  "miette",
  "sentry",
- "sentry-anyhow",
+ "sentry-miette",
  "spk-build",
  "spk-cli-common",
  "spk-cli-group1",
@@ -3717,7 +3711,6 @@ dependencies = [
  "once_cell",
  "rstest",
  "sentry",
- "sentry-anyhow",
  "sentry-tracing",
  "serde_json",
  "serde_yaml 0.9.27",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ progress_bar_derive_macro = { path = "crates/progress_bar_derive_macro" }
 prost = "0.12.1"
 rstest = "0.15.0"
 sentry = { version = "0.27.0" }
-sentry-anyhow = { version = "0.27.0" }
+sentry-miette = { version = "0.1.0", path = "crates/sentry-miette" }
 sentry-tracing = { version = "0.27.0" }
 serde = "1.0"
 serde_json = "1.0"

--- a/crates/sentry-miette/Cargo.toml
+++ b/crates/sentry-miette/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+authors = { workspace = true }
+edition = { workspace = true }
+name = "sentry-miette"
+version = "0.1.0"
+
+[dependencies]
+miette = { workspace = true }
+sentry = { workspace = true }

--- a/crates/sentry-miette/src/lib.rs
+++ b/crates/sentry-miette/src/lib.rs
@@ -1,0 +1,42 @@
+// Copyright (c) Sony Pictures Imageworks, et al.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/imageworks/spk
+
+// TODO: this might be overkill for the integration changes we make/need
+
+use sentry::protocol::Event;
+use sentry::types::Uuid;
+use sentry::Hub;
+
+/// Helper function to capture an miette error/report for sentry
+pub fn capture_miette(e: &miette::Error) -> Uuid {
+    Hub::with_active(|hub| hub.capture_miette(e))
+}
+
+/// Helper function to create an event from a `miette::Error`.
+pub fn event_from_error(err: &miette::Error) -> Event<'static> {
+    let dyn_err: &dyn std::error::Error = err.as_ref();
+
+    let mut event = sentry::event_from_error(dyn_err);
+
+    // Use the miette formated version of the error in the sentry
+    // event's message when it doesn't already have a message.
+    if event.message.is_none() {
+        event.message = Some(format!("{err:?}"));
+    }
+
+    event
+}
+
+/// Hub extension methods for working with [`miette`].
+pub trait MietteHubExt {
+    /// Captures an [`miette::Error`] on a specific hub.
+    fn capture_miette(&self, e: &miette::Error) -> Uuid;
+}
+
+impl MietteHubExt for Hub {
+    fn capture_miette(&self, miette_error: &miette::Error) -> Uuid {
+        let event = event_from_error(miette_error);
+        self.capture_event(event)
+    }
+}

--- a/crates/spfs-cli/common/Cargo.toml
+++ b/crates/spfs-cli/common/Cargo.toml
@@ -10,11 +10,11 @@ workspace = true
 [features]
 sentry = [
     "dep:sentry",
-    "dep:sentry-anyhow",
     "dep:whoami",
     "spfs/sentry",
     "dep:strip-ansi-escapes",
     "dep:serde_json",
+    "dep:sentry-miette",
     "dep:sentry-tracing",
 ]
 
@@ -24,7 +24,7 @@ libc = { workspace = true }
 miette = { workspace = true, features = ["fancy"] }
 once_cell = { workspace = true }
 sentry = { workspace = true, optional = true }
-sentry-anyhow = { workspace = true, optional = true }
+sentry-miette = { workspace = true, optional = true }
 sentry-tracing = { workspace = true, optional = true }
 serde_json = { version = "1.0.57", optional = true }
 spfs = { path = "../../spfs" }

--- a/crates/spfs-cli/common/src/args.rs
+++ b/crates/spfs-cli/common/src/args.rs
@@ -553,9 +553,8 @@ pub fn capture_if_relevant(err: &Error) {
         Some(spfs::Error::AmbiguousReference(_)) => (),
         Some(spfs::Error::NothingToCommit) => (),
         _ => {
-            // This will always add a backtrace to the sentry event
             #[cfg(feature = "sentry")]
-            sentry::capture_error(std::convert::AsRef::<dyn std::error::Error>::as_ref(err));
+            sentry_miette::capture_miette(err);
         }
     }
 }

--- a/crates/spk-cli/common/Cargo.toml
+++ b/crates/spk-cli/common/Cargo.toml
@@ -18,7 +18,6 @@ migration-to-components = [
 ]
 sentry = [
     "dep:sentry",
-    "dep:sentry-anyhow",
     "dep:sentry-tracing",
     "dep:strip-ansi-escapes",
     "spk-solve/sentry",
@@ -40,7 +39,6 @@ once_cell = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 sentry = { workspace = true, optional = true }
-sentry-anyhow = { workspace = true, optional = true }
 sentry-tracing = { workspace = true, optional = true }
 spfs = { path = "../../spfs" }
 spk-build = { path = '../../spk-build' }

--- a/crates/spk/Cargo.toml
+++ b/crates/spk/Cargo.toml
@@ -21,9 +21,9 @@ migration-to-components = [
 ]
 sentry = [
     "dep:sentry",
-    "dep:sentry-anyhow",
     "spk-cli-common/sentry",
     "spk-solve/sentry",
+    "dep:sentry-miette",
 ]
 spk-cli-common = ["dep:spk-cli-common"]
 cli = [
@@ -55,7 +55,7 @@ clap = { workspace = true }
 clap_complete = { workspace = true }
 colored = { workspace = true }
 sentry = { workspace = true, optional = true }
-sentry-anyhow = { workspace = true, optional = true }
+sentry-miette = { workspace = true, optional = true }
 spk-build = { path = '../spk-build' }
 spk-cli-common = { path = '../spk-cli/common', optional = true }
 spk-cli-group1 = { path = '../spk-cli/group1', optional = true }

--- a/crates/spk/src/cli.rs
+++ b/crates/spk/src/cli.rs
@@ -118,9 +118,7 @@ impl Opt {
                             // client is configured. Panics will have backtraces,
                             // but aren't handled by this, they are sent when
                             // the _sentry_guard goes out of scope.
-                            sentry::capture_error(
-                                std::convert::AsRef::<dyn std::error::Error>::as_ref(err),
-                            );
+                            sentry_miette::capture_miette(err);
                         },
                     );
                 }


### PR DESCRIPTION
This adds a `sentry-miette` crate with `capture_miette` function for translating between`miette::Error/Report` objects and `sentry` events. This involves using the miette formatted output as the event message, if the standard sentry error conversion does not fill in the event's message field.

This also removes some leftover references to `sentry-anyhow` to `Cargo.toml` files.
