### PR TITLE
Draft: explore type state for FSRepository

### DIFF
--- a/crates/spfs-cli/main/src/cmd_init.rs
+++ b/crates/spfs-cli/main/src/cmd_init.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 
 use clap::{Args, Subcommand};
 use miette::Result;
+use spfs::storage::fs::ValidRenderStoreForCurrentUser;
 
 /// Create an empty filesystem repository
 #[derive(Debug, Args)]
@@ -35,7 +36,8 @@ impl InitSubcommand {
     pub async fn run(&self, _config: &spfs::Config) -> Result<i32> {
         match self {
             Self::Repo { path } => {
-                spfs::storage::fs::FsRepository::create(&path).await?;
+                spfs::storage::fs::FsRepository::<ValidRenderStoreForCurrentUser>::create(&path)
+                    .await?;
                 Ok(0)
             }
         }

--- a/crates/spfs/src/resolve.rs
+++ b/crates/spfs/src/resolve.rs
@@ -396,6 +396,9 @@ where
     };
     match repo {
         storage::RepositoryHandle::FS(r) => resolve_stack_to_layers_with_repo(stack, r).await,
+        storage::RepositoryHandle::FSNoUserRenders(r) => {
+            resolve_stack_to_layers_with_repo(stack, r).await
+        }
         storage::RepositoryHandle::Tar(r) => resolve_stack_to_layers_with_repo(stack, r).await,
         storage::RepositoryHandle::Rpc(r) => resolve_stack_to_layers_with_repo(stack, r).await,
         storage::RepositoryHandle::FallbackProxy(r) => {

--- a/crates/spfs/src/storage/fs/database.rs
+++ b/crates/spfs/src/storage/fs/database.rs
@@ -13,11 +13,15 @@ use futures::{Stream, StreamExt, TryFutureExt};
 use graph::DatabaseView;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
+use super::RenderStoreMode;
 use crate::graph::Object;
 use crate::{encoding, graph, Error, Result};
 
 #[async_trait::async_trait]
-impl DatabaseView for super::FsRepository {
+impl<T> DatabaseView for super::FsRepository<T>
+where
+    T: RenderStoreMode,
+{
     async fn has_object(&self, digest: encoding::Digest) -> bool {
         let Ok(opened) = self.opened().await else {
             return false;
@@ -56,7 +60,10 @@ impl DatabaseView for super::FsRepository {
 }
 
 #[async_trait::async_trait]
-impl graph::Database for super::FsRepository {
+impl<T> graph::Database for super::FsRepository<T>
+where
+    T: RenderStoreMode,
+{
     async fn write_object(&self, obj: &graph::Object) -> Result<()> {
         self.opened().await?.write_object(obj).await
     }
@@ -78,7 +85,10 @@ impl graph::Database for super::FsRepository {
 }
 
 #[async_trait::async_trait]
-impl DatabaseView for super::OpenFsRepository {
+impl<T> DatabaseView for super::OpenFsRepository<T>
+where
+    T: RenderStoreMode,
+{
     async fn has_object(&self, digest: encoding::Digest) -> bool {
         let filepath = self.objects.build_digest_path(&digest);
         tokio::fs::symlink_metadata(filepath).await.is_ok()
@@ -124,7 +134,10 @@ impl DatabaseView for super::OpenFsRepository {
 }
 
 #[async_trait::async_trait]
-impl graph::Database for super::OpenFsRepository {
+impl<T> graph::Database for super::OpenFsRepository<T>
+where
+    T: RenderStoreMode,
+{
     async fn write_object(&self, obj: &graph::Object) -> Result<()> {
         let digest = obj.digest()?;
         let filepath = self.objects.build_digest_path(&digest);

--- a/crates/spfs/src/storage/fs/mod.rs
+++ b/crates/spfs/src/storage/fs/mod.rs
@@ -35,8 +35,11 @@ pub use repository::{
     read_last_migration_version,
     Config,
     FsRepository,
+    NoRenderStoreForCurrentUser,
     OpenFsRepository,
     Params,
     RenderStore,
+    RenderStoreMode,
+    ValidRenderStoreForCurrentUser,
     DURABLE_EDITS_DIR,
 };

--- a/crates/spfs/src/storage/fs/payloads.rs
+++ b/crates/spfs/src/storage/fs/payloads.rs
@@ -8,13 +8,16 @@ use std::pin::Pin;
 use futures::future::ready;
 use futures::{Stream, StreamExt, TryFutureExt};
 
-use super::{FsRepository, OpenFsRepository};
+use super::{FsRepository, OpenFsRepository, RenderStoreMode};
 use crate::storage::prelude::*;
 use crate::tracking::BlobRead;
 use crate::{encoding, Error, Result};
 
 #[async_trait::async_trait]
-impl crate::storage::PayloadStorage for FsRepository {
+impl<T> crate::storage::PayloadStorage for FsRepository<T>
+where
+    T: RenderStoreMode,
+{
     async fn has_payload(&self, digest: encoding::Digest) -> bool {
         let Ok(opened) = self.opened().await else {
             return false;
@@ -52,7 +55,10 @@ impl crate::storage::PayloadStorage for FsRepository {
 }
 
 #[async_trait::async_trait]
-impl crate::storage::PayloadStorage for OpenFsRepository {
+impl<T> crate::storage::PayloadStorage for OpenFsRepository<T>
+where
+    T: RenderStoreMode,
+{
     async fn has_payload(&self, digest: encoding::Digest) -> bool {
         let path = self.payloads.build_digest_path(&digest);
         tokio::fs::symlink_metadata(path).await.is_ok()

--- a/crates/spfs/src/storage/fs/tag.rs
+++ b/crates/spfs/src/storage/fs/tag.rs
@@ -18,7 +18,7 @@ use futures::{Future, Stream, StreamExt, TryFutureExt};
 use relative_path::RelativePath;
 use tokio::io::{AsyncRead, AsyncSeek, AsyncWriteExt, ReadBuf};
 
-use super::{FsRepository, OpenFsRepository};
+use super::{FsRepository, OpenFsRepository, RenderStoreMode};
 use crate::storage::tag::{EntryType, TagSpecAndTagStream, TagStream};
 use crate::storage::TagStorage;
 use crate::{encoding, tracking, Error, OsError, OsErrorExt, Result};
@@ -26,7 +26,10 @@ use crate::{encoding, tracking, Error, OsError, OsErrorExt, Result};
 const TAG_EXT: &str = "tag";
 
 #[async_trait::async_trait]
-impl TagStorage for FsRepository {
+impl<T> TagStorage for FsRepository<T>
+where
+    T: RenderStoreMode,
+{
     fn ls_tags(
         &self,
         path: &RelativePath,
@@ -81,14 +84,20 @@ impl TagStorage for FsRepository {
     }
 }
 
-impl OpenFsRepository {
+impl<T> OpenFsRepository<T>
+where
+    T: RenderStoreMode,
+{
     fn tags_root(&self) -> PathBuf {
         self.root().join("tags")
     }
 }
 
 #[async_trait::async_trait]
-impl TagStorage for OpenFsRepository {
+impl<T> TagStorage for OpenFsRepository<T>
+where
+    T: RenderStoreMode,
+{
     fn ls_tags(
         &self,
         path: &RelativePath,

--- a/crates/spfs/src/storage/handle.rs
+++ b/crates/spfs/src/storage/handle.rs
@@ -25,6 +25,7 @@ macro_rules! each_variant {
     ($repo:expr, $inner:ident, $ops:tt) => {
         match $repo {
             RepositoryHandle::FS($inner) => $ops,
+            RepositoryHandle::FSNoUserRenders($inner) => $ops,
             RepositoryHandle::Tar($inner) => $ops,
             RepositoryHandle::Rpc($inner) => $ops,
             RepositoryHandle::FallbackProxy($inner) => $ops,

--- a/crates/spk-storage/src/fixtures.rs
+++ b/crates/spk-storage/src/fixtures.rs
@@ -10,6 +10,7 @@ use once_cell::sync::Lazy;
 use rstest::fixture;
 use spfs::config::Remote;
 use spfs::prelude::*;
+use spfs::storage::fs::ValidRenderStoreForCurrentUser;
 use spfs::Result;
 use spk_schema::foundation::fixtures::*;
 use tokio::sync::{Mutex, MutexGuard};
@@ -106,7 +107,10 @@ pub async fn make_repo(kind: RepoKind) -> TempRepo {
     let repo = match kind {
         RepoKind::Spfs => {
             let storage_root = tmpdir.path().join("repo");
-            let spfs_repo = spfs::storage::fs::FsRepository::create(&storage_root)
+            let spfs_repo =
+                spfs::storage::fs::FsRepository::<ValidRenderStoreForCurrentUser>::create(
+                    &storage_root,
+                )
                 .await
                 .expect("failed to establish temporary local repo for test");
             let written = spfs_repo


### PR DESCRIPTION
Exploring the idea of using the type state pattern to have two different flavors of an `FSRepository`, one that promises the user's renders directory exists, and one that doesn't, for use by cmd_clean (#923).

There are some type conversion todos left in the code, but I got this to the point where the non-test code will compile and in theory `spfs clean` would not attempt to create the user's render directory.

Looking for feedback on this approach or if there are any suggestions for an alternative approach. Something much simpler would be the tried and true pass-a-bool-down, since all I really want to accomplish is to skip creating one of the directories inside `create`. There's just a lot of abstraction between `open_repository_from_string` and the call to `create`.

This draft change doesn't offer any other advantages, like it doesn't prevent using a no-renders repo as if it were a yes-renders one. The distinction gets hidden behind the `RepositoryHandle`. I guess I'm saying I don't like this code but I thought I'd at least get a second opinion.