### PR TITLE
Remove spfs-join from process tree

### DIFF
--- a/crates/spfs-cli/cmd-join/src/cmd_join.rs
+++ b/crates/spfs-cli/cmd-join/src/cmd_join.rs
@@ -129,12 +129,9 @@ impl CmdJoin {
                 spfs::build_interactive_shell_command(rt, None)?
             }
         };
-        let mut proc = cmd.into_std();
-        tracing::debug!("{:?}", proc);
-        Ok(proc
-            .status()
-            .map_err(|err| Error::process_spawn_error("exec_runtime_command", err, None))?
-            .code()
-            .unwrap_or(1))
+        tracing::debug!("{cmd:#?}");
+        cmd.exec()
+            .map(|_| 0)
+            .wrap_err("Failed to execute runtime command")
     }
 }


### PR DESCRIPTION
Our users reported some unexpected behaviour, like spfs-join capturing ctrl-c and breaking interactions with launched processes.