### PR TITLE
Updates for auto_host_vars docs and spk new template

### DIFF
--- a/crates/spk-cli/group2/src/cmd_new.rs
+++ b/crates/spk-cli/group2/src/cmd_new.rs
@@ -40,7 +40,8 @@ impl CommandArgs for New {
 
 fn get_stub(name: &PkgNameBuf) -> String {
     format!(
-        r#"pkg: {name}/0.1.0
+        r#"api: v0/package
+pkg: {name}/0.1.0
 
 build:
 

--- a/docs/ref/spec.md
+++ b/docs/ref/spec.md
@@ -127,14 +127,24 @@ options to each build, as described in the table:
 |  Value     | Adds these host options                        |
 | ---------- | ---------------------------------------------- |
 | **Distro** (default) | "distro", "arch", "os", and the "<distroname>" |
-| **Arch**   | "arch", "os", and the "<distroname>"           |
+| **Arch**   | "arch", "os"                                   |
 | **Os**     | "os"                                           |
-| **None**   |                                                |
+| **Full**   |                                                |
 
 If the host OS has no distroname, "unknown_distro" will be used as the
 distro name. If the host OS' distroname is not valid as a var option
 name, it will be converted lossily to a valid var option name.
 
+Example:
+```yaml
+api: v0/package
+pkg: example/0.0.1
+build:
+  auto_host_vars: Distro
+  options:
+     ...
+...
+```
 
 ## TestSpec
 


### PR DESCRIPTION
This has a couple of small updates to the `auto_host_vars` docs to fix some mistakes and add example yaml.

It also adds `api: v0/package` to the `spk new` command's pkg template.
