### PR TITLE
Further updates the for auto_host_var docs

### DIFF
--- a/crates/spk-build/src/build/binary_test.rs
+++ b/crates/spk-build/src/build/binary_test.rs
@@ -53,7 +53,7 @@ async fn test_empty_var_option_is_not_a_request() {
         r#"{
             pkg: mypackage/1.0.0,
             build: {
-                host_compat: Any,
+                auto_host_vars: None,
                 options: [
                     {var: something}
                 ]
@@ -832,7 +832,7 @@ async fn test_default_build_component() {
             "pkg": "mypkg/1.0.0",
             "sources": [],
             "build": {
-                "host_compat": "Any",
+                "auto_host_vars": "None",
                 "options": [{"pkg": "somepkg/1.0.0"}],
                 "script": "echo building...",
             },

--- a/crates/spk-solve/crates/package-iterator/src/package_iterator_test.rs
+++ b/crates/spk-solve/crates/package-iterator/src/package_iterator_test.rs
@@ -26,7 +26,7 @@ async fn test_solver_sorted_build_iterator_sort_by_option_values() {
         {
             "pkg": "vnp3/2.0.0",
             "build": {
-                "host_compat": "Any",
+                "auto_host_vars": "None",
                 "options": [
                     {"var": "tuesday/debug"},
                     {"var": "cmake/3.0"},
@@ -41,7 +41,7 @@ async fn test_solver_sorted_build_iterator_sort_by_option_values() {
         {
             "pkg": "vnp3/2.0.0",
             "build": {
-                "host_compat": "Any",
+                "auto_host_vars": "None",
                 "options": [
                     {"pkg": "gcc/6"},
                     {"var": "cheese/3.0"},
@@ -61,7 +61,7 @@ async fn test_solver_sorted_build_iterator_sort_by_option_values() {
         {
             "pkg": "vnp3/2.0.0/src",
             "build": {
-                "host_compat": "Any",
+                "auto_host_vars": "None",
                 "options": [
                     {"var": "tuesday/debug"},
                     {"var": "cmake/3.0"},

--- a/docs/ref/spec.md
+++ b/docs/ref/spec.md
@@ -173,14 +173,14 @@ The HostCompat value sets which host- and os-related options are
 automatically added to each build. The values add zero, or more, host
 options to each build, as described in the table:
 
-|  Value     | Adds these host options                        |
-| ---------- | ---------------------------------------------- |
-| **Distro** (default) | "distro", "arch", "os", and the "<distroname>" |
-| **Arch**   | "arch", "os"                                   |
-| **Os**     | "os"                                           |
-| **Full**   |                                                |
+|  Value               |  Adds these host var options                               |  Examples of added host var options            |
+| -------------------- | ---------------------------------------------------------- | ---------------------------------------------- |
+| **Distro** (default) | "distro", "arch", "os", and the "\<distroname\>"           | distro=centos, arch=x86_64, os=linux, centos=7 |
+| **Arch**             | "arch", "os"                                               | arch=x86_64, os=linux                          |
+| **Os**               | "os"                                                       | os=linux                                       |
+| **None**             |                                                            |                                                |
 
-If the host OS has no distroname, "unknown_distro" will be used as the
+If the host OS has no distro name, "unknown_distro" will be used as the
 distro name. If the host OS' distroname is not valid as a var option
 name, it will be converted lossily to a valid var option name.
 


### PR DESCRIPTION
This updates the`<distroname>` token in docs to escape the < and >, and adds examples of the added var options to the table.
