### PR TITLE
modified error message when variant fails

### DIFF
--- a/crates/spk-cli/cmd-build/src/cmd_build.rs
+++ b/crates/spk-cli/cmd-build/src/cmd_build.rs
@@ -75,10 +75,10 @@ impl Run for Build {
                 verbose: self.verbose,
                 packages: packages.clone(),
                 runtime: self.runtime.clone(),
-                created_src: Vec::new(),
+                created_src: std::mem::take(&mut builds_for_summary),
             };
             let idents = make_source.make_source().await?;
-            builds_for_summary.append(&mut make_source.created_src);
+            builds_for_summary = std::mem::take(&mut make_source.created_src);
 
             let mut make_binary = spk_cmd_make_binary::cmd_make_binary::MakeBinary {
                 verbose: self.verbose,
@@ -98,13 +98,14 @@ impl Run for Build {
                 variant: self.variant,
                 formatter_settings: self.formatter_settings.clone(),
                 allow_circular_dependencies: self.allow_circular_dependencies,
-                created_builds: Vec::new(),
+                created_builds: std::mem::take(&mut builds_for_summary),
             };
             let code = make_binary.run().await?;
             if code != 0 {
                 return Ok(code);
             }
-            builds_for_summary.append(&mut make_binary.created_builds);
+
+            builds_for_summary = std::mem::take(&mut make_binary.created_builds);
         }
 
         println!("Completed builds:");

--- a/crates/spk-cli/cmd-make-binary/src/cmd_make_binary.rs
+++ b/crates/spk-cli/cmd-make-binary/src/cmd_make_binary.rs
@@ -219,7 +219,14 @@ impl Run for MakeBinary {
                             ),
                         ),
                     ) => {
-                        tracing::error!("variant failed:\n{variant}");
+                        if !self.created_builds.is_empty() {
+                            tracing::warn!("Completed builds:");
+                            for msg in self.created_builds.iter() {
+                                tracing::warn!("{msg}");
+                            }
+                        }
+
+                        tracing::error!("variant {variant_index} failed:\n{variant}");
                         return Err(err.into());
                     }
                     Ok((spec, _cmpts)) => spec,


### PR DESCRIPTION
Additional change to the previous PR: https://github.com/imageworks/spk/pull/939 to print a more useful message when a variant fails.

ex:

```
 WARN Impossible initial request, no builds in the repos [local, origin] satisfy: boost-python:build/1.8
 WARN Completed builds:
 WARN    temp-pkg/0/src
 WARN    temp-pkg/0/A3R27WF7 variant 0, {arch: x86_64, centos: 7, distro: centos, os: linux, python: 2.7}
ERROR variant 1 failed:
Options: {arch=x86_64, boost-python=1.8, centos=7, distro=centos, os=linux, python=3.7}
Additional Requirements:
  python/3.7
  boost-python/1.8
ERROR   x Initial requests contain 1 impossible request.
```