### PR TITLE
Bugfix spfs run when using fuse backend and LiveLayerFile EnvSpecItems

### DIFF
--- a/crates/spfs-cli/main/src/cmd_run.rs
+++ b/crates/spfs-cli/main/src/cmd_run.rs
@@ -185,7 +185,7 @@ impl CmdRun {
                 let repo = spfs::storage::ProxyRepository::from_config(proxy_config)
                     .await
                     .wrap_err("Failed to build proxy repository for environment resolution")?;
-                for item in reference.iter() {
+                for item in reference.iter().filter(|i| !i.is_livelayerfile()) {
                     let digest = item.resolve_digest(&repo).await?;
                     runtime.push_digest(digest);
                 }

--- a/crates/spfs/src/tracking/env.rs
+++ b/crates/spfs/src/tracking/env.rs
@@ -63,6 +63,11 @@ impl EnvSpecItem {
             _ => Ok(Cow::Borrowed(self)),
         }
     }
+
+    /// Returns true if this item is a live layer file
+    pub fn is_livelayerfile(&self) -> bool {
+        matches!(self, Self::LiveLayerFile(_))
+    }
 }
 
 impl std::fmt::Display for EnvSpecItem {


### PR DESCRIPTION
This fixes a bug where spfs run was not filterout out LiveLayerFile EnvSpecItems when using fuse backends to set up the spfs objects/layers. This caused an error when spf run tried to resolve the digests of those EnvSpecItems. LiveLayerFile items do not have an associated digest.
