### PR TITLE
Updates auto_host_vars field so default value doesn't get serialised

### DIFF
--- a/crates/spk-schema/src/build_spec.rs
+++ b/crates/spk-schema/src/build_spec.rs
@@ -131,7 +131,7 @@ pub struct BuildSpec {
     pub variants: Vec<v0::Variant>,
     #[serde(default, skip_serializing_if = "ValidationSpec::is_default")]
     pub validation: ValidationSpec,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "AutoHostVars::is_default")]
     pub auto_host_vars: AutoHostVars,
 }
 


### PR DESCRIPTION
This updates the `auto_host_vars` field so it doesn't get serialised when it is set to the default value.
