### PR TITLE
Output lint summary after build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4116,6 +4116,7 @@ dependencies = [
  "spk-storage",
  "tempfile",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -4257,6 +4258,7 @@ dependencies = [
  "async-trait",
  "clap 4.5.0",
  "miette",
+ "serde_yaml 0.9.27",
  "spfs",
  "spk-build",
  "spk-cli-common",

--- a/crates/spk-cli/cmd-build/Cargo.toml
+++ b/crates/spk-cli/cmd-build/Cargo.toml
@@ -27,10 +27,11 @@ spfs = { workspace = true }
 spk-cli-common = { workspace = true }
 spk-cmd-make-binary = { workspace = true }
 spk-cmd-make-source = { workspace = true }
+spk-schema = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 rstest = { workspace = true }
-spk-schema = { workspace = true }
 spk-storage = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true }

--- a/crates/spk-cli/cmd-make-source/Cargo.toml
+++ b/crates/spk-cli/cmd-make-source/Cargo.toml
@@ -24,6 +24,7 @@ migration-to-components = [
 miette = { workspace = true, features = ["fancy"] }
 async-trait = { workspace = true }
 clap = { workspace = true }
+serde_yaml = { workspace = true }
 spfs = { workspace = true }
 spk-build = { workspace = true }
 spk-cli-common = { workspace = true }

--- a/crates/spk-cli/cmd-make-source/src/cmd_make_source.rs
+++ b/crates/spk-cli/cmd-make-source/src/cmd_make_source.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/spkenv/spk
 
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -11,7 +12,17 @@ use spk_build::SourcePackageBuilder;
 use spk_cli_common::{flags, BuildArtifact, BuildResult, CommandArgs, Run};
 use spk_schema::foundation::format::FormatIdent;
 use spk_schema::ident::LocatedBuildIdent;
-use spk_schema::{Package, Recipe, SpecTemplate, Template, TemplateExt};
+use spk_schema::v0::Spec;
+use spk_schema::{
+    AnyIdent,
+    Lint,
+    LintedItem,
+    Package,
+    Recipe,
+    SpecTemplate,
+    Template,
+    TemplateExt,
+};
 use spk_storage as storage;
 
 /// Build a source package from a spec file.
@@ -34,6 +45,10 @@ pub struct MakeSource {
     /// Populated with the created src to generate a summary from the caller.
     #[clap(skip)]
     pub created_src: BuildResult,
+
+    /// Used to gather lints to output at the end of a build.
+    #[clap(skip)]
+    pub lints: BTreeMap<String, Vec<Lint>>,
 }
 
 #[async_trait::async_trait]
@@ -81,6 +96,7 @@ impl MakeSource {
                     template
                 }
             };
+
             let root = template
                 .file_path()
                 .parent()
@@ -99,6 +115,20 @@ impl MakeSource {
                 )
             })?;
             let ident = recipe.ident();
+
+            let lints: std::result::Result<LintedItem<Spec<AnyIdent>>, serde_yaml::Error> =
+                serde_yaml::from_str(&template.render_to_string(&options)?);
+
+            match lints {
+                Ok(linted_item) => match linted_item.lints.is_empty() {
+                    true => (),
+                    false => {
+                        self.lints
+                            .insert(ident.format_ident(), linted_item.lints.clone());
+                    }
+                },
+                Err(e) => tracing::error!("Failed to retrieve lints: {e}"),
+            }
 
             tracing::info!("saving package recipe for {}", ident.format_ident());
             local.force_publish_recipe(&recipe).await?;


### PR DESCRIPTION
Additional feature to the linting changes to show a summary of the generated lints if any exists.

Ex:

```
Completed builds:
   temp-pkg/1.0.3/src
   temp-pkg/1.0.3/AKCOQQ5Q variant 0, {arch: x86_64, centos: 7, distro: centos, os: linux, python: 2.7}
   temp-pkg/1.0.3/AHASMWKK variant 1, {arch: x86_64, centos: 7, distro: centos, os: linux, python: 3.7}
Lints:
 WARN temp-pkg/1.0.3 Unrecognized key: envionment. (Did you mean: 'environment'?)
 ```