### PR TITLE
Bug example: EncodingFormat and DigestStrategy legacy values cause test fail

### DIFF
--- a/crates/spfs/src/graph/object.rs
+++ b/crates/spfs/src/graph/object.rs
@@ -725,11 +725,11 @@ pub enum DigestStrategy {
     /// Hash the output of the original spfs encoding, which
     /// has known collision issues. Not recommended for use
     /// except for backwards-compatibility
+    #[default]
     Legacy = 0,
     /// Encoding using the original spfs encoding, but adds salt
     /// and the [`ObjectKind`] to mitigate issues found in the
     /// original encoding mechanism
-    #[default]
     WithKindAndSalt = 1,
 }
 
@@ -749,10 +749,10 @@ impl DigestStrategy {
 pub enum EncodingFormat {
     /// Encode using the original spfs encoding, which uses
     /// a bespoke binary format
+    #[default]
     Legacy = 0,
     /// Encode using the [`spfs_proto::AnyObject`] flatbuffers
     /// schema.
-    #[default]
     FlatBuffers = 1,
 }
 


### PR DESCRIPTION
This is an example to show a bug / test failure. I'll put in a corresponding ticket.

This should not be merge as it is.

This changes the graph::object's  `EncodingFormat` and `DigestStrategy` defauls to their legacy setting values, and causes the `check::check_test::test_check_missing_object_recover` test to fail like this:

```
...
TRACE spfs::check: Checking digest digest=Z4D4OQYOU4ITXSJ4ZKE2YGCONT57I35JKRXUJNRZQVCMOOCLLM3Q====
TRACE spfs::storage::fs::database: writing object to db digest=Z4D4OQYOU4ITXSJ4ZKE2YGCONT57I35JKRXUJNRZQVCMOOCLLM3Q==== kind=spfs_proto::spfs_generated::Blob
ERROR spfs::graph::platform: read 14918111381510623547 layers in platform
thread 'check::check_test::test_check_missing_object_recover' panicked at library/alloc/src/raw_vec.rs:545:5:
capacity overflow


failures:
    check::check_test::test_check_missing_object_recover
...
```

The test generatees a set of random spfs objects in two repos. It finds a file entry in one and deletes the blob object that is the file's contents from that repo, then it attempts to repair the missing object using the other repo. The failure occurs when it tries to sync the missing blob object from the other repo. The test output above shows that it is trying to read the blob object as a platform and stumbles over an unreasonably large number of layers in that platfrom . The thing is the test doesn't generate any platform objects, and the missing object is a blob not a platform.

From what I can tell, the problem happens in the `sync_digest` function in `crates/spfs/src/sync.rs` that starts at line 258.
```
    pub async fn sync_digest(&self, digest: encoding::Digest) -> Result<SyncObjectResult> {
        // don't write the digest here, as that is the responsibility
        // of the function that actually handles the data copying.
        // a short-circuit is still nice when possible, though
        if self.processed_digests.contains(&digest) {
            return Ok(SyncObjectResult::Duplicate);
        }
        let obj = self.read_object_with_fallback(digest).await?;  <--- between here
        self.sync_object(obj).await                               <--- and here obj changes???
    }
```
The `obj` is apparently set as `FlatObject<AnyObject<'_>>`. But the `self.sync_object(...)` call takes a `graph::Object` parameter.  So is an implicit conversion happening between the two lines and that's messing the object up? I'm not sure what's going on.





