### PR TITLE
Change spk Run trait to have generic return type

### DIFF
--- a/crates/spk-cli/cmd-build/src/cmd_build.rs
+++ b/crates/spk-cli/cmd-build/src/cmd_build.rs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
-use std::process::ExitStatus;
-
 use clap::Args;
 use miette::Result;
 use spk_cli_common::{flags, CommandArgs, Run};
@@ -59,7 +57,7 @@ pub struct Build {
 /// Runs make-source and then make-binary
 #[async_trait::async_trait]
 impl Run for Build {
-    type Output = ExitStatus;
+    type Output = i32;
 
     async fn run(&mut self) -> Result<Self::Output> {
         self.runtime
@@ -104,9 +102,9 @@ impl Run for Build {
                 allow_circular_dependencies: self.allow_circular_dependencies,
                 created_builds: std::mem::take(&mut builds_for_summary),
             };
-            let exit_status = make_binary.run().await?;
-            if !exit_status.success() {
-                return Ok(exit_status);
+            let code = make_binary.run().await?;
+            if code != 0 {
+                return Ok(code);
             }
 
             builds_for_summary = std::mem::take(&mut make_binary.created_builds);
@@ -117,7 +115,7 @@ impl Run for Build {
             println!("{msg}");
         }
 
-        Ok(ExitStatus::default())
+        Ok(0)
     }
 }
 

--- a/crates/spk-cli/cmd-convert/src/cmd_convert.rs
+++ b/crates/spk-cli/cmd-convert/src/cmd_convert.rs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
-use std::process::ExitStatus;
-
 use clap::Args;
 use miette::Result;
 use spk_cli_common::{flags, CommandArgs, Run};
@@ -39,7 +37,7 @@ pub struct Convert {
 
 #[async_trait::async_trait]
 impl Run for Convert {
-    type Output = ExitStatus;
+    type Output = i32;
 
     async fn run(&mut self) -> Result<Self::Output> {
         let converter_package = format!("spk-convert-{}", self.converter);

--- a/crates/spk-cli/cmd-debug/src/cmd_debug.rs
+++ b/crates/spk-cli/cmd-debug/src/cmd_debug.rs
@@ -4,7 +4,6 @@
 
 use std::collections::HashMap;
 use std::convert::TryInto;
-use std::process::ExitStatus;
 
 use clap::Args;
 use futures::TryFutureExt;
@@ -32,7 +31,7 @@ pub struct Debug {
 
 #[async_trait::async_trait]
 impl Run for Debug {
-    type Output = ExitStatus;
+    type Output = i32;
 
     async fn run(&mut self) -> Result<Self::Output> {
         let (env, mut repos, local_repo) = tokio::try_join!(
@@ -85,7 +84,7 @@ impl Run for Debug {
 
         if source_layers.is_empty() {
             tracing::info!("No source packages were found for the current environment.");
-            return Ok(ExitStatus::default());
+            return Ok(0);
         }
 
         let mut rt = spfs::active_runtime().await?;
@@ -105,7 +104,7 @@ impl Run for Debug {
         rt.save_state_to_storage().await?;
         spfs::remount_runtime(&rt).await?;
 
-        Ok(ExitStatus::default())
+        Ok(0)
     }
 }
 

--- a/crates/spk-cli/cmd-du/src/cmd_du.rs
+++ b/crates/spk-cli/cmd-du/src/cmd_du.rs
@@ -5,7 +5,6 @@
 use std::collections::{HashMap, HashSet};
 use std::fmt::Arguments;
 use std::pin::Pin;
-use std::process::ExitStatus;
 use std::sync::Arc;
 
 use async_stream::try_stream;
@@ -166,7 +165,7 @@ pub struct Du<Output: Default = Console> {
 
 #[async_trait::async_trait]
 impl<T: Output> Run for Du<T> {
-    type Output = ExitStatus;
+    type Output = i32;
 
     async fn run(&mut self) -> Result<Self::Output> {
         let input_depth = self.path.split(LEVEL_SEPARATOR).collect_vec().len();
@@ -175,7 +174,7 @@ impl<T: Output> Run for Du<T> {
         } else {
             self.print_all_entries(input_depth).await?;
         }
-        Ok(ExitStatus::default())
+        Ok(0)
     }
 }
 

--- a/crates/spk-cli/cmd-env/src/cmd_env.rs
+++ b/crates/spk-cli/cmd-env/src/cmd_env.rs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
-use std::process::ExitStatus;
-
 use clap::Args;
 use miette::{Context, Result};
 use spk_cli_common::{build_required_packages, flags, CommandArgs, Run};
@@ -47,7 +45,7 @@ pub struct Env {
 
 #[async_trait::async_trait]
 impl Run for Env {
-    type Output = ExitStatus;
+    type Output = i32;
 
     async fn run(&mut self) -> Result<Self::Output> {
         let mut rt = self
@@ -116,7 +114,7 @@ impl Run for Env {
 
         command
             .exec()
-            .map(|_| ExitStatus::default())
+            .map(|_| 0)
             .wrap_err("Failed to execute runtime command")
     }
 }

--- a/crates/spk-cli/cmd-explain/src/cmd_explain.rs
+++ b/crates/spk-cli/cmd-explain/src/cmd_explain.rs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
-use std::process::ExitStatus;
-
 use clap::Args;
 use miette::Result;
 use spk_cli_common::{flags, CommandArgs, Run};
@@ -47,7 +45,7 @@ pub struct Explain {
 
 #[async_trait::async_trait]
 impl Run for Explain {
-    type Output = ExitStatus;
+    type Output = i32;
 
     async fn run(&mut self) -> Result<Self::Output> {
         // Warn about deprecated arguments.
@@ -88,7 +86,7 @@ impl Run for Explain {
             .build();
         formatter.run_and_print_resolve(&solver).await?;
 
-        Ok(ExitStatus::default())
+        Ok(0)
     }
 }
 

--- a/crates/spk-cli/cmd-install/src/cmd_install.rs
+++ b/crates/spk-cli/cmd-install/src/cmd_install.rs
@@ -4,11 +4,6 @@
 
 use std::collections::HashSet;
 use std::io::Write;
-#[cfg(unix)]
-use std::os::unix::process::ExitStatusExt;
-#[cfg(windows)]
-use std::os::windows::process::ExitStatusExt;
-use std::process::ExitStatus;
 
 use clap::Args;
 use colored::Colorize;
@@ -47,7 +42,7 @@ pub struct Install {
 
 #[async_trait::async_trait]
 impl Run for Install {
-    type Output = ExitStatus;
+    type Output = i32;
 
     async fn run(&mut self) -> Result<Self::Output> {
         let (mut solver, env) = tokio::try_join!(
@@ -119,7 +114,7 @@ impl Run for Install {
                 "y" | "yes" => {}
                 _ => {
                     println!("Installation cancelled");
-                    return Ok(ExitStatus::from_raw(1));
+                    return Ok(1);
                 }
             }
         }
@@ -128,7 +123,7 @@ impl Run for Install {
             .await
             .wrap_err("Failed to build one or more packages from source")?;
         setup_current_runtime(&compiled_solution).await?;
-        Ok(ExitStatus::default())
+        Ok(0)
     }
 }
 

--- a/crates/spk-cli/cmd-make-binary/src/cmd_make_binary.rs
+++ b/crates/spk-cli/cmd-make-binary/src/cmd_make_binary.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
-use std::process::ExitStatus;
 use std::sync::Arc;
 
 use clap::Args;
@@ -106,7 +105,7 @@ impl CommandArgs for MakeBinary {
 
 #[async_trait::async_trait]
 impl Run for MakeBinary {
-    type Output = ExitStatus;
+    type Output = i32;
 
     async fn run(&mut self) -> Result<Self::Output> {
         if spfs::get_config()?
@@ -253,11 +252,12 @@ impl Run for MakeBinary {
                         .arg(request.pkg.to_string());
                     tracing::info!("entering environment with new package...");
                     tracing::debug!("{:?}", cmd);
-                    return cmd.status().into_diagnostic();
+                    let status = cmd.status().into_diagnostic()?;
+                    return Ok(status.code().unwrap_or(1));
                 }
                 variant_index += 1;
             }
         }
-        Ok(ExitStatus::default())
+        Ok(0)
     }
 }

--- a/crates/spk-cli/cmd-make-recipe/src/cmd_make_recipe.rs
+++ b/crates/spk-cli/cmd-make-recipe/src/cmd_make_recipe.rs
@@ -2,11 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
-#[cfg(unix)]
-use std::os::unix::process::ExitStatusExt;
-#[cfg(windows)]
-use std::os::windows::process::ExitStatusExt;
-use std::process::ExitStatus;
 use std::sync::Arc;
 
 use clap::Args;
@@ -46,7 +41,7 @@ impl CommandArgs for MakeRecipe {
 
 #[async_trait::async_trait]
 impl Run for MakeRecipe {
-    type Output = ExitStatus;
+    type Output = i32;
 
     async fn run(&mut self) -> Result<Self::Output> {
         let options = self.options.get_options()?;
@@ -73,11 +68,11 @@ impl Run for MakeRecipe {
         match template.render(&options) {
             Err(err) => {
                 tracing::error!("This template did not render into a valid spec {err}");
-                Ok(ExitStatus::from_raw(1))
+                Ok(1)
             }
             Ok(_) => {
                 tracing::info!("Successfully rendered a valid spec");
-                Ok(ExitStatus::default())
+                Ok(0)
             }
         }
     }

--- a/crates/spk-cli/cmd-make-source/src/cmd_make_source.rs
+++ b/crates/spk-cli/cmd-make-source/src/cmd_make_source.rs
@@ -3,7 +3,6 @@
 // https://github.com/imageworks/spk
 
 use std::path::PathBuf;
-use std::process::ExitStatus;
 use std::sync::Arc;
 
 use clap::Args;
@@ -39,10 +38,10 @@ pub struct MakeSource {
 
 #[async_trait::async_trait]
 impl Run for MakeSource {
-    type Output = ExitStatus;
+    type Output = i32;
 
     async fn run(&mut self) -> Result<Self::Output> {
-        self.make_source().await.map(|_| ExitStatus::default())
+        self.make_source().await.map(|_| 0)
     }
 }
 

--- a/crates/spk-cli/cmd-render/src/cmd_render.rs
+++ b/crates/spk-cli/cmd-render/src/cmd_render.rs
@@ -3,7 +3,6 @@
 // https://github.com/imageworks/spk
 
 use std::path::PathBuf;
-use std::process::ExitStatus;
 
 use clap::Args;
 use miette::{bail, Context, IntoDiagnostic, Result};
@@ -38,7 +37,7 @@ pub struct Render {
 
 #[async_trait::async_trait]
 impl Run for Render {
-    type Output = ExitStatus;
+    type Output = i32;
 
     async fn run(&mut self) -> Result<Self::Output> {
         let mut solver = self.solver.get_solver(&self.options).await?;
@@ -105,7 +104,7 @@ impl Run for Render {
         }
 
         tracing::info!("Render completed: {path:?}");
-        Ok(ExitStatus::default())
+        Ok(0)
     }
 }
 

--- a/crates/spk-cli/cmd-repo/src/cmd_repo.rs
+++ b/crates/spk-cli/cmd-repo/src/cmd_repo.rs
@@ -2,12 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
-#[cfg(unix)]
-use std::os::unix::process::ExitStatusExt;
-#[cfg(windows)]
-use std::os::windows::process::ExitStatusExt;
-use std::process::ExitStatus;
-
 use clap::{Args, Subcommand};
 use miette::{Context, Result};
 use spk_cli_common::{CommandArgs, Run};
@@ -23,7 +17,7 @@ pub struct Repo {
 
 #[async_trait::async_trait]
 impl Run for Repo {
-    type Output = ExitStatus;
+    type Output = i32;
 
     async fn run(&mut self) -> Result<Self::Output> {
         self.command.run().await
@@ -54,7 +48,7 @@ pub enum RepoCommand {
 }
 
 impl RepoCommand {
-    pub async fn run(&mut self) -> Result<ExitStatus> {
+    pub async fn run(&mut self) -> Result<i32> {
         let repo = match &self {
             Self::Upgrade { repo } => repo,
         };
@@ -64,6 +58,6 @@ impl RepoCommand {
         };
         let status = repo.upgrade().await.wrap_err("Upgrade failed")?;
         tracing::info!("{}", status);
-        Ok(ExitStatus::from_raw(1))
+        Ok(1)
     }
 }

--- a/crates/spk-cli/cmd-test/src/cmd_test.rs
+++ b/crates/spk-cli/cmd-test/src/cmd_test.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
-use std::process::ExitStatus;
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -61,7 +60,7 @@ pub struct CmdTest {
 
 #[async_trait::async_trait]
 impl Run for CmdTest {
-    type Output = ExitStatus;
+    type Output = i32;
 
     async fn run(&mut self) -> Result<Self::Output> {
         let options = self.options.get_options()?;
@@ -226,7 +225,7 @@ impl Run for CmdTest {
                 }
             }
         }
-        Ok(ExitStatus::default())
+        Ok(0)
     }
 }
 

--- a/crates/spk-cli/common/src/cli.rs
+++ b/crates/spk-cli/common/src/cli.rs
@@ -4,8 +4,6 @@
 
 //! Main entry points and utilities for command line interface and interaction.
 
-use std::process::ExitStatus;
-
 use miette::Result;
 
 /// Trait all cli commands must implement to be runnable.
@@ -14,8 +12,8 @@ pub trait Run {
     /// The return value of the command.
     ///
     /// A command may return rich information, but the type must be
-    /// able to convert itself into an `ExitStatus`.
-    type Output: Into<ExitStatus>;
+    /// able to convert itself into an `i32`.
+    type Output: Into<i32>;
 
     async fn run(&mut self) -> Result<Self::Output>;
 }

--- a/crates/spk-cli/group1/src/cmd_bake.rs
+++ b/crates/spk-cli/group1/src/cmd_bake.rs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
-use std::process::ExitStatus;
-
 use clap::Args;
 use futures::TryFutureExt;
 use miette::IntoDiagnostic;
@@ -92,7 +90,7 @@ const UNKNOWN_COMPONENT: &str = "";
 
 #[async_trait::async_trait]
 impl Run for Bake {
-    type Output = ExitStatus;
+    type Output = i32;
 
     async fn run(&mut self) -> miette::Result<Self::Output> {
         // Get the layer data from either the active runtime, or the
@@ -136,7 +134,7 @@ impl Run for Bake {
             }
         };
         println!("{data}");
-        Ok(ExitStatus::default())
+        Ok(0)
     }
 }
 

--- a/crates/spk-cli/group1/src/cmd_completion.rs
+++ b/crates/spk-cli/group1/src/cmd_completion.rs
@@ -5,7 +5,6 @@
 //! Generate shell completions for "spk"
 
 use std::io::Write;
-use std::process::ExitStatus;
 
 use clap::{value_parser, Command, Parser};
 use clap_complete;
@@ -23,12 +22,12 @@ pub struct Completion {
 }
 
 impl Completion {
-    pub fn run(&self, mut cmd: Command) -> Result<ExitStatus> {
+    pub fn run(&self, mut cmd: Command) -> Result<i32> {
         let mut buf = vec![];
         clap_complete::generate(self.shell, &mut cmd, "spk", &mut buf);
         std::io::stdout().write_all(&buf).unwrap_or(());
 
-        Ok(ExitStatus::default())
+        Ok(0)
     }
 }
 

--- a/crates/spk-cli/group1/src/cmd_deprecate_test.rs
+++ b/crates/spk-cli/group1/src/cmd_deprecate_test.rs
@@ -33,7 +33,7 @@ async fn test_deprecate_without_prompt() {
     let result = change_deprecation_state(ChangeAction::Deprecate, &repos, &packages, yes).await;
 
     match result {
-        Ok(r) => assert!(r.success()),
+        Ok(r) => assert_eq!(r, 0),
         Err(e) => {
             // This should not happen
             println!("{e}");

--- a/crates/spk-cli/group1/src/cmd_undeprecate.rs
+++ b/crates/spk-cli/group1/src/cmd_undeprecate.rs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
-use std::process::ExitStatus;
-
 use clap::Args;
 use miette::Result;
 use spk_cli_common::{flags, CommandArgs, Run};
@@ -41,7 +39,7 @@ pub struct Undeprecate {
 /// Undeprecates package builds in a repository.
 #[async_trait::async_trait]
 impl Run for Undeprecate {
-    type Output = ExitStatus;
+    type Output = i32;
 
     async fn run(&mut self) -> Result<Self::Output> {
         change_deprecation_state(

--- a/crates/spk-cli/group1/src/cmd_undeprecate_test.rs
+++ b/crates/spk-cli/group1/src/cmd_undeprecate_test.rs
@@ -33,7 +33,7 @@ async fn test_undeprecate_without_prompt() {
     let result = change_deprecation_state(ChangeAction::Undeprecate, &repos, &packages, yes).await;
 
     match result {
-        Ok(r) => assert!(r.success()),
+        Ok(r) => assert_eq!(r, 0),
         Err(e) => {
             // This should not happen
             println!("{e}");
@@ -71,7 +71,7 @@ async fn test_undeprecate_no_repos() {
     let result = change_deprecation_state(ChangeAction::Undeprecate, &repos, &packages, yes).await;
 
     match result {
-        Ok(r) => assert_eq!(r.code(), Some(1)),
+        Ok(r) => assert_eq!(r, 1),
         Err(e) => {
             // This should not happen
             println!("{e}");
@@ -97,7 +97,7 @@ async fn test_undeprecate_no_version() {
     let result = change_deprecation_state(ChangeAction::Undeprecate, &repos, &packages, yes).await;
 
     match result {
-        Ok(r) => assert_eq!(r.code(), Some(2)),
+        Ok(r) => assert_eq!(r, 2),
         Err(e) => {
             // This should not happen
             println!("{e}");
@@ -123,7 +123,7 @@ async fn test_undeprecate_no_version_but_trailing_slash() {
     let result = change_deprecation_state(ChangeAction::Undeprecate, &repos, &packages, yes).await;
 
     match result {
-        Ok(r) => assert_eq!(r.code(), Some(3)),
+        Ok(r) => assert_eq!(r, 3),
         Err(e) => {
             // This should not happen
             println!("{e}");
@@ -153,7 +153,7 @@ async fn test_undeprecate_with_no_package_found() {
     let result = change_deprecation_state(ChangeAction::Undeprecate, &repos, &packages, yes).await;
 
     match result {
-        Ok(r) => assert_eq!(r.code(), Some(4)),
+        Ok(r) => assert_eq!(r, 4),
         Err(e) => {
             // This should not happen
             println!("{e}");

--- a/crates/spk-cli/group2/src/cmd_ls.rs
+++ b/crates/spk-cli/group2/src/cmd_ls.rs
@@ -4,7 +4,6 @@
 
 use std::collections::BTreeSet;
 use std::fmt::Write;
-use std::process::ExitStatus;
 
 use clap::Args;
 use colored::Colorize;
@@ -78,7 +77,7 @@ pub struct Ls<Output: Default = Console> {
 
 #[async_trait::async_trait]
 impl<T: Output> Run for Ls<T> {
-    type Output = ExitStatus;
+    type Output = i32;
 
     async fn run(&mut self) -> Result<Self::Output> {
         let repos = self.repos.get_repos_for_non_destructive_operation().await?;
@@ -219,7 +218,7 @@ impl<T: Output> Run for Ls<T> {
         for item in results {
             self.output.println(item.to_string());
         }
-        Ok(ExitStatus::default())
+        Ok(0)
     }
 }
 
@@ -237,7 +236,7 @@ impl<T: Output> Ls<T> {
     async fn list_recursively(
         &mut self,
         repos: Vec<(String, storage::RepositoryHandle)>,
-    ) -> Result<ExitStatus> {
+    ) -> Result<i32> {
         let search_term = self
             .package
             .as_ref()
@@ -336,7 +335,7 @@ impl<T: Output> Ls<T> {
                 }
             }
         }
-        Ok(ExitStatus::default())
+        Ok(0)
     }
 
     async fn format_build(&self, spec: &Spec, repo: &storage::RepositoryHandle) -> Result<String> {

--- a/crates/spk-cli/group2/src/cmd_new.rs
+++ b/crates/spk-cli/group2/src/cmd_new.rs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
-use std::process::ExitStatus;
-
 use clap::Args;
 use colored::Colorize;
 use miette::{IntoDiagnostic, Result};
@@ -24,7 +22,7 @@ pub struct New {
 
 #[async_trait::async_trait]
 impl Run for New {
-    type Output = ExitStatus;
+    type Output = i32;
 
     async fn run(&mut self) -> Result<Self::Output> {
         let spec = get_stub(&self.name);
@@ -32,7 +30,7 @@ impl Run for New {
         let spec_file = format!("{}.spk.yaml", self.name);
         std::fs::write(&spec_file, spec).into_diagnostic()?;
         println!("{}: {}", "Created".green(), spec_file);
-        Ok(ExitStatus::default())
+        Ok(0)
     }
 }
 

--- a/crates/spk-cli/group2/src/cmd_num_variants.rs
+++ b/crates/spk-cli/group2/src/cmd_num_variants.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
-use std::process::ExitStatus;
 use std::sync::Arc;
 
 use clap::Args;
@@ -25,7 +24,7 @@ pub struct NumVariants {
 
 #[async_trait::async_trait]
 impl Run for NumVariants {
-    type Output = ExitStatus;
+    type Output = i32;
 
     async fn run(&mut self) -> Result<Self::Output> {
         let options = self.options.get_options()?;
@@ -44,7 +43,7 @@ impl Run for NumVariants {
 
         println!("{}", recipe.default_variants().len());
 
-        Ok(ExitStatus::default())
+        Ok(0)
     }
 }
 

--- a/crates/spk-cli/group2/src/cmd_publish.rs
+++ b/crates/spk-cli/group2/src/cmd_publish.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
-use std::process::ExitStatus;
 use std::sync::Arc;
 
 use clap::Args;
@@ -45,7 +44,7 @@ pub struct Publish {
 
 #[async_trait::async_trait]
 impl Run for Publish {
-    type Output = ExitStatus;
+    type Output = i32;
 
     async fn run(&mut self) -> Result<Self::Output> {
         let (source, target) = tokio::try_join!(
@@ -69,7 +68,7 @@ impl Run for Publish {
         }
 
         tracing::info!("done");
-        Ok(ExitStatus::default())
+        Ok(0)
     }
 }
 

--- a/crates/spk-cli/group2/src/cmd_remove.rs
+++ b/crates/spk-cli/group2/src/cmd_remove.rs
@@ -3,11 +3,6 @@
 // https://github.com/imageworks/spk
 
 use std::io::Write;
-#[cfg(unix)]
-use std::os::unix::process::ExitStatusExt;
-#[cfg(windows)]
-use std::os::windows::process::ExitStatusExt;
-use std::process::ExitStatus;
 
 use clap::Args;
 use colored::Colorize;
@@ -36,7 +31,7 @@ pub struct Remove {
 
 #[async_trait::async_trait]
 impl Run for Remove {
-    type Output = ExitStatus;
+    type Output = i32;
 
     async fn run(&mut self) -> Result<Self::Output> {
         let repos = self.repos.get_repos_for_destructive_operation().await?;
@@ -45,7 +40,7 @@ impl Run for Remove {
                 "{}",
                 "No repositories selected, specify --enable-repo (-r)".yellow()
             );
-            return Ok(ExitStatus::from_raw(1));
+            return Ok(1);
         }
 
         for name in &self.packages {
@@ -65,7 +60,7 @@ impl Run for Remove {
                     "y" | "yes" => {}
                     _ => {
                         println!("Removal cancelled");
-                        return Ok(ExitStatus::from_raw(1));
+                        return Ok(1);
                     }
                 }
             }
@@ -94,7 +89,7 @@ impl Run for Remove {
                 }
             }
         }
-        Ok(ExitStatus::default())
+        Ok(0)
     }
 }
 

--- a/crates/spk-cli/group3/src/cmd_export.rs
+++ b/crates/spk-cli/group3/src/cmd_export.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
-use std::process::ExitStatus;
 use std::sync::Arc;
 
 use clap::{Args, ValueHint};
@@ -39,7 +38,7 @@ pub struct Export {
 
 #[async_trait::async_trait]
 impl Run for Export {
-    type Output = ExitStatus;
+    type Output = i32;
 
     async fn run(&mut self) -> Result<Self::Output> {
         let options = self.options.get_options()?;
@@ -78,7 +77,7 @@ impl Run for Export {
         }
         res?;
         println!("{}: {:?}", "Created".green(), filename);
-        Ok(ExitStatus::default())
+        Ok(0)
     }
 }
 

--- a/crates/spk-cli/group3/src/cmd_import.rs
+++ b/crates/spk-cli/group3/src/cmd_import.rs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
-use std::process::ExitStatus;
-
 use clap::Args;
 use futures::TryStreamExt;
 use miette::{Context, Result};
@@ -27,7 +25,7 @@ pub struct Import {
 
 #[async_trait::async_trait]
 impl Run for Import {
-    type Output = ExitStatus;
+    type Output = i32;
 
     async fn run(&mut self) -> Result<Self::Output> {
         let mut summary = spfs::sync::SyncSummary::default();
@@ -53,7 +51,7 @@ impl Run for Import {
                 .summary();
         }
         tracing::info!("{:#?}", summary);
-        Ok(ExitStatus::default())
+        Ok(0)
     }
 }
 

--- a/crates/spk-cli/group3/src/cmd_import_test.rs
+++ b/crates/spk-cli/group3/src/cmd_import_test.rs
@@ -78,8 +78,5 @@ async fn test_archive_io() {
     }
     .run()
     .await;
-    assert!(
-        matches!(result, Ok(s) if s.success()),
-        "import should not fail"
-    );
+    assert!(matches!(result, Ok(0)), "import should not fail");
 }

--- a/crates/spk-cli/group4/src/cmd_lint.rs
+++ b/crates/spk-cli/group4/src/cmd_lint.rs
@@ -2,12 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
-#[cfg(unix)]
-use std::os::unix::process::ExitStatusExt;
-#[cfg(windows)]
-use std::os::windows::process::ExitStatusExt;
 use std::path::{Path, PathBuf};
-use std::process::ExitStatus;
 
 use clap::Args;
 use colored::Colorize;
@@ -27,7 +22,7 @@ pub struct Lint {
 
 #[async_trait::async_trait]
 impl Run for Lint {
-    type Output = ExitStatus;
+    type Output = i32;
 
     async fn run(&mut self) -> Result<Self::Output> {
         let options = self.options.get_options()?;
@@ -47,7 +42,7 @@ impl Run for Lint {
                 }
             }
         }
-        Ok(ExitStatus::from_raw(out))
+        Ok(out)
     }
 }
 

--- a/crates/spk-cli/group4/src/cmd_search.rs
+++ b/crates/spk-cli/group4/src/cmd_search.rs
@@ -2,12 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
-#[cfg(unix)]
-use std::os::unix::process::ExitStatusExt;
-#[cfg(windows)]
-use std::os::windows::process::ExitStatusExt;
-use std::process::ExitStatus;
-
 use clap::Args;
 use colored::Colorize;
 use miette::Result;
@@ -34,7 +28,7 @@ pub struct Search {
 
 #[async_trait::async_trait]
 impl Run for Search {
-    type Output = ExitStatus;
+    type Output = i32;
 
     async fn run(&mut self) -> Result<Self::Output> {
         let repos = self.repos.get_repos_for_non_destructive_operation().await?;
@@ -111,7 +105,7 @@ impl Run for Search {
                 }
             }
         }
-        Ok(ExitStatus::from_raw(exit))
+        Ok(exit)
     }
 }
 

--- a/crates/spk-cli/group4/src/cmd_version.rs
+++ b/crates/spk-cli/group4/src/cmd_version.rs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
-use std::process::ExitStatus;
-
 use clap::Args;
 use miette::Result;
 use spk_cli_common::{CommandArgs, Run, VERSION};
@@ -14,12 +12,12 @@ pub struct Version {}
 
 #[async_trait::async_trait]
 impl Run for Version {
-    type Output = ExitStatus;
+    type Output = i32;
 
     async fn run(&mut self) -> Result<Self::Output> {
         println!(" spk {VERSION}");
         println!("spfs {}", spfs::VERSION);
-        Ok(ExitStatus::default())
+        Ok(0)
     }
 }
 

--- a/crates/spk-cli/group4/src/cmd_view.rs
+++ b/crates/spk-cli/group4/src/cmd_view.rs
@@ -4,11 +4,6 @@
 
 use std::borrow::Cow;
 use std::collections::BTreeMap;
-#[cfg(unix)]
-use std::os::unix::process::ExitStatusExt;
-#[cfg(windows)]
-use std::os::windows::process::ExitStatusExt;
-use std::process::ExitStatus;
 use std::sync::Arc;
 
 use clap::Args;
@@ -117,7 +112,7 @@ pub struct View {
 
 #[async_trait::async_trait]
 impl Run for View {
-    type Output = ExitStatus;
+    type Output = i32;
 
     async fn run(&mut self) -> Result<Self::Output> {
         if self.variants {
@@ -195,7 +190,7 @@ struct PrintVariant<'a> {
 }
 
 impl View {
-    async fn print_current_env(&self) -> Result<ExitStatus> {
+    async fn print_current_env(&self) -> Result<i32> {
         let solution = current_env().await?;
         let solver = self.solver.get_solver(&self.options).await?;
         println!(
@@ -208,10 +203,10 @@ impl View {
                 )
                 .await?
         );
-        Ok(ExitStatus::default())
+        Ok(0)
     }
 
-    fn print_variants_info(&self, options: &OptionMap) -> Result<ExitStatus> {
+    fn print_variants_info(&self, options: &OptionMap) -> Result<i32> {
         let (_, template) = flags::find_package_template(self.package.as_ref())
             .wrap_err("find package template")?
             .must_be_found();
@@ -243,11 +238,11 @@ impl View {
                 }
             }
         }
-        Ok(ExitStatus::default())
+        Ok(0)
     }
 
     /// Given a filepath inside /spfs, print out the package(s) and spfs entries for it.
-    async fn print_filepath_info(&self, filepath: &str) -> Result<ExitStatus> {
+    async fn print_filepath_info(&self, filepath: &str) -> Result<i32> {
         // First, we need a list of all the providing pathlists that
         // contain this file. Each of them should contain at least a
         // layer and the filepath entry, but might contain other spfs
@@ -272,7 +267,7 @@ impl View {
                     "No active runtime".red()
                 }
             );
-            return Ok(ExitStatus::from_raw(1));
+            return Ok(1);
         }
 
         // The layers need to be pulled out of each pathlist in order
@@ -393,11 +388,11 @@ impl View {
             }
         }
 
-        Ok(ExitStatus::default())
+        Ok(0)
     }
 
     /// Display the contents of a package spec
-    fn print_build_spec(&self, package_spec: Arc<Spec>) -> Result<ExitStatus> {
+    fn print_build_spec(&self, package_spec: Arc<Spec>) -> Result<i32> {
         match &self.format.clone().unwrap_or_default() {
             OutputFormat::Yaml => serde_yaml::to_writer(std::io::stdout(), &*package_spec)
                 .into_diagnostic()
@@ -406,7 +401,7 @@ impl View {
                 .into_diagnostic()
                 .wrap_err("Failed to serialize loaded spec")?,
         }
-        Ok(ExitStatus::default())
+        Ok(0)
     }
 
     /// Display information on the package by looking up its
@@ -420,7 +415,7 @@ impl View {
     /// spk info python/3.7.3/src <-- outputs the build spec
     /// spk info python/3.7.3/F4E632 <-- outputs the build spec
     /// ```
-    async fn print_package_info(&self, package: &String) -> Result<ExitStatus> {
+    async fn print_package_info(&self, package: &String) -> Result<i32> {
         let solver = self.solver.get_solver(&self.options).await?;
         let repos = solver.repositories();
 
@@ -452,7 +447,7 @@ impl View {
             }
 
             tracing::error!("Error: no such package/version/build found: {package}",);
-            return Ok(ExitStatus::from_raw(1));
+            return Ok(1);
         }
 
         // Request is just a package name, e.g.
@@ -481,7 +476,7 @@ impl View {
                                     .wrap_err("Failed to serialize loaded spec")?
                             }
                         }
-                        return Ok(ExitStatus::default());
+                        return Ok(0);
                     }
                     Err(err) => {
                         tracing::debug!("Unable to read recipe from {}: {err}", repo.name());
@@ -535,7 +530,7 @@ impl View {
                 .join("\n")
         );
 
-        Ok(ExitStatus::default())
+        Ok(0)
     }
 
     /// Helper to get all the versions for the given package name in these repo
@@ -561,7 +556,7 @@ impl View {
     /// Original info gathering process using a solver to resolve the
     /// request for package and select the package build in the
     /// solution as the one to display information about.
-    async fn print_package_info_from_solve(&self, package: &String) -> Result<ExitStatus> {
+    async fn print_package_info_from_solve(&self, package: &String) -> Result<i32> {
         let mut solver = self.solver.get_solver(&self.options).await?;
 
         let request = match self
@@ -611,7 +606,7 @@ impl View {
                     }
                 }
 
-                return Ok(ExitStatus::from_raw(1));
+                return Ok(1);
             }
         };
 
@@ -622,6 +617,6 @@ impl View {
         }
 
         tracing::error!("Internal Error: requested package was not in solution");
-        Ok(ExitStatus::from_raw(1))
+        Ok(1)
     }
 }


### PR DESCRIPTION
~~Rather than use i32 directly, allow this type be generic and only require
that it can be converted into an `ExitStatus`. The benefit may not be
clear yet, but this will allow tests to access more detailed information
about what happened after invoking `run()` on a cli tool implementation.~~

~~`ExitStatus` was used here instead of the more obvious choice of `ExitCode`
because `ExitCode` does not expose any method to inspect its value.~~

Edit: I've spent the day editing a bunch of files, first trying to use `ExitCode` instead of `i32` and when that turned out to not be viable, changing to `ExitStatus`, then realizing that wasn't good either.

pr-chain:
- #961
- #962 
- #964