### PR TITLE
Create types to hold build result information

### DIFF
--- a/crates/spk-cli/cmd-build/src/cmd_build.rs
+++ b/crates/spk-cli/cmd-build/src/cmd_build.rs
@@ -70,7 +70,7 @@ impl Run for Build {
             runs.push(Vec::new());
         }
 
-        let mut builds_for_summary = Vec::new();
+        let mut builds_for_summary = spk_cli_common::BuildResult::default();
         for packages in runs {
             let mut make_source = spk_cmd_make_source::cmd_make_source::MakeSource {
                 options: self.options.clone(),
@@ -111,8 +111,8 @@ impl Run for Build {
         }
 
         println!("Completed builds:");
-        for msg in builds_for_summary.iter() {
-            println!("{msg}");
+        for (_, artifact) in builds_for_summary.iter() {
+            println!("   {artifact}");
         }
 
         Ok(0)

--- a/crates/spk-cli/common/src/build_result.rs
+++ b/crates/spk-cli/common/src/build_result.rs
@@ -1,0 +1,55 @@
+// Copyright (c) Sony Pictures Imageworks, et al.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/imageworks/spk
+
+use spk_schema::foundation::format::FormatIdent;
+use spk_schema::{BuildIdent, OptionMap};
+
+/// Details on a single build artifact.
+#[derive(Debug)]
+pub enum BuildArtifact {
+    /// A source build
+    Source(BuildIdent),
+    /// A binary build and its variant index and options
+    Binary(BuildIdent, usize, OptionMap),
+}
+
+impl std::fmt::Display for BuildArtifact {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BuildArtifact::Source(ident) => write!(f, "{}", ident.format_ident()),
+            BuildArtifact::Binary(ident, variant_index, options) => write!(
+                f,
+                "{} variant {variant_index}, {options}",
+                ident.format_ident()
+            ),
+        }
+    }
+}
+
+/// The result(s) of a build operation.
+#[derive(Debug, Default)]
+pub struct BuildResult {
+    /// Each of the builds that were created.
+    ///
+    /// The first element of the tuple describes what the input was, such as
+    /// the filename of a spec file.
+    pub artifacts: Vec<(String, BuildArtifact)>,
+}
+
+impl BuildResult {
+    /// Return if the result is empty.
+    pub fn is_empty(&self) -> bool {
+        self.artifacts.is_empty()
+    }
+
+    /// Iterate over the artifacts.
+    pub fn iter(&self) -> impl Iterator<Item = &(String, BuildArtifact)> {
+        self.artifacts.iter()
+    }
+
+    /// Append a new artifact to the result.
+    pub fn push(&mut self, input: String, output: BuildArtifact) {
+        self.artifacts.push((input, output));
+    }
+}

--- a/crates/spk-cli/common/src/flags.rs
+++ b/crates/spk-cli/common/src/flags.rs
@@ -715,7 +715,7 @@ where
 /// directory, or published version of the requested package, if any.
 ///
 /// This function tries to discover the matching yaml template file
-/// and populate it using the options. If it cannot file a file, it
+/// and populate it using the options. If it cannot find a file, it
 /// will try to find the matching package/version in the repo and use
 /// the recipe published for that.
 ///

--- a/crates/spk-cli/common/src/lib.rs
+++ b/crates/spk-cli/common/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/imageworks/spk
 
+mod build_result;
 mod cli;
 mod env;
 mod error;
@@ -11,6 +12,7 @@ pub mod parsing;
 mod publish;
 pub mod with_version_and_build_set;
 
+pub use build_result::{BuildArtifact, BuildResult};
 pub use cli::{CommandArgs, Run};
 #[cfg(feature = "sentry")]
 pub use env::configure_sentry;


### PR DESCRIPTION
This extends the idea of the build summary to collect the information in a way that it can be utilized by test code, waiting to render it into a string until the information is to be displayed.

The input "filename" is collected too, in case that is useful, since it is possible to provide multiple files to build on the same command line.

pr-chain:
- #961
- #962 
- #964