### PR TITLE
Add rpc config values for timeout and message size

### DIFF
--- a/crates/spfs/src/storage/rpc/mod.rs
+++ b/crates/spfs/src/storage/rpc/mod.rs
@@ -9,4 +9,4 @@ mod payload;
 mod repository;
 mod tag;
 
-pub use repository::{Config, RpcRepository};
+pub use repository::{Config, Params, RpcRepository};


### PR DESCRIPTION
This one is hitting us right now, the latest tonic version started checking message sizes and so we are seeing errors across the board for some of our larger manifests - which are more like 8Mb rather than the new limit of 4Mb.