### PR TITLE
Also check payloads when committing

### DIFF
--- a/crates/spfs/src/commit.rs
+++ b/crates/spfs/src/commit.rs
@@ -252,7 +252,11 @@ where
                 let node = node.into_owned();
                 let fut = async move {
                     let entry = &node.entry;
-                    if self.repo.has_object(entry.object).await {
+                    let (has_object, has_payload) = tokio::join!(
+                        self.repo.has_object(entry.object),
+                        self.repo.has_payload(entry.object),
+                    );
+                    if has_object && has_payload {
                         return Ok(CommitBlobResult::AlreadyExists(node));
                     }
                     let created = if entry.is_symlink() {


### PR DESCRIPTION
This is a small change that seems prudent in ensuring that committed files are guaranteed to be internally consistent even when a repo has been messed with externally (which has happened to us)