### PR TITLE
Version up spk-convert-pip tool to v1.3.1

### DIFF
--- a/packages/spk-convert-pip/spk-convert-pip.spk.yaml
+++ b/packages/spk-convert-pip/spk-convert-pip.spk.yaml
@@ -1,4 +1,4 @@
-pkg: spk-convert-pip/1.3.0
+pkg: spk-convert-pip/1.3.1
 api: v0/package
 build:
   script:


### PR DESCRIPTION
This versions up the `spk-convert-pip` tool to `1.3.1` to seprate the recent generated metadata changes from the previous version. This should have been part of adding those metadata chanegs, but I forgot to update the version number then.