### PR TITLE
Make spfs diff only check sizes on blobs

### DIFF
--- a/crates/spfs/src/tracking/entry.rs
+++ b/crates/spfs/src/tracking/entry.rs
@@ -138,8 +138,14 @@ impl<T, T2> PartialEq<Entry<T2>> for Entry<T> {
             entries,
             user_data: _,
         } = other;
-        if self.kind != *kind || self.mode != *mode || self.size != *size || self.object != *object
-        {
+        if self.kind != *kind || self.mode != *mode || self.object != *object {
+            return false;
+        }
+        // Only compare size for blobs. The size captured for directories can
+        // vary based on the filesystem in use or if fuse is in use, and
+        // a rendered manifest may not have the expected size even if it is
+        // unmodified.
+        if self.kind.is_blob() && self.size != *size {
             return false;
         }
         if self.entries.len() != entries.len() {


### PR DESCRIPTION
The main issue is the size of directories. If a path is committed on one machine with a different filesystem type or with/without fuse, the directory sizes captured into the manifest are platform-dependent, and then rendering that manifest on a different system may cause `spfs diff` to report changes.

One easy way to make this happen is to `spk build` a package while fuse is enabled and then `spk env` the built package with fuse disabled.

```
$ spk env stdfs -- spfs diff
~/spfs/bin [size {0=>6}]
~/spfs/etc [size {1=>18}]
~/spfs/etc/spfs [size {1=>23}]
~/spfs/etc/spfs/startup.d [size {2=>53}]
~/spfs/lib [size {0=>6}]
~/spfs/spk [size {1=>17}]
~/spfs/spk/pkg [size {1=>19}]
~/spfs/spk/pkg/stdfs [size {1=>19}]
~/spfs/spk/pkg/stdfs/1.1.0 [size {1=>22}]
~/spfs/spk/pkg/stdfs/1.1.0/PF6B6TLF [size {5=>77}]
```