### PR TITLE
Partly remove the notion of entry sizes for non-blobs

### DIFF
--- a/crates/spfs-cli/main/src/cmd_ls.rs
+++ b/crates/spfs-cli/main/src/cmd_ls.rs
@@ -166,7 +166,7 @@ impl TotalSize for Entry {
         if self.is_dir() {
             self.entries.values().map(|e| e.total_size()).sum()
         } else {
-            self.size
+            self.size()
         }
     }
 }

--- a/crates/spfs-proto/schema/spfs.fbs
+++ b/crates/spfs-proto/schema/spfs.fbs
@@ -76,6 +76,7 @@ table Entry {
     kind:EntryKind;
     object:Digest (required);
     mode:uint32;
+    // Size should only be present for blob entries
     size:uint64;
     name:string (required);
 }

--- a/crates/spfs/src/commit.rs
+++ b/crates/spfs/src/commit.rs
@@ -395,7 +395,7 @@ impl tracking::ComputeManifestReporter for ConsoleCommitReporter {
         bars.entries.inc(1);
         if entry.kind.is_blob() {
             bars.blobs.inc_length(1);
-            bars.bytes.inc_length(entry.size);
+            bars.bytes.inc_length(entry.size());
         }
     }
 }
@@ -403,8 +403,13 @@ impl tracking::ComputeManifestReporter for ConsoleCommitReporter {
 impl CommitReporter for ConsoleCommitReporter {
     fn committed_blob(&self, result: &CommitBlobResult) {
         let bars = self.get_bars();
-        bars.bytes.inc(result.node().entry.size);
-        bars.blobs.inc(1);
+        if result.node().entry.kind.is_blob() {
+            bars.bytes.inc(result.node().entry.size());
+            bars.blobs.inc(1);
+        } else {
+            debug_assert!(false, "committed_blob called with non-blob entry");
+            bars.blobs.inc(1);
+        }
     }
 }
 

--- a/crates/spfs/src/graph/entry_test.rs
+++ b/crates/spfs/src/graph/entry_test.rs
@@ -12,7 +12,7 @@ use crate::tracking::{self, EntryKind};
 
 #[rstest(entry, digest,
     case(
-        EntryBuf::build(
+        EntryBuf::build_with_legacy_size(
             "testcase",
             EntryKind::Tree,
             0o40755,
@@ -24,9 +24,8 @@ use crate::tracking::{self, EntryKind};
     case(
         EntryBuf::build(
             "swig_full_names.xsl",
-            EntryKind::Blob,
+            EntryKind::Blob(3293),
             0o100644,
-            3293,
             &"ZD25L3AN5E3LTZ6MDQOIZUV6KRV5Y4SSXRE4YMYZJJ3PXCQ3FMQA====".parse().unwrap(),
         ),
         "GP7DYE22DYLH3I5MB33PW5Z3AZXZIBGOND7MX65KECBMHVMXBUHQ====".parse().unwrap(),
@@ -46,15 +45,13 @@ fn test_entry_encoding_compat(entry: EntryBuf, digest: encoding::Digest) {
 fn test_entry_blobs_compare_name() {
     let a = EntryBuf::build(
         "a",
-        tracking::EntryKind::Blob,
-        0,
+        tracking::EntryKind::Blob(0),
         0,
         &encoding::EMPTY_DIGEST.into(),
     );
     let b = EntryBuf::build(
         "b",
-        tracking::EntryKind::Blob,
-        0,
+        tracking::EntryKind::Blob(0),
         0,
         &encoding::EMPTY_DIGEST.into(),
     );
@@ -68,13 +65,11 @@ fn test_entry_trees_compare_name() {
         "a",
         tracking::EntryKind::Tree,
         0,
-        0,
         &encoding::EMPTY_DIGEST.into(),
     );
     let b = EntryBuf::build(
         "b",
         tracking::EntryKind::Tree,
-        0,
         0,
         &encoding::EMPTY_DIGEST.into(),
     );
@@ -88,13 +83,11 @@ fn test_entry_mask_compare_name() {
         "a",
         tracking::EntryKind::Mask,
         0,
-        0,
         &encoding::EMPTY_DIGEST.into(),
     );
     let b = EntryBuf::build(
         "b",
         tracking::EntryKind::Mask,
-        0,
         0,
         &encoding::EMPTY_DIGEST.into(),
     );
@@ -106,15 +99,13 @@ fn test_entry_mask_compare_name() {
 fn test_entry_compare_kind() {
     let blob = EntryBuf::build(
         "a",
-        tracking::EntryKind::Blob,
-        0,
+        tracking::EntryKind::Blob(0),
         0,
         &encoding::EMPTY_DIGEST.into(),
     );
     let tree = EntryBuf::build(
         "b",
         tracking::EntryKind::Tree,
-        0,
         0,
         &encoding::EMPTY_DIGEST.into(),
     );
@@ -126,15 +117,13 @@ fn test_entry_compare_kind() {
 fn test_entry_compare() {
     let root_file = EntryBuf::build(
         "file",
-        tracking::EntryKind::Blob,
-        0,
+        tracking::EntryKind::Blob(0),
         0,
         &encoding::NULL_DIGEST.into(),
     );
     let root_dir = EntryBuf::build(
         "xdir",
         tracking::EntryKind::Tree,
-        0,
         0,
         &encoding::NULL_DIGEST.into(),
     );

--- a/crates/spfs/src/graph/manifest.rs
+++ b/crates/spfs/src/graph/manifest.rs
@@ -92,10 +92,10 @@ impl Manifest {
                 let mut new_entry = tracking::Entry {
                     kind: entry.kind(),
                     mode: entry.mode(),
-                    size: entry.size(),
                     entries: Default::default(),
                     object: *entry.object(),
                     user_data: (),
+                    legacy_size: entry.size_for_legacy_encode(),
                 };
                 if entry.kind().is_tree() {
                     new_entry.object = encoding::NULL_DIGEST.into();
@@ -275,7 +275,7 @@ impl ManifestBuilder {
                         node.path.as_str(),
                         node.entry.kind,
                         node.entry.mode,
-                        node.entry.size,
+                        node.entry.size_for_legacy_encode(),
                         &sub_root_digest,
                     )
                 }

--- a/crates/spfs/src/graph/object.rs
+++ b/crates/spfs/src/graph/object.rs
@@ -168,7 +168,7 @@ impl Object {
                     }
                     Enum::Manifest(object) => {
                         for node in object.to_tracking_manifest().walk_abs("/spfs") {
-                            total_size += node.entry.size
+                            total_size += node.entry.size()
                         }
                     }
                     Enum::Blob(object) => total_size += object.size(),

--- a/crates/spfs/src/graph/tree.rs
+++ b/crates/spfs/src/graph/tree.rs
@@ -114,7 +114,7 @@ impl TreeBuf {
                             kind: entry.kind().into(),
                             object: Some(entry.object()),
                             mode: entry.mode(),
-                            size_: entry.size(),
+                            size_: entry.size_for_legacy_encode(),
                             name: Some(name),
                         },
                     )

--- a/crates/spfs/src/graph/tree_test.rs
+++ b/crates/spfs/src/graph/tree_test.rs
@@ -14,7 +14,7 @@ use crate::tracking::EntryKind;
 #[rstest]
 #[case(
     TreeBuf::build(vec![
-        EntryBuf::build(
+        EntryBuf::build_with_legacy_size(
             "pkg",
             EntryKind::Tree,
             0o40755,
@@ -28,19 +28,17 @@ use crate::tracking::EntryKind;
     TreeBuf::build(vec![
         EntryBuf::build(
             ".helmignore",
-            EntryKind::Blob,
+            EntryKind::Blob(342),
             0o100644,
-            342,
             &"NJDVDBWMXKU2BJG6L2LKLS3N3T47VUGXNPBY4BCHBLEEIRNSDILA====".parse().unwrap(),
         ),
         EntryBuf::build(
             "Chart.yaml",
-            EntryKind::Blob,
+            EntryKind::Blob(911),
             0o100644,
-            911,
             &"ULAX2BMLX3WKVI7YKRQLJEQDEWJRSDPCFPZPGBJCIQZJ4FIVZIKA====".parse().unwrap(),
         ),
-        EntryBuf::build(
+        EntryBuf::build_with_legacy_size(
             "templates",
             EntryKind::Tree,
             0o40755,
@@ -49,9 +47,8 @@ use crate::tracking::EntryKind;
         ),
         EntryBuf::build(
             "values.yaml",
-            EntryKind::Blob,
+            EntryKind::Blob(1699),
             0o100644,
-            1699,
             &"IZFXS6UQJTHYBVYK3KYPPZC3FYX6NL3L3MWXAJUULAJMFTGZPODQ====".parse().unwrap(),
         ),
     ]),

--- a/crates/spfs/src/io.rs
+++ b/crates/spfs/src/io.rs
@@ -87,8 +87,8 @@ pub fn format_diffs<'a, U1: 'a, U2: 'a>(
             if a.object != b.object {
                 abouts.push("content".to_string());
             }
-            if a.size != b.size {
-                abouts.push(format!("size {{{}=>{}}}", a.size, b.size));
+            if a.size() != b.size() {
+                abouts.push(format!("size {{{}=>{}}}", a.size(), b.size()));
             }
         }
         let about = if !abouts.is_empty() {
@@ -188,7 +188,7 @@ pub async fn pretty_print_filepath(
                     unix_mode::to_string(entry.mode),
                     entry.kind.to_string().green(),
                     format_digest(entry.object, digest_format.clone()).await?,
-                    format_size(entry.size),
+                    format_size(entry.size()),
                 );
             }
         }

--- a/crates/spfs/src/proto/conversions.rs
+++ b/crates/spfs/src/proto/conversions.rs
@@ -377,7 +377,7 @@ impl<'buf> From<&graph::Entry<'buf>> for super::Entry {
     fn from(source: &graph::Entry) -> Self {
         let kind = match source.kind() {
             tracking::EntryKind::Tree => super::EntryKind::Tree as i32,
-            tracking::EntryKind::Blob => super::EntryKind::Blob as i32,
+            tracking::EntryKind::Blob(_) => super::EntryKind::Blob as i32,
             tracking::EntryKind::Mask => super::EntryKind::Mask as i32,
         };
         Self {

--- a/crates/spfs/src/storage/fs/renderer_unix.rs
+++ b/crates/spfs/src/storage/fs/renderer_unix.rs
@@ -502,7 +502,7 @@ where
                             res.map(|_| None).map_err(|err| err.wrap(format!("render_into_dir '{}'", entry.name())))
                         }
                         tracking::EntryKind::Mask => Ok(None),
-                        tracking::EntryKind::Blob => {
+                        tracking::EntryKind::Blob(_) => {
                             self.render_blob(root_dir_fd, entry, render_type).await.map(Some).map_err(|err| err.wrap(format!("render blob '{}'", entry.name())))
                         }
                     }.map(|render_blob_result_opt| (entry, render_blob_result_opt))

--- a/crates/spk-build/src/build/binary.rs
+++ b/crates/spk-build/src/build/binary.rs
@@ -376,7 +376,7 @@ where
                 continue;
             };
             let entry = environment_filesystem.mknod(&path, entry)?;
-            if !matches!(entry.kind, EntryKind::Blob) {
+            if !matches!(entry.kind, EntryKind::Blob(_)) {
                 continue;
             }
 

--- a/crates/spk-build/src/build/binary_test.rs
+++ b/crates/spk-build/src/build/binary_test.rs
@@ -30,12 +30,12 @@ fn test_split_manifest_permissions() {
         .mknod(
             "bin/runme",
             Entry {
-                kind: EntryKind::Blob,
+                kind: EntryKind::Blob(0),
                 object: EMPTY_DIGEST.into(),
                 mode: 0o555,
-                size: 0,
                 entries: Default::default(),
                 user_data: (),
+                legacy_size: 0,
             },
         )
         .unwrap();

--- a/crates/spk-cli/cmd-du/src/cmd_du.rs
+++ b/crates/spk-cli/cmd-du/src/cmd_du.rs
@@ -521,7 +521,7 @@ impl DiskUsage for Entry {
                     if entry.kind.is_blob() {
                         yield EntryDiskUsage::new(
                                 updated_paths.clone(),
-                                entry.size,
+                                entry.size(),
                                 entry.object,
                             )
                     }


### PR DESCRIPTION
This kind of change is desired to eliminate a problem of `spfs diff` reporting changes to directory sizes.

However, the size value associated with non-blob entries is still needed in order to preserve the same on-disk representation and digest calculated for manifests.