### PR TITLE
RFC: Add way for solver to iterate over versions oldest first

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4234,6 +4234,7 @@ dependencies = [
  "serde_yaml 0.9.27",
  "spk-schema-foundation",
  "thiserror",
+ "variantly",
 ]
 
 [[package]]

--- a/crates/spk-schema/crates/ident/Cargo.toml
+++ b/crates/spk-schema/crates/ident/Cargo.toml
@@ -17,6 +17,7 @@ format_serde_error = { version = "0.3", default_features = false, features = [
     "colored",
 ] }
 itertools = { workspace = true }
+miette = { workspace = true }
 nom = { workspace = true }
 nom-supreme = { workspace = true }
 relative-path = { workspace = true }
@@ -24,7 +25,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_yaml = { workspace = true }
 spk-schema-foundation = { workspace = true }
 thiserror = { workspace = true }
-miette = { workspace = true }
+variantly = { workspace = true }
 
 [dev-dependencies]
 data-encoding = "2.3"

--- a/crates/spk-schema/crates/ident/src/lib.rs
+++ b/crates/spk-schema/crates/ident/src/lib.rs
@@ -32,6 +32,7 @@ pub use request::{
     Request,
     RequestedBy,
     VarRequest,
+    VersionIterationOrder,
 };
 pub use satisfy::Satisfy;
 

--- a/crates/spk-solve/crates/package-iterator/Cargo.toml
+++ b/crates/spk-solve/crates/package-iterator/Cargo.toml
@@ -20,15 +20,15 @@ async-trait = { workspace = true }
 dyn-clone = { workspace = true }
 futures = { workspace = true }
 glob = { workspace = true }
+miette = { workspace = true }
 once_cell = { workspace = true }
 spk-config = { workspace = true }
-spk-solve-solution = { workspace = true }
 spk-schema = { workspace = true }
+spk-solve-solution = { workspace = true }
 spk-storage = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt"] }
 tracing = { workspace = true }
-miette = { workspace = true }
 
 [dev-dependencies]
 itertools = { workspace = true }

--- a/crates/spk-solve/crates/package-iterator/src/package_iterator_test.rs
+++ b/crates/spk-solve/crates/package-iterator/src/package_iterator_test.rs
@@ -14,6 +14,7 @@ use spk_schema::{recipe, spec, BuildIdent, Package, Spec};
 use spk_solve_macros::{make_build, make_repo};
 
 use super::{BuildIterator, PackageIterator, RepositoryPackageIterator, SortedBuildIterator};
+use crate::package_iterator::VersionIterationOrder;
 
 #[rstest]
 #[tokio::test]
@@ -180,7 +181,11 @@ async fn test_solver_sorted_build_iterator_sort_by_option_values() {
     let arc_repo = Arc::new(repo);
     let repos = vec![Arc::clone(&arc_repo)];
 
-    let mut rp_iterator = RepositoryPackageIterator::new(pkg_name.to_owned(), repos.clone());
+    let mut rp_iterator = RepositoryPackageIterator::new(
+        pkg_name.to_owned(),
+        VersionIterationOrder::NewestFirst,
+        repos.clone(),
+    );
     while let Some((_pkg, builds)) = rp_iterator.next().await.unwrap() {
         // This runs the test, by sorting the builds
         let mut iterator = SortedBuildIterator::new(


### PR DESCRIPTION
Here is an idea for a "cheap" way (minimal code change) to let a recipe ask for the minimum version that is compatible rather than the newest version, to address the problems explained in #897.

This doesn't iterate in the exact order that would be desired, but it can acheive the desired results in practice.

The complication comes from the fact that different builds in the same version can have different `compat` rules, plus different versions of a package may have different numbers of version parts. The solver goes version-by-version and then build-by-build, limiting its iteration order flexibility.

Given these builds and compat rules:

- 1.2.1.2/BUILDA x.x.a.b
- 1.2.1.1/BUILDA x.a.b
- 1.2.1.1/BUILDB x.x.a.b
- 1.2.1/BUILDA x.a.b
- 1.2.0.1/BUILDA x.a.b
- 1.2.0/BUILDA x.a.b
- 1.1.0/BUILDA x.a.b

The ideal iteration order might use an algorithm like this:

1. Pick a build from the newest version and find all the versions/builds compatible with it, then iterate on those in oldest-first order.
2. Repeat step 1 skipping anything already visited.

That would produce the following order for the above example:

- 1.2.1.1/BUILDB x.x.a.b -- group 1
- 1.2.1.2/BUILDA x.x.a.b -- group 1
- 1.2.0/BUILDA x.a.b -- group 2
- 1.2.0.1/BUILDA x.a.b -- group 2
- 1.2.1/BUILDA x.a.b -- group 2
- 1.2.1.1/BUILDA x.a.b -- group 2
- 1.1.0/BUILDA x.a.b -- group 3

They are grouped by matching `compat` values, and the version(s) that are all considered equal with each other following that `compat` rule.

As you can see, assuming I applied the algorithm correctly, it would jump between versions as it steps over builds, not exhausting all builds of a single version before trying a different version.

This would be a substantial change to the solver and package iteration.

The naive approach in this PR would visit 1.1.0 first, when in the ideal order it would be visited last.