### PR TITLE
Mark NameOrCurrent as an untagged enum

### DIFF
--- a/crates/spk-schema/src/validation.rs
+++ b/crates/spk-schema/src/validation.rs
@@ -237,6 +237,7 @@ pub enum FileAlteration {
 
 /// Either a package name or a special reference to the current package
 #[derive(Debug, Clone, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[serde(untagged)]
 pub enum NameOrCurrent {
     #[serde(rename = "Self")]
     Current,


### PR DESCRIPTION
This changes the required syntax when defining validation rules to be as documented in the examples.

Expected (works with this change):

    - allow: AlterExistingFiles
      packages:
        - automake

Reality (before this change):

    - allow: AlterExistingFiles
      packages:
        - !Name automake