### PR TITLE
Add test for graph::Manifest conversion from tracking::Manifest

### DIFF
--- a/crates/spfs/src/graph/entry_test.rs
+++ b/crates/spfs/src/graph/entry_test.rs
@@ -8,7 +8,7 @@ use rstest::rstest;
 use super::EntryBuf;
 use crate::encoding::{self};
 use crate::fixtures::*;
-use crate::tracking::EntryKind;
+use crate::tracking::{self, EntryKind};
 
 #[rstest(entry, digest,
     case(
@@ -40,4 +40,103 @@ fn test_entry_encoding_compat(entry: EntryBuf, digest: encoding::Digest) {
         actual_digest, digest,
         "expected encoding to match existing result"
     );
+}
+
+#[rstest]
+fn test_entry_blobs_compare_name() {
+    let a = EntryBuf::build(
+        "a",
+        tracking::EntryKind::Blob,
+        0,
+        0,
+        &encoding::EMPTY_DIGEST.into(),
+    );
+    let b = EntryBuf::build(
+        "b",
+        tracking::EntryKind::Blob,
+        0,
+        0,
+        &encoding::EMPTY_DIGEST.into(),
+    );
+    assert!(a.as_entry() < b.as_entry());
+    assert!(b.as_entry() > a.as_entry());
+}
+
+#[rstest]
+fn test_entry_trees_compare_name() {
+    let a = EntryBuf::build(
+        "a",
+        tracking::EntryKind::Tree,
+        0,
+        0,
+        &encoding::EMPTY_DIGEST.into(),
+    );
+    let b = EntryBuf::build(
+        "b",
+        tracking::EntryKind::Tree,
+        0,
+        0,
+        &encoding::EMPTY_DIGEST.into(),
+    );
+    assert!(a.as_entry() < b.as_entry());
+    assert!(b.as_entry() > a.as_entry());
+}
+
+#[rstest]
+fn test_entry_mask_compare_name() {
+    let a = EntryBuf::build(
+        "a",
+        tracking::EntryKind::Mask,
+        0,
+        0,
+        &encoding::EMPTY_DIGEST.into(),
+    );
+    let b = EntryBuf::build(
+        "b",
+        tracking::EntryKind::Mask,
+        0,
+        0,
+        &encoding::EMPTY_DIGEST.into(),
+    );
+    assert!(a.as_entry() < b.as_entry());
+    assert!(b.as_entry() > a.as_entry());
+}
+
+#[rstest]
+fn test_entry_compare_kind() {
+    let blob = EntryBuf::build(
+        "a",
+        tracking::EntryKind::Blob,
+        0,
+        0,
+        &encoding::EMPTY_DIGEST.into(),
+    );
+    let tree = EntryBuf::build(
+        "b",
+        tracking::EntryKind::Tree,
+        0,
+        0,
+        &encoding::EMPTY_DIGEST.into(),
+    );
+    assert!(tree.as_entry() > blob.as_entry());
+    assert!(blob.as_entry() < tree.as_entry());
+}
+
+#[rstest]
+fn test_entry_compare() {
+    let root_file = EntryBuf::build(
+        "file",
+        tracking::EntryKind::Blob,
+        0,
+        0,
+        &encoding::NULL_DIGEST.into(),
+    );
+    let root_dir = EntryBuf::build(
+        "xdir",
+        tracking::EntryKind::Tree,
+        0,
+        0,
+        &encoding::NULL_DIGEST.into(),
+    );
+    assert!(root_dir.as_entry() > root_file.as_entry());
 }


### PR DESCRIPTION
This adds a test for graph::Manifest conversion from tracking::Manifest to make sure the converted manifest is not missing any entries, by checking it is identical to the original manifest when converted back. 

We encountered a situation with our internal, pre-flatbuffers, build where this was not the case. That bug was patched internally, and we confirmed the problem does not exist in post-flatbuffers changes. But want to add the test that detects it to the test suite.

This also relocates the entry related tests that were in the graph::Manifest test file to the `entry_test.rs` file with the other entry related tests.