### PR TITLE
Add `--no-publish/--no` option to `spk-convert-pip`

### DIFF
--- a/packages/spk-convert-pip/spk-convert-pip
+++ b/packages/spk-convert-pip/spk-convert-pip
@@ -61,7 +61,7 @@ def main() -> int:
         help="Also publish the packages after conversion. Does not ask if you want to publish, assumes yes",
     )
     group.add_argument(
-        "--no-publish", "--no",
+        "--no-publish",
         default=None,
         action="store_true",
         help="Do not publish the packages after conversion. Does not ask if you want to publish, assumes no",


### PR DESCRIPTION
This adds `--no-publish/--no` option to the `spk-convert-pip` script. This allows the user to bypass the "Do you want to also publish these packages? [y/N]: " question, effectively pre-answering it with 'no'.

The `spk-convert-pip` script already has a `--publish` option, which effectively answers 'yes' to the question and goes on to publish the converted packages. But when I was porting python tools from one OS to another, and between one python version and another, I needed a smoother way to convert, but not publish, various versions of python modules. I didn't want to publish each converted version while narrowing down the dependencies for the port, because I knew the latest versions might not play well with other modules.  But answering 'no' manually for each conversion was tedious. I added `--no` to this command to streamline it.
