### PR TITLE
Adds --stop-on-block/--stop option to solver

### DIFF
--- a/crates/spk-cli/common/src/flags.rs
+++ b/crates/spk-cli/common/src/flags.rs
@@ -1082,6 +1082,10 @@ pub struct DecisionFormatterSettings {
     /// Stop the solver the first time it is BLOCKED.
     #[clap(long, alias = "stop")]
     stop_on_block: bool,
+
+    /// Pause the solver each time it is blocked, until the user hits Enter.
+    #[clap(long, alias = "step")]
+    step_on_block: bool,
 }
 
 impl DecisionFormatterSettings {
@@ -1120,6 +1124,7 @@ impl DecisionFormatterSettings {
             .with_solver_to_run(self.solver_to_run.into())
             .with_search_space_size(self.show_search_size)
             .with_stop_on_block(self.stop_on_block)
+            .with_step_on_block(self.step_on_block)
             .with_compare_solvers(self.compare_solvers);
         Ok(builder)
     }


### PR DESCRIPTION
This adds `--stop-on-block/--stop` option to solver. This option stops the solver completely when it reaches the first `BLOCKED` state (step-back). 

This turned out to be useful when working out missing dependencies, e.g. when porting a package between OSes or python versions, or otherwise dealing with lots of dependencies changing. While debugging solves that entered solver hell, I found myself running and interrupting the solve over and over. I would scroll back up the output to the first BLOCKED line and use that to work out what request to change, or what other package needed to be converted or built and published. Having the solver stop when it hit BLOCKED streamlined the process for me.

For example:
```
> spk env mypackage --stop-on-block
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! BLOCKED could not satisfy 'openvdb:all/Binary:10.0.1,Binary:9.0.0' as required by: my-plugins/0.1.56/EIEIO my-something/1.0.5/ABCDEF, openimageio/2.6.0.2/ABCEII
hit BLOCKED state with '--stop-on-block' enabled.
ERROR (link)

  x Solver interrupted: hit BLOCKED state with '--stop-on-block' enabled.
```
It can be combined with all the usual verbosity and report settings to show more context around the point that it BLOCKED. By default,  using `--stop-on-block` does not print the solver report that interrupting the solver with Ctrl-C or a timeout does, but you can use `-t` to see the report as well.