### PR TITLE
Do not clean renders when not supported

### DIFF
--- a/crates/spfs/src/clean.rs
+++ b/crates/spfs/src/clean.rs
@@ -575,9 +575,15 @@ where
         };
         let repo = repo.opened().await?;
 
-        result += self
+        result += match self
             .remove_unvisited_renders_and_proxies_for_storage(None, &repo)
-            .await?;
+            .await
+        {
+            // If the repository is not setup for render storage, then we
+            // quietly ignore this entire process
+            Err(Error::NoRenderStorage(_)) => return Ok(result),
+            res => res?,
+        };
 
         let renders_for_all_users = repo.renders_for_all_users()?;
 


### PR DESCRIPTION
I get an error running the clean operation on fs repos that don't have renders. This is my first stab at resolving it, but I haven't tested very deeply. In any case, this first check feels appropriate