### PR TITLE
Bugfix: implements counting hardlinks for directories in spfs' fuse

### DIFF
--- a/crates/spfs-vfs/src/fuse.rs
+++ b/crates/spfs-vfs/src/fuse.rs
@@ -170,8 +170,9 @@ impl Filesystem {
             entry.size
         };
         let nlink: u32 = if entry.is_dir() {
-            // Directory has 2 hardlinks for . and .. plus one for
-            // each subdirectory. Symlinks do not count.
+            // Directory has 2 hardlinks, one for . and one for the
+            // entry in its parent (..), plus one for each
+            // subdirectory. Symlinks do not count.
             (entry.entries.iter().filter(|(_n, e)| e.is_dir()).count() + 2) as u32
         } else {
             // Everything else just has itself


### PR DESCRIPTION
This implements counting hardlinks for directories in spfs' fuse. The makes the `nlink` values directories valid for external processes that access a spfs fuse-backed filesystem, e.g. perl's File::Find module.

