### PR TITLE
Change any hyphens in SPK_OPT_* env var names

### DIFF
--- a/crates/spk-schema/crates/foundation/src/name/mod.rs
+++ b/crates/spk-schema/crates/foundation/src/name/mod.rs
@@ -12,6 +12,8 @@ pub use error::{Error, Result};
 use miette::Diagnostic;
 use thiserror::Error;
 
+use crate::spec_ops::EnvName;
+
 #[cfg(test)]
 #[path = "./name_test.rs"]
 mod name_test;
@@ -261,6 +263,12 @@ impl OptNameBuf {
         }
 
         unsafe { OptNameBuf::from_string(new_name) }
+    }
+}
+
+impl EnvName for OptNameBuf {
+    fn env_name(&self) -> String {
+        self.0.replace('-', "_")
     }
 }
 

--- a/crates/spk-schema/crates/foundation/src/option_map/mod.rs
+++ b/crates/spk-schema/crates/foundation/src/option_map/mod.rs
@@ -14,6 +14,7 @@ use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 
 use crate::name::{OptName, OptNameBuf, PkgName};
+use crate::spec_ops::EnvName;
 
 mod error;
 mod format;
@@ -186,7 +187,7 @@ impl OptionMap {
     pub fn to_environment(&self) -> HashMap<String, String> {
         let mut out = HashMap::default();
         for (name, value) in self.iter() {
-            let var_name = format!("SPK_OPT_{name}");
+            let var_name = format!("SPK_OPT_{}", name.env_name());
             out.insert(var_name, value.into());
         }
         out


### PR DESCRIPTION
A followup to #793, which did the same kind of change for SPK_PKG_* env var names.