### PR TITLE
Add Version::to_storage_string

### DIFF
--- a/crates/spk-schema/crates/foundation/src/version/mod.rs
+++ b/crates/spk-schema/crates/foundation/src/version/mod.rs
@@ -459,6 +459,34 @@ impl Version {
         }
         !self.parts.iter().any(|x| x > &0)
     }
+
+    /// Like `to_string` but normalize the base version as it would be for its
+    /// spfs tag path.
+    pub fn to_storage_string(&self) -> String {
+        format!(
+            "{}{}{}{}{}",
+            self.parts
+                .iter_for_storage()
+                .map(|p| p.to_string())
+                .join(VERSION_SEP),
+            {
+                if self.pre.is_empty() {
+                    ""
+                } else {
+                    "-"
+                }
+            },
+            self.pre,
+            {
+                if self.post.is_empty() {
+                    ""
+                } else {
+                    "+"
+                }
+            },
+            self.post,
+        )
+    }
 }
 
 impl MetadataPath for Version {


### PR DESCRIPTION
This fills a niche where something wants the normalized version string as would be used for the SPFS tag name, but doesn't want the full tag path.