### PR TITLE
Allow requests for "3.10" to be compat with "3.10.10"

### DIFF
--- a/crates/spk-schema/crates/foundation/src/version/compat.rs
+++ b/crates/spk-schema/crates/foundation/src/version/compat.rs
@@ -395,6 +395,14 @@ impl Compat {
         for (i, rule) in self.parts.iter().enumerate() {
             let a = base.parts.get(i);
             let b = other.parts.get(i);
+
+            if a.is_none() {
+                // Handle case where "3.10" is specified and other is "3.10.10".
+                // Since 3 == 3 and 10 == 10 and no other version parts are
+                // specified, we consider these compatible.
+                return Compatibility::Compatible;
+            }
+
             if rule.0.contains(&CompatRule::None) {
                 match (a, b) {
                     (Some(a), Some(b)) if a != b => {

--- a/crates/spk-schema/src/version_range_test.rs
+++ b/crates/spk-schema/src/version_range_test.rs
@@ -159,6 +159,8 @@ fn test_version_range_is_satisfied_recipe(
 #[case("Binary:1.38.0", spec!({"pkg": "test/1.38.0+r.3/JRSXNRF4", "compat": "x.x.x+ab"}), true)]
 // smaller numbers are not compatible
 #[case("Binary:5.12.2.1", spec!({"pkg": "test/5.12.2/JRSXNRF4", "compat": "x.x.ab"}), false)]
+// asking for "3.10" is expected to allow "3.10.10"
+#[case::under_specified_version_and_x_compat("API:3.10", spec!({"pkg": "test/3.10.10/JRSXNRF4", "compat": "x.x.x"}), true)]
 fn test_version_range_is_satisfied_spec(
     #[case] range: &str,
     #[case] spec: Spec,


### PR DESCRIPTION
Even when "3.10.10" has "x.x.x" compat.

Fixes #1030.