### PR TITLE
Distro compat range

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4342,6 +4342,7 @@ dependencies = [
 name = "spk-schema"
 version = "0.42.0"
 dependencies = [
+ "config",
  "data-encoding",
  "dunce",
  "enum_dispatch",

--- a/crates/spk-config/src/config.rs
+++ b/crates/spk-config/src/config.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/spkenv/spk
 
+use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
 use config::Environment;
@@ -121,9 +122,6 @@ pub struct Cli {
 #[derive(Clone, Default, Debug, Deserialize, Serialize)]
 #[serde(default)]
 pub struct DistroRule {
-    /// The name of the distro to match, e.g., "rocky"
-    pub name: String,
-
     /// The compat rule to set for the distro, e.g., "x.ab"
     pub compat_rule: Option<String>,
 }
@@ -131,8 +129,8 @@ pub struct DistroRule {
 #[derive(Clone, Default, Debug, Deserialize, Serialize)]
 #[serde(default)]
 pub struct HostOptions {
-    /// A list of distro names to recognize and customizations for each.
-    pub distro_rules: Vec<DistroRule>,
+    /// A mapping of distro names to recognize and customizations for each.
+    pub distro_rules: HashMap<String, DistroRule>,
 }
 
 /// Configuration values for spk.

--- a/crates/spk-config/src/config.rs
+++ b/crates/spk-config/src/config.rs
@@ -118,6 +118,23 @@ pub struct Cli {
     pub ls: Ls,
 }
 
+#[derive(Clone, Default, Debug, Deserialize, Serialize)]
+#[serde(default)]
+pub struct DistroRule {
+    /// The name of the distro to match, e.g., "rocky"
+    pub name: String,
+
+    /// The compat rule to set for the distro, e.g., "x.ab"
+    pub compat_rule: Option<String>,
+}
+
+#[derive(Clone, Default, Debug, Deserialize, Serialize)]
+#[serde(default)]
+pub struct HostOptions {
+    /// A list of distro names to recognize and customizations for each.
+    pub distro_rules: Vec<DistroRule>,
+}
+
 /// Configuration values for spk.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(default)]
@@ -130,6 +147,7 @@ pub struct Config {
     pub statsd: Statsd,
     pub metadata: Metadata,
     pub cli: Cli,
+    pub host_options: HostOptions,
 }
 
 impl Config {

--- a/crates/spk-schema/Cargo.toml
+++ b/crates/spk-schema/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 migration-to-components = ["spk-schema-foundation/migration-to-components"]
 
 [dependencies]
+config = { workspace = true }
 data-encoding = "2.3"
 dunce = { workspace = true }
 enum_dispatch = "0.3.8"

--- a/crates/spk-schema/src/build_spec.rs
+++ b/crates/spk-schema/src/build_spec.rs
@@ -93,11 +93,7 @@ impl AutoHostVars {
                             // Look for any configured compat rules for the
                             // distro
                             let config = get_config()?;
-                            for rule in config.host_options.distro_rules.iter() {
-                                if rule.name != distro_name {
-                                    continue;
-                                }
-
+                            if let Some(rule) = config.host_options.distro_rules.get(&distro_name) {
                                 if let Some(compat_rule) = &rule.compat_rule {
                                     var_opt.compat = Some(
                                         Compat::from_str(compat_rule).map_err(|err| {

--- a/docs/admin/config.md
+++ b/docs/admin/config.md
@@ -253,4 +253,12 @@ environment = ""
 [cli.ls]
 # Use all current host's host options by default for filtering in ls
 host_filtering = false
+
+# SPK supports some customization of the distro host options.
+[[host_options.distro_rules]]
+# The name of the distro that the customizations apply to.
+name = "rocky"
+# Set a default compat rule for this distro. For example, on Rocky Linux
+# packages built on 9.3 would be usable on 9.4.
+compat_rule = "x.ab"
 ```

--- a/docs/admin/config.md
+++ b/docs/admin/config.md
@@ -255,9 +255,7 @@ environment = ""
 host_filtering = false
 
 # SPK supports some customization of the distro host options.
-[[host_options.distro_rules]]
-# The name of the distro that the customizations apply to.
-name = "rocky"
+[host_options.distro_rules.rocky]
 # Set a default compat rule for this distro. For example, on Rocky Linux
 # packages built on 9.3 would be usable on 9.4.
 compat_rule = "x.ab"


### PR DESCRIPTION
At SPI we recently started building package for Rocky while on Rocky 9.3, and on Rocky the host options detect the version as `"9.3"`, whereas on CentOS the version was detected as just `"7"`. Now we are starting to build systems with Rocky 9.4, and since that generates a host option of `"rocky": "9.4"` the solver is unwilling to pick up any packages that were built on Rocky 9.3.

This PR explores one idea for solving this problem. It introduces the ability to set a `compat` value on a var option, as in:

```yaml
build:
  options:
    - var: distro
    - var: rocky
      compat: "x.b"
```

~~Note these vars would normally be auto-generated for a recipe and in this PR it auto-generates the "rocky" var with the compat enabled based on a hard coded list of distro names.~~

The logic for handling this is when checking for compatibility, it first compares the values as raw strings like usual, so like before it would detect this inequality:

    "9.3" != "9.4"

But now before returning incompatible for this case, if the option has a compat value, then the two sides are treated as version numbers and checked against the defined compat rule.

Here is an example of what the incompatibility message looks like in the situation where the versions are not considered compatible:
![image](https://github.com/imageworks/spk/assets/3501/acf853b0-e99a-42ba-a4a0-db147bdea8f3)

This gets us part of the way to what we want. If we build a package on Rocky 9.3, we can use it on Rocky 9.4. But with the current semantics, if we build a package on Rocky 9.4, we _can't_ use it on Rocky 9.3. To fully get the behavior we want (since rhel-based OSes promise up-and-down binary compatibility) then perhaps `Compat` needs to be extended to have a way to express, like a capital letter could indicate bidirectional compatibility: `x.B`.

We'd also need a way to configure the compat rules so it isn't hard coded into the source code.

Being able to use a `compat` value and this new behavior on any var option seems like it could be useful feature. It adds a way for package authors to describe extra dimensions of compatibility ranges. But I don't have any particular use cases in mind besides this distro one.

Edit: the hard-coded compat rules have been replaced by a new spk config section.