### PR TITLE
Add `--step-on-decision` to the solver

### DIFF
--- a/crates/spk-cli/common/src/flags.rs
+++ b/crates/spk-cli/common/src/flags.rs
@@ -1086,6 +1086,10 @@ pub struct DecisionFormatterSettings {
     /// Pause the solver each time it is blocked, until the user hits Enter.
     #[clap(long, alias = "step")]
     step_on_block: bool,
+
+    /// Pause the solver each time it makes a decision, until the user hits Enter.
+    #[clap(long, alias = "decision")]
+    step_on_decision: bool,
 }
 
 impl DecisionFormatterSettings {
@@ -1125,6 +1129,7 @@ impl DecisionFormatterSettings {
             .with_search_space_size(self.show_search_size)
             .with_stop_on_block(self.stop_on_block)
             .with_step_on_block(self.step_on_block)
+            .with_step_on_decision(self.step_on_decision)
             .with_compare_solvers(self.compare_solvers);
         Ok(builder)
     }


### PR DESCRIPTION
This adds `--step-on-decision` option to the solver. This pauses the solver after each decision is made. The solver will start up again when the user hits Enter.  This an extension to the `--step-on-block` mechanism but waiting after any decision the solver makes. This allows the solver to be stepped through. On it's own, this isn't that useful but it is a precursor to being able to inspect the current state the solver has reached (see related PR: https://github.com/imageworks/spk/pull/1039).
