### PR TITLE
Adds basic iteractive menu for inspecting current state of solver when stepping

### DIFF
--- a/crates/spk-solve/src/io.rs
+++ b/crates/spk-solve/src/io.rs
@@ -226,12 +226,9 @@ where
                 //     )
                 //     .await?
                 tracing::info!(
-                    "{}",
-                    format!(
-                        "{}{}",
-                        self.settings.heading_prefix,
-                        solution.format_solution(self.settings.verbosity)
-                    )
+                    "{}{}",
+                    self.settings.heading_prefix,
+                    solution.format_solution(self.settings.verbosity)
                 );
             }
         }

--- a/crates/spk-solve/src/io.rs
+++ b/crates/spk-solve/src/io.rs
@@ -316,8 +316,7 @@ where
         // or disable when this menu is active
         if let Some(state) = current_state {
             // Simplistic menu for now
-            let mut done = false;
-            while !done {
+            loop {
                 // Show a compressed version of the menu
                 print!(
                     "{} Select one of [r,u,v,o,s,a,c,?,C-c]> ",
@@ -341,7 +340,7 @@ where
                     's' | 'a' => self.show_state(state),
                     'c' => {
                         self.remove_step_and_stop_setting();
-                        done = true;
+                        break;
                     }
                     // TODO: could look at adding other things in future:
                     // - show dep graph image based on current resolved/unresolved
@@ -349,7 +348,7 @@ where
                     // - launch spk env based on current resolved packages
                     // - rewind the solve
                     // - save/restore point for the solve, for use in tests
-                    _ => done = true,
+                    _ => break,
                 }
             }
         }


### PR DESCRIPTION
This adds a very basic interactive menu for inspecting current state the solver has reached, when using `--step/stop-on-block` or `--step-on-decision`. 

It adds methods for showing the current state's resolved packages, unresolved requests, variable requests, options, and showing all of the those when stepping or stopping. I imagine more could be added later, e.g. we have a request to launch an environment of the currently resolved packages. I have a plan to add showing graphs of the current dependencies to this menu (PR: TBD).

The menu doesn't use any other crates and appears among the normal solver output, but doesn't use the output setting the solver has. This was partly for initial implementation ease, partly to keep the existing output intact, and partly because its interactive. 

Questions:
- Should it use the solver's output setting? 
- Should it use a menu crate, if so do we have a preference? I tryed out `console_menu` but didn't like it clearing the screen and jumping back and forth between the existing solver output.

Gotchas uncovered:
- Waiting long enough on the menu (individually or in total) will trip the solver's verbosity timeout and it will increase the verbosity between steps
- Waiting taking too long on straight-forward solves may mean the background solver (spk runs 2 solvers in parallel by default) fiinishes with a solution so your next "step" actually skips to the end with the solution. The can be disconcerting when you thought you were stepping through resolve one, then resolve two, and it jumps to "all done" even though you know you had 50+ packages still to resolve.

Example output (updated with single line menu):
```
> spk explain python-pytest --step-on-decision --solver-to-run cli
> RESOLVE python-pytest/8.1.1/OK7CBJKZ  (requested by command line)
Pausing after decision. Select one of [r,u,v,o,s,a,c,?,C-c]> ?
Pausing after decision. Enter a letter for an action:
 ? - Print help (these details)
 r - Show resolved packages
 u - Show unresolved requests
 v - Show var requests
 o - Show options
 s, a - Show state [all of the above]
 c - Run solver to completion, removes step/stop
 Ctrl-c - Interrupt this program
 any other - Continue solving
Pausing after decision. Select one of [r,u,v,o,s,a,c,?,C-c]> r
 INFO Nothing Installed
Pausing after decision. Select one of [r,u,v,o,s,a,c,?,C-c]> u
 INFO Unresolved Requests:
  python-pytest:all/*
Number of Unresolved Requests: 1
Pausing after decision. Select one of [r,u,v,o,s,a,c,?,C-c]>  (just hit enter)
>> RESOLVE python/3.9.7+r.1/QOEDONJ7  (requested by python-pytest/8.1.1/OK7CBJKZ)
Pausing after decision. Select one of [r,u,v,o,s,a,c,?,C-c]> r
 INFO Installed Packages:
  origin/python-pytest:{build,run}/=8.1.1/OK7CBJKZ (required by command line) 
 Number of Packages: 1
Pausing after decision. Select one of [r,u,v,o,s,a,c,?,C-c]> u
 INFO Unresolved Requests:
  python-packaging:all/*
  python-pluggy:all/<2.0.0,>=1.4.0
  python-iniconfig:all/*
  python-tomli:all/>=1.0.0
  python-exceptiongroup:all/>=1.0.0-rc.8
  python:all/3.9.0
Number of Unresolved Requests: 6
Pausing after decision. Select one of [r,u,v,o,s,a,c,?,C-c]> v
 INFO Var Requests:
  arch: x86_64
  centos: 7
  distro: centos
  os: linux
  python.abi: cp39
Number of Var Requests: 5
Pausing after decision. Select one of [r,u,v,o,s,a,c,?,C-c]> o
 INFO Options:
  {arch=x86_64
  centos=7
  distro=centos
  os=linux
  python-pytest=~8.1.1
  python-pytest.arch=x86_64
  python-pytest.centos=7
  python-pytest.distro=centos
  python-pytest.os=linux
  python-pytest.python=~3.9.7
  python-pytest.python-pip=~22.0.4
  python.abi=cp39}
Number of Options: 12
Pausing after decision. Select one of [r,u,v,o,s,a,c,?,C-c]> s
 INFO Installed Packages:
  origin/python-pytest:{build,run}/=8.1.1/OK7CBJKZ (required by command line) 
 Number of Packages: 1
 INFO Unresolved Requests:
  python-packaging:all/*
  python-pluggy:all/<2.0.0,>=1.4.0
  python-iniconfig:all/*
  python-tomli:all/>=1.0.0
  python-exceptiongroup:all/>=1.0.0-rc.8
  python:all/3.9.0
Number of Unresolved Requests: 6
 INFO Var Requests:
  arch: x86_64
  centos: 7
  distro: centos
  os: linux
  python.abi: cp39
Number of Var Requests: 5
 INFO Options:
  {arch=x86_64
  centos=7
  distro=centos
  os=linux
  python-pytest=~8.1.1
  python-pytest.arch=x86_64
  python-pytest.centos=7
  python-pytest.distro=centos
  python-pytest.os=linux
  python-pytest.python=~3.9.7
  python-pytest.python-pip=~22.0.4
  python.abi=cp39}
Number of Options: 12
Pausing after decision. Select one of [r,u,v,o,s,a,c,?,C-c]>  ^C
Solve is taking too long, > 30 secs. Increasing verbosity level to 2
Solver interrupted by user ...
...
```
