### PR TITLE
Use a single http client and pool in rpc repo

### DIFF
--- a/crates/spfs/src/storage/rpc/payload.rs
+++ b/crates/spfs/src/storage/rpc/payload.rs
@@ -51,7 +51,6 @@ impl storage::PayloadStorage for super::RpcRepository {
             .await?
             .into_inner()
             .to_result()?;
-        let client = hyper::Client::new();
         let compressed_reader = async_compression::tokio::bufread::BzEncoder::new(reader);
         let stream = tokio_util::codec::FramedRead::new(
             compressed_reader,
@@ -65,7 +64,7 @@ impl storage::PayloadStorage for super::RpcRepository {
             .map_err(|err| {
                 crate::Error::String(format!("Failed to build upload request: {err:?}"))
             })?;
-        let resp = client.request(request).await.map_err(|err| {
+        let resp = self.http_client.request(request).await.map_err(|err| {
             crate::Error::String(format!("Failed to send upload request: {err:?}"))
         })?;
         if !resp.status().is_success() {
@@ -99,7 +98,6 @@ impl storage::PayloadStorage for super::RpcRepository {
             .await?
             .into_inner()
             .to_result()?;
-        let client = hyper::Client::new();
         let url_str = option
             .locations
             .first()
@@ -113,7 +111,7 @@ impl storage::PayloadStorage for super::RpcRepository {
             .map_err(|err| {
                 crate::Error::String(format!("Failed to build download request: {err:?}"))
             })?;
-        let resp = client.request(req).await.map_err(|err| {
+        let resp = self.http_client.request(req).await.map_err(|err| {
             crate::Error::String(format!("Failed to send download request: {err:?}"))
         })?;
         if !resp.status().is_success() {

--- a/crates/spfs/src/storage/rpc/repository.rs
+++ b/crates/spfs/src/storage/rpc/repository.rs
@@ -73,13 +73,14 @@ impl ToAddress for Config {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct RpcRepository {
     address: url::Url,
     pub(super) repo_client: RepositoryClient<tonic::transport::Channel>,
     pub(super) tag_client: TagServiceClient<tonic::transport::Channel>,
     pub(super) db_client: DatabaseServiceClient<tonic::transport::Channel>,
     pub(super) payload_client: PayloadServiceClient<tonic::transport::Channel>,
+    pub(super) http_client: hyper::Client<hyper::client::HttpConnector, hyper::Body>,
     /// the namespace to use for tag resolution. If set, then this is treated
     /// as "chroot" of the real tag root.
     tag_namespace: Option<TagNamespaceBuf>,
@@ -139,6 +140,7 @@ impl RpcRepository {
             tag_client,
             db_client,
             payload_client,
+            http_client: hyper::Client::new(),
             tag_namespace: config.params.tag_namespace,
         })
     }


### PR DESCRIPTION
This setup was simply inefficient and was not able to reuse connections at all. This is especially impactful for heavy sync operations.