### PR TITLE
Fix poor performance of to_tracking_manifest

### DIFF
--- a/crates/spfs/src/graph/mod.rs
+++ b/crates/spfs/src/graph/mod.rs
@@ -35,7 +35,7 @@ pub use database::{
 pub use entry::Entry;
 pub use kind::{HasKind, Kind, ObjectKind};
 pub use layer::{KeyAnnotationValuePair, Layer};
-pub use manifest::Manifest;
+pub use manifest::{Manifest, ManifestTreeCache};
 pub use object::{FlatObject, Object, ObjectProto};
 pub use platform::Platform;
 pub use stack::Stack;

--- a/cspell.json
+++ b/cspell.json
@@ -745,6 +745,7 @@
     "undeprecated",
     "undeprecates",
     "undeprecating",
+    "undigestible",
     "uninstallation",
     "unistd",
     "unloadable",


### PR DESCRIPTION
This method had something like O(n^3) complexity because it would for
every tree in a manifest iterate over every tree in a manifest and
calculate the digest for every tree in the manifest (modulo short
circuiting).

`Manifest::get_tree` is the culprit and an alternative technique of
caching the mapping of digest to tree was added. Both uses of this
method have been updated but this method was left in place with a new
warning. It would be cheaper to call `get_tree` in a contrived case
where the cache is only accessed once and not reused for multiple
lookups.

Fixes #1043.