### PR TITLE
Fix spfs-fuse task panicking on mask entry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3725,6 +3725,7 @@ dependencies = [
  "prost",
  "protobuf-src",
  "spfs",
+ "thiserror",
  "tokio",
  "tonic",
  "tonic-build",

--- a/crates/spfs-vfs/Cargo.toml
+++ b/crates/spfs-vfs/Cargo.toml
@@ -35,6 +35,7 @@ libc = "0.2"
 miette = { workspace = true, features = ["fancy"] }
 prost = { workspace = true, optional = true }
 spfs = { workspace = true }
+thiserror = { workspace = true }
 tokio = { version = "1.20", features = ["rt", "rt-multi-thread"] }
 tracing = { workspace = true }
 tonic = { workspace = true, optional = true }

--- a/crates/spfs-vfs/src/error.rs
+++ b/crates/spfs-vfs/src/error.rs
@@ -1,0 +1,13 @@
+// Copyright (c) Sony Pictures Imageworks, et al.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/imageworks/spk
+
+use thiserror::Error;
+
+/// Errors specific to fuse operations.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// An operation was attempted on a mask entry.
+    #[error("Entry is a mask")]
+    EntryIsMask,
+}

--- a/crates/spfs-vfs/src/lib.rs
+++ b/crates/spfs-vfs/src/lib.rs
@@ -9,6 +9,9 @@
 
 #![deny(missing_docs)]
 
+mod error;
+pub use error::Error;
+
 #[cfg(all(unix, feature = "fuse-backend"))]
 mod fuse;
 #[cfg(all(windows, feature = "winfsp-backend"))]


### PR DESCRIPTION
Rather than use `unreachable!`, make `attr_from_entry` fallible and ignore mask entries inside `readdirplus`.

Some log lines captured while debugging:
```
Jun 13 16:37:40 wolf0848.spimageworks.com spfs[195052]: TRACE readdirplus add README.txt
Jun 13 16:37:40 wolf0848.spimageworks.com spfs[195052]: TRACE ... readdirplus add README.txt:false
Jun 13 16:37:40 wolf0848.spimageworks.com spfs[195052]: ERROR attr_from_entry encountered mask
Jun 13 16:37:40 wolf0848.spimageworks.com spfs[195052]:  WARN Reply not sent for operation 49, replying with I/O error
Jun 13 16:37:40 wolf0848.spimageworks.com spfs[195052]: ERROR Error in readdirplus: task 142 panicked
```