### PR TITLE
Update documentation links to be relative

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -9,7 +9,7 @@ alt="SPK Logo" src="/images/spk_black.png"/>
 
 The **S**oftware **P**ackaging **K**it (SPK) provides package management and a software runtime for studio environments.
 
-<div style="text-align: center; width: 100%">{{% button href="/use" %}}Getting Started{{% /button %}} {{% button href="/ref/spec" %}}Yaml Reference{{% /button %}} {{% button href="/error_codes" %}}Error Codes{{% /button %}}</div>
+<div style="text-align: center; width: 100%">{{% button href="./use" %}}Getting Started{{% /button %}} {{% button href="./ref/spec" %}}Yaml Reference{{% /button %}} {{% button href="./error_codes" %}}Error Codes{{% /button %}}</div>
 
 Driven by the unique requirements of the film, vfx, and animation industries, SPK has a few primary goals:
 

--- a/docs/spfs/_index.md
+++ b/docs/spfs/_index.md
@@ -4,7 +4,7 @@ chapter: true
 ---
 
 <img style="max-width: 200px"
-alt="SPFS Logo" src="/images/spfs_black.png"/>
+alt="SPFS Logo" src="../images/spfs_black.png"/>
 ---
 
 The **S**oftware **P**latform **F**ile**S**ystem (SPFS) is a tool for isolating, capturing and distributing software runtime environments. In many ways, what it provides is like a lightweight container combined with the functionality of git. SPFS delivers some of the benefits of a container runtime without creating too much isolation from the host environment.


### PR DESCRIPTION
Like #979, so the links still work when the documentation is nested into a child folder of a larger site.