### PR TITLE
Require universal filesystem access for spfs-enter

### DIFF
--- a/.site/spi/spk.spec
+++ b/.site/spi/spk.spec
@@ -55,7 +55,7 @@ cp "$RELEASE_DIR"/spk %{buildroot}/opt/spk.dist/
 %caps(cap_net_admin+ep) /usr/local/bin/spfs-monitor
 %caps(cap_chown,cap_fowner+ep) /usr/local/bin/spfs-render
 %caps(cap_sys_chroot,cap_sys_admin+ep) /usr/local/bin/spfs-join
-%caps(cap_setuid,cap_chown,cap_mknod,cap_sys_admin,cap_fowner+ep) /usr/local/bin/spfs-enter
+%caps(cap_dac_override,cap_setuid,cap_chown,cap_mknod,cap_sys_admin,cap_fowner+ep) /usr/local/bin/spfs-enter
 %caps(cap_sys_admin+ep) /usr/local/bin/spfs-fuse
 /usr/local/bin/spk-launcher
 /opt/spk.dist/

--- a/Makefile.linux
+++ b/Makefile.linux
@@ -51,7 +51,7 @@ setcap:
 	sudo setcap 'cap_net_admin+ep' '$(DESTDIR)$(bindir)/spfs-monitor'
 	sudo setcap 'cap_chown,cap_fowner+ep' '$(DESTDIR)$(bindir)/spfs-render'
 	sudo setcap 'cap_sys_chroot,cap_sys_admin+ep' '$(DESTDIR)$(bindir)/spfs-join'
-	sudo setcap 'cap_setuid,cap_chown,cap_mknod,cap_sys_admin,cap_fowner+ep' '$(DESTDIR)$(bindir)/spfs-enter'
+	sudo setcap 'cap_dac_override,cap_setuid,cap_chown,cap_mknod,cap_sys_admin,cap_fowner+ep' '$(DESTDIR)$(bindir)/spfs-enter'
 	sudo setcap 'cap_sys_admin+ep' '$(DESTDIR)$(bindir)/spfs-fuse'
 
 .PHONY: check-copyrights

--- a/spfs.spec
+++ b/spfs.spec
@@ -48,7 +48,7 @@ done
 %caps(cap_net_admin+ep) /usr/local/bin/spfs-monitor
 %caps(cap_chown,cap_fowner+ep) /usr/local/bin/spfs-render
 %caps(cap_sys_chroot,cap_sys_admin+ep) /usr/local/bin/spfs-join
-%caps(cap_setuid,cap_chown,cap_mknod,cap_sys_admin,cap_fowner+ep) /usr/local/bin/spfs-enter
+%caps(cap_dac_override,cap_setuid,cap_chown,cap_mknod,cap_sys_admin,cap_fowner+ep) /usr/local/bin/spfs-enter
 %caps(cap_sys_admin+ep) /usr/local/bin/spfs-fuse
 
 %post

--- a/spk.spec
+++ b/spk.spec
@@ -58,7 +58,7 @@ mv %{buildroot}/usr/local/bin/spk %{buildroot}/usr/local/bin/spk-%{version}
 %caps(cap_net_admin+ep) /usr/local/bin/spfs-monitor
 %caps(cap_chown,cap_fowner+ep) /usr/local/bin/spfs-render
 %caps(cap_sys_chroot,cap_sys_admin+ep) /usr/local/bin/spfs-join
-%caps(cap_setuid,cap_chown,cap_mknod,cap_sys_admin,cap_fowner+ep) /usr/local/bin/spfs-enter
+%caps(cap_dac_override,cap_setuid,cap_chown,cap_mknod,cap_sys_admin,cap_fowner+ep) /usr/local/bin/spfs-enter
 %caps(cap_sys_admin+ep) /usr/local/bin/spfs-fuse
 
 %post


### PR DESCRIPTION
On a modern 'fedora 40' linux distro, the enter process fails on any attempt to modify the runtime or create directories in the repository in my home directory. The error is EACCESS, which denotes that the process doesn't have search permission on one of the directories involved. The CAP_DAC_OVERRIDE privilege is needed in this configuraiton to allow the enter process (running as root) full access to the file system.

FYI @davvid 