### PR TITLE
Add solver config to control default the solver and displayed output

### DIFF
--- a/crates/spk-cli/common/src/flags.rs
+++ b/crates/spk-cli/common/src/flags.rs
@@ -1085,11 +1085,11 @@ pub struct DecisionFormatterSettings {
     /// the (cli) solver is displayed. even if the result ultimately
     /// comes from the (checks) solver. To run only one solver, use
     /// `--solver-to-run <cli|checks>`.
-    #[clap(long, value_enum, default_value_t = SolverToRun::All, env = "SPK_SOLVER_TO_RUN")]
+    #[clap(long, env = "SPK_SOLVER__SOLVER_TO_RUN", value_enum, default_value_t = SolverToRun::All)]
     pub solver_to_run: SolverToRun,
     /// Control what solver's output is shown when multiple solvers
     /// (all) are being run.
-    #[clap(long, value_enum, default_value_t = SolverToShow::Cli, env = "SPK_SOLVER_TO_SHOW")]
+    #[clap(long, env = "SPK_SOLVER__SOLVER_TO_SHOW", value_enum, default_value_t = SolverToShow::Cli)]
     pub solver_to_show: SolverToShow,
 
     /// Display a report on of the search space size for the resolved solution.

--- a/crates/spk-cli/common/src/flags.rs
+++ b/crates/spk-cli/common/src/flags.rs
@@ -990,8 +990,17 @@ pub enum SolverToRun {
     Cli,
     /// Run and show output from the "impossible requests" checking solver
     Checks,
-    /// Run both solvers, showing the output from the basic solver
+    /// Run both solvers, showing the output from the basic solver,
+    /// unless overridden with --solver-to-show
     All,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+pub enum SolverToShow {
+    /// Show output from the basic solver
+    Cli,
+    /// Show output from the "impossible requests" checking solver
+    Checks,
 }
 
 impl From<SolverToRun> for MultiSolverKind {
@@ -1000,6 +1009,15 @@ impl From<SolverToRun> for MultiSolverKind {
             SolverToRun::Cli => MultiSolverKind::Unchanged,
             SolverToRun::Checks => MultiSolverKind::AllImpossibleChecks,
             SolverToRun::All => MultiSolverKind::All,
+        }
+    }
+}
+
+impl From<SolverToShow> for MultiSolverKind {
+    fn from(item: SolverToShow) -> MultiSolverKind {
+        match item {
+            SolverToShow::Cli => MultiSolverKind::Unchanged,
+            SolverToShow::Checks => MultiSolverKind::AllImpossibleChecks,
         }
     }
 }
@@ -1055,20 +1073,24 @@ pub struct DecisionFormatterSettings {
     #[clap(long)]
     pub status_bar: bool,
 
-    /// Control what solver(s) are used and what output is shown.
+    /// Control what solver(s) are used.
     ///
     /// There are currently two modes for the solver, one that is faster when
     /// there are few problems encountered looking for packages (cli) and one
     /// that is faster when it is difficult to find a set of packages that
     /// satisfy a request (checks).
     ///
-    /// By default, both solvers are run in parallel and the result is taken
-    /// from the first one that finishes. However, the output from the (cli)
-    /// solver is displayed even if the result ultimately comes from the
-    /// (checks) solver. To see the output from the (checks) solver, use
-    /// `--solver-to-run checks` to see that output.
-    #[clap(long, value_enum, default_value_t = SolverToRun::All)]
+    /// By default, both solvers are run in parallel and the result is
+    /// taken from the first one that finishes, and the output from
+    /// the (cli) solver is displayed. even if the result ultimately
+    /// comes from the (checks) solver. To run only one solver, use
+    /// `--solver-to-run <cli|checks>`.
+    #[clap(long, value_enum, default_value_t = SolverToRun::All, env = "SPK_SOLVER_TO_RUN")]
     pub solver_to_run: SolverToRun,
+    /// Control what solver's output is shown when multiple solvers
+    /// (all) are being run.
+    #[clap(long, value_enum, default_value_t = SolverToShow::Cli, env = "SPK_SOLVER_TO_SHOW")]
+    pub solver_to_show: SolverToShow,
 
     /// Display a report on of the search space size for the resolved solution.
     #[clap(long)]
@@ -1126,6 +1148,7 @@ impl DecisionFormatterSettings {
             .with_max_frequent_errors(self.max_frequent_errors)
             .with_status_bar(self.status_bar)
             .with_solver_to_run(self.solver_to_run.into())
+            .with_solver_to_show(self.solver_to_show.into())
             .with_search_space_size(self.show_search_size)
             .with_stop_on_block(self.stop_on_block)
             .with_step_on_block(self.step_on_block)

--- a/crates/spk-config/src/config.rs
+++ b/crates/spk-config/src/config.rs
@@ -95,6 +95,12 @@ pub struct Solver {
     /// Comma-separated list of option names to promote to the front of the
     /// resolve order.
     pub request_priority_order: String,
+
+    /// Name of the solver, or all, to run when performing a solve
+    pub solver_to_run: String,
+
+    /// Name of the solver whose output to show  when multiple solvers are being run.
+    pub solver_to_show: String,
 }
 
 #[derive(Clone, Default, Debug, Deserialize, Serialize)]

--- a/crates/spk-solve/src/io.rs
+++ b/crates/spk-solve/src/io.rs
@@ -59,6 +59,10 @@ use crate::{
 const STOP_ON_BLOCK_FLAG: &str = "--stop-on-block";
 const BY_USER: &str = "by user";
 
+const CLI_SOLVER: &str = "cli";
+const IMPOSSIBLE_CHECKS_SOLVER: &str = "check";
+const ALL_SOLVERS: &str = "all";
+
 static USER_CANCELLED: Lazy<Arc<AtomicBool>> = Lazy::new(|| {
     // Initialise the USER_CANCELLED value
     let b = Arc::new(AtomicBool::new(false));
@@ -533,6 +537,8 @@ impl DecisionFormatterBuilder {
             timeout: cfg.solve_timeout,
             long_solves_threshold: cfg.long_solve_threshold,
             max_frequent_errors: cfg.max_frequent_errors,
+            solver_to_run: MultiSolverKind::from_config_run_value(&cfg.solver_to_run),
+            solver_to_show: MultiSolverKind::from_config_output_value(&cfg.solver_to_show),
             ..Default::default()
         }
     }
@@ -755,9 +761,32 @@ impl MultiSolverKind {
     /// Return the command line option value for this MultiSolveKind
     fn cli_name(&self) -> &'static str {
         match self {
-            MultiSolverKind::Unchanged => "cli",
-            MultiSolverKind::AllImpossibleChecks => "checks",
-            MultiSolverKind::All => "all",
+            MultiSolverKind::Unchanged => CLI_SOLVER,
+            MultiSolverKind::AllImpossibleChecks => IMPOSSIBLE_CHECKS_SOLVER,
+            MultiSolverKind::All => ALL_SOLVERS,
+        }
+    }
+
+    /// Return the MultiSolverKind setting for a solver to run from a
+    /// config value. This will fallback to MultiSolverKind:Cli if the
+    /// given value is invalid.
+    fn from_config_run_value(value: &String) -> MultiSolverKind {
+        match value.to_lowercase().as_ref() {
+            CLI_SOLVER => MultiSolverKind::Unchanged,
+            IMPOSSIBLE_CHECKS_SOLVER => MultiSolverKind::AllImpossibleChecks,
+            ALL_SOLVERS => MultiSolverKind::All,
+            _ => MultiSolverKind::Unchanged,
+        }
+    }
+
+    /// Return the MultiSolverKind setting for a solver to output from a
+    /// config value. This will fallback to MultiSolverKind:Cli if the
+    /// given value is invalid.
+    fn from_config_output_value(value: &String) -> MultiSolverKind {
+        match value.to_lowercase().as_ref() {
+            CLI_SOLVER => MultiSolverKind::Unchanged,
+            IMPOSSIBLE_CHECKS_SOLVER => MultiSolverKind::AllImpossibleChecks,
+            _ => MultiSolverKind::Unchanged,
         }
     }
 }

--- a/crates/spk-solve/src/io.rs
+++ b/crates/spk-solve/src/io.rs
@@ -770,7 +770,7 @@ impl MultiSolverKind {
     /// Return the MultiSolverKind setting for a solver to run from a
     /// config value. This will fallback to MultiSolverKind:Cli if the
     /// given value is invalid.
-    fn from_config_run_value(value: &String) -> MultiSolverKind {
+    fn from_config_run_value(value: &str) -> MultiSolverKind {
         match value.to_lowercase().as_ref() {
             CLI_SOLVER => MultiSolverKind::Unchanged,
             IMPOSSIBLE_CHECKS_SOLVER => MultiSolverKind::AllImpossibleChecks,
@@ -782,7 +782,7 @@ impl MultiSolverKind {
     /// Return the MultiSolverKind setting for a solver to output from a
     /// config value. This will fallback to MultiSolverKind:Cli if the
     /// given value is invalid.
-    fn from_config_output_value(value: &String) -> MultiSolverKind {
+    fn from_config_output_value(value: &str) -> MultiSolverKind {
         match value.to_lowercase().as_ref() {
             CLI_SOLVER => MultiSolverKind::Unchanged,
             IMPOSSIBLE_CHECKS_SOLVER => MultiSolverKind::AllImpossibleChecks,

--- a/crates/spk-solve/src/io.rs
+++ b/crates/spk-solve/src/io.rs
@@ -486,6 +486,7 @@ pub struct DecisionFormatterBuilder {
     max_frequent_errors: usize,
     status_bar: bool,
     solver_to_run: MultiSolverKind,
+    solver_to_show: MultiSolverKind,
     show_search_space_size: bool,
     compare_solvers: bool,
     stop_on_block: bool,
@@ -507,6 +508,7 @@ impl Default for DecisionFormatterBuilder {
             max_frequent_errors: 0,
             status_bar: false,
             solver_to_run: MultiSolverKind::Unchanged,
+            solver_to_show: MultiSolverKind::Unchanged,
             show_search_space_size: false,
             compare_solvers: false,
             stop_on_block: false,
@@ -590,6 +592,11 @@ impl DecisionFormatterBuilder {
         self
     }
 
+    pub fn with_solver_to_show(&mut self, kind: MultiSolverKind) -> &mut Self {
+        self.solver_to_show = kind;
+        self
+    }
+
     pub fn with_search_space_size(&mut self, enable: bool) -> &mut Self {
         self.show_search_space_size = enable;
         self
@@ -653,6 +660,7 @@ impl DecisionFormatterBuilder {
                 max_frequent_errors: self.max_frequent_errors,
                 status_bar: self.status_bar,
                 solver_to_run: self.solver_to_run.clone(),
+                solver_to_show: self.solver_to_show.clone(),
                 show_search_space_size: self.show_search_space_size,
                 compare_solvers: self.compare_solvers,
                 stop_on_block: self.stop_on_block,
@@ -715,6 +723,7 @@ pub(crate) struct DecisionFormatterSettings {
     pub(crate) max_frequent_errors: usize,
     pub(crate) status_bar: bool,
     pub(crate) solver_to_run: MultiSolverKind,
+    pub(crate) solver_to_show: MultiSolverKind,
     pub(crate) show_search_space_size: bool,
     pub(crate) compare_solvers: bool,
     pub(crate) stop_on_block: bool,
@@ -807,6 +816,7 @@ impl DecisionFormatter {
                 max_frequent_errors: 5,
                 status_bar: false,
                 solver_to_run: MultiSolverKind::Unchanged,
+                solver_to_show: MultiSolverKind::Unchanged,
                 show_search_space_size: false,
                 compare_solvers: false,
                 stop_on_block: false,
@@ -930,7 +940,7 @@ impl DecisionFormatter {
         for solver_settings in solvers {
             let mut task_formatter = self.clone();
             if self.settings.solver_to_run.is_multi()
-                && solver_settings.solver_kind != MultiSolverKind::Unchanged
+                && self.settings.solver_to_show != solver_settings.solver_kind
             {
                 // Hide the output from all the solvers except the
                 // unchanged one. The output from the unchanged solver
@@ -1086,7 +1096,7 @@ impl DecisionFormatter {
                         };
                         let name = solver_kind.cli_name();
 
-                        tracing::info!("The {solver_kind} solver found {solver_outcome}, but its output was disabled. To see its output, rerun the spk command with '--solver-to-run {name}'" );
+                        tracing::info!("The {solver_kind} solver found {solver_outcome}, but its output was disabled. To see its output, rerun the spk command with '--solver-to-show {name}' or `--solver-to-run {name}`" );
                     }
 
                     if self.settings.compare_solvers {


### PR DESCRIPTION
This adds solver configuration and options to set the default solver and default solver to display solver output from. This will let sites configure the solver/s they want, and let individual commands override that when required.

These changes add:
- `--solver-to-show <SOLVER>` argument to commands with Solver cli flags
- `solver_to_run` to the Solver section of the spk config file
- `solver_to_show` to the Solver section of the spk config file
- environment variable defaults to `--solver-to-run` and `--solver-to-show`. They use `SPK_SOLVER__SOLVER_TO_RUN` and `SPK_SOLVER__SOLVER_TO_SHOW` respectively to line up with the spk config file
- constants for the names used on the command line for the various solvers

Examples:
```
# Run all (both) the solvers and show the cli solver's output - this is the built-in default
spk explain python --solver-to-run all --solver-to-show cli

# Run all (both) the solvers and show the impossible checks solver's output
spk explain python --solver-to-run all --solver-to-show checks

# Run only the impossible checks solver and show its output
spk explain python --solver-to-run checks 

# Run all (both) the solvers and show the impossible checks solver's output
env SPK_SOLVER__SOLVER_TO_SHOW=checks spk explain spwidgets 

# Run only the cli solver and show its output
env SPK_SOLVER__SOLVER_TO_RUN=cli spk explain spwidgets 
```