### PR TITLE
Fix `spk export` not respecting repository arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3909,6 +3909,7 @@ dependencies = [
  "spk-build",
  "spk-cli-common",
  "spk-schema",
+ "spk-solve",
  "spk-storage",
  "tar",
  "tokio",
@@ -4481,6 +4482,7 @@ dependencies = [
  "tracing-subscriber",
  "ulid",
  "url",
+ "variantly",
 ]
 
 [[package]]

--- a/crates/spk-cli/group3/Cargo.toml
+++ b/crates/spk-cli/group3/Cargo.toml
@@ -27,4 +27,5 @@ tokio = "1.20"
 [dev-dependencies]
 tar = "0.4.3"
 spk-build = { workspace = true }
+spk-solve = { workspace = true }
 rstest = { workspace = true }

--- a/crates/spk-storage/Cargo.toml
+++ b/crates/spk-storage/Cargo.toml
@@ -49,3 +49,4 @@ tracing = { workspace = true }
 tracing-subscriber = "0.3.17"
 ulid = { workspace = true }
 url = "2.2"
+variantly = { workspace = true }

--- a/crates/spk-storage/src/lib.rs
+++ b/crates/spk-storage/src/lib.rs
@@ -20,5 +20,6 @@ pub use storage::{
     RepositoryHandle,
     RuntimeRepository,
     SpfsRepository,
+    SpfsRepositoryHandle,
     Storage,
 };

--- a/crates/spk-storage/src/storage/archive.rs
+++ b/crates/spk-storage/src/storage/archive.rs
@@ -5,13 +5,19 @@
 use std::convert::TryFrom;
 use std::path::Path;
 
+use itertools::{Itertools, Position};
 use spk_schema::ident_ops::TagPathStrategy;
 use spk_schema::{AnyIdent, BuildIdent, VersionIdent};
+use variantly::Variantly;
 
 use super::{Repository, SpfsRepository};
-use crate::{Error, NameAndRepositoryWithTagStrategy, Result};
+use crate::{Error, NameAndRepositoryWithTagStrategy, Result, SpfsRepositoryHandle};
 
-pub async fn export_package<S>(pkg: impl AsRef<AnyIdent>, filename: impl AsRef<Path>) -> Result<()>
+pub async fn export_package<'a, S>(
+    source_repos: &[SpfsRepositoryHandle<'a>],
+    pkg: impl AsRef<AnyIdent>,
+    filename: impl AsRef<Path>,
+) -> Result<()>
 where
     S: TagPathStrategy + Send + Sync,
 {
@@ -37,13 +43,6 @@ where
         })
         .unwrap_or_else(|| Ok(()))?;
 
-    // Don't require the "origin" repo to exist here.
-    let (local_repo, remote_repo) = tokio::join!(
-        super::local_repository(),
-        super::remote_repository::<_, S>("origin"),
-    );
-    let local_repo = local_repo?;
-
     let tar_repo = spfs::storage::tar::TarRepository::create(&filename)
         .await
         .map_err(|source| spfs::Error::FailedToOpenRepository {
@@ -65,108 +64,84 @@ where
     let mut to_transfer = std::collections::BTreeSet::new();
     to_transfer.insert(pkg.clone());
     if pkg.build().is_none() {
-        to_transfer.extend(
-            local_repo
-                .list_package_builds(pkg.as_version())
-                .await?
-                .into_iter()
-                .map(|pkg| pkg.into_any()),
-        );
-        if remote_repo.is_err() {
-            return remote_repo.map(|_| ());
+        for repo in source_repos {
+            to_transfer.extend(
+                repo.list_package_builds(pkg.as_version())
+                    .await?
+                    .into_iter()
+                    .map(|pkg| pkg.into_any()),
+            );
         }
-        to_transfer.extend(
-            remote_repo
-                .as_ref()
-                .unwrap()
-                .list_package_builds(pkg.as_version())
-                .await?
-                .into_iter()
-                .map(|pkg| pkg.into_any()),
-        );
     } else {
         to_transfer.insert(pkg.with_build(None));
     }
 
-    for transfer_pkg in to_transfer.into_iter() {
+    'pkg: for transfer_pkg in to_transfer.into_iter() {
         if transfer_pkg.is_embedded() {
             // Don't attempt to export an embedded package; the stub
             // will be recreated if exporting its provider.
             continue;
         }
 
+        #[derive(Variantly)]
         enum CopyResult {
             VersionNotFound,
             BuildNotFound,
             Err(Error),
         }
 
-        impl CopyResult {
-            fn or(self, other: CopyResult) -> Option<Error> {
-                if let CopyResult::Err(err) = self {
-                    Some(err)
-                } else if let CopyResult::Err(err) = other {
-                    Some(err)
-                } else {
-                    None
+        let mut first_error = None;
+        let mut all_errors_are_build_not_found = true;
+
+        for (position, repo) in source_repos.iter().with_position() {
+            let err = match copy_any(transfer_pkg.clone(), repo, &target_repo).await {
+                Ok(_) => continue 'pkg,
+                Err(Error::PackageNotFound(ident)) => {
+                    if ident.build().is_some() {
+                        CopyResult::BuildNotFound
+                    } else {
+                        CopyResult::VersionNotFound
+                    }
+                }
+                Err(err) => CopyResult::Err(err),
+            };
+
+            // `list_package_builds` can return builds that only exist as spfs tags
+            // under `spk/spec`, meaning the build doesn't really exist. Ignore
+            // `PackageNotFound` about these ... unless the build was
+            // explicitly named to be archived.
+            //
+            // Consider changing `list_package_builds` so it doesn't do that
+            // anymore, although it has a comment that it is doing so
+            // intentionally. Maybe it should return a richer type that describes
+            // if only the "spec build" exists and that info could be used here.
+            all_errors_are_build_not_found = all_errors_are_build_not_found
+                && matches!(err, CopyResult::BuildNotFound)
+                && pkg.build().is_none();
+
+            // We'll report the error from the first repo that failed, under the
+            // assumption that the repo(s) listed first are more likely to be
+            // where the problem is fixable (e.g., the local repo).
+            if first_error.is_none() {
+                first_error = Some(err);
+            }
+
+            match position {
+                Position::Last | Position::Only if all_errors_are_build_not_found => {
+                    continue 'pkg;
+                }
+                Position::Last | Position::Only => {
+                    return Err(first_error
+                        .unwrap()
+                        .err()
+                        .unwrap_or_else(|| Error::PackageNotFound(transfer_pkg)));
+                }
+                _ => {
+                    // Try the next repo
+                    continue;
                 }
             }
         }
-
-        let local_err = match copy_any(transfer_pkg.clone(), &local_repo, &target_repo).await {
-            Ok(_) => continue,
-            Err(Error::PackageNotFound(ident)) => {
-                if ident.build().is_some() {
-                    CopyResult::BuildNotFound
-                } else {
-                    CopyResult::VersionNotFound
-                }
-            }
-            Err(err) => CopyResult::Err(err),
-        };
-        if remote_repo.is_err() {
-            return remote_repo.map(|_| ());
-        }
-        let remote_err = match copy_any(
-            transfer_pkg.clone(),
-            remote_repo.as_ref().unwrap(),
-            &target_repo,
-        )
-        .await
-        {
-            Ok(_) => continue,
-            Err(Error::PackageNotFound(ident)) => {
-                if ident.build().is_some() {
-                    CopyResult::BuildNotFound
-                } else {
-                    CopyResult::VersionNotFound
-                }
-            }
-            Err(err) => CopyResult::Err(err),
-        };
-
-        // `list_package_builds` can return builds that only exist as spfs tags
-        // under `spk/spec`, meaning the build doesn't really exist. Ignore
-        // `PackageNotFound` about these ... unless the build was
-        // explicitly named to be archived.
-        //
-        // Consider changing `list_package_builds` so it doesn't do that
-        // anymore, although it has a comment that it is doing so
-        // intentionally. Maybe it should return a richer type that describes
-        // if only the "spec build" exists and that info could be used here.
-        if matches!(local_err, CopyResult::BuildNotFound)
-            && matches!(remote_err, CopyResult::BuildNotFound)
-            && pkg.build().is_none()
-        {
-            continue;
-        }
-
-        // we will hide the remote_err in cases when both failed,
-        // because the remote was always a fallback and fixing the
-        // local error is preferred
-        return Err(local_err
-            .or(remote_err)
-            .unwrap_or_else(|| Error::PackageNotFound(transfer_pkg)));
     }
 
     tracing::info!(path=?filename, "building archive");
@@ -177,13 +152,12 @@ where
     Ok(())
 }
 
-async fn copy_any<S1, S2>(
+async fn copy_any<'a, S2>(
     pkg: AnyIdent,
-    src_repo: &SpfsRepository<S1>,
+    src_repo: &SpfsRepositoryHandle<'a>,
     dst_repo: &SpfsRepository<S2>,
 ) -> Result<()>
 where
-    S1: TagPathStrategy + Send + Sync,
     S2: TagPathStrategy + Send + Sync,
 {
     match pkg.into_inner() {
@@ -194,13 +168,12 @@ where
     }
 }
 
-async fn copy_recipe<S1, S2>(
+async fn copy_recipe<'a, S2>(
     pkg: &VersionIdent,
-    src_repo: &SpfsRepository<S1>,
+    src_repo: &SpfsRepositoryHandle<'a>,
     dst_repo: &SpfsRepository<S2>,
 ) -> Result<()>
 where
-    S1: TagPathStrategy + Send + Sync,
     S2: TagPathStrategy + Send + Sync,
 {
     let spec = src_repo.read_recipe(pkg).await?;
@@ -209,19 +182,18 @@ where
     Ok(())
 }
 
-async fn copy_package<S1, S2>(
+async fn copy_package<'a, S2>(
     pkg: &BuildIdent,
-    src_repo: &SpfsRepository<S1>,
+    src_repo: &SpfsRepositoryHandle<'a>,
     dst_repo: &SpfsRepository<S2>,
 ) -> Result<()>
 where
-    S1: TagPathStrategy + Send + Sync,
     S2: TagPathStrategy + Send + Sync,
 {
     let spec = src_repo.read_package(pkg).await?;
     let components = src_repo.read_components(pkg).await?;
     tracing::info!(%pkg, "exporting");
-    let syncer = spfs::Syncer::new(src_repo, dst_repo)
+    let syncer = spfs::Syncer::new(src_repo.spfs_repository_handle(), dst_repo)
         .with_reporter(spfs::sync::ConsoleSyncReporter::default());
     let desired = components.iter().map(|i| *i.1).collect();
     syncer.sync_env(desired).await?;

--- a/crates/spk-storage/src/storage/mod.rs
+++ b/crates/spk-storage/src/storage/mod.rs
@@ -20,4 +20,5 @@ pub use self::spfs::{
     remote_repository,
     NameAndRepositoryWithTagStrategy,
     SpfsRepository,
+    SpfsRepositoryHandle,
 };

--- a/crates/spk-storage/src/storage/spfs.rs
+++ b/crates/spk-storage/src/storage/spfs.rs
@@ -1276,6 +1276,31 @@ impl StoredPackage {
     }
 }
 
+pub enum SpfsRepositoryHandle<'a> {
+    Normalized(&'a SpfsRepository<NormalizedTagStrategy>),
+    Verbatim(&'a SpfsRepository<VerbatimTagStrategy>),
+}
+
+impl<'a> SpfsRepositoryHandle<'a> {
+    pub fn spfs_repository_handle(&self) -> &spfs::prelude::RepositoryHandle {
+        match self {
+            Self::Normalized(repo) => &repo.inner,
+            Self::Verbatim(repo) => &repo.inner,
+        }
+    }
+}
+
+impl<'a> std::ops::Deref for SpfsRepositoryHandle<'a> {
+    type Target = dyn crate::storage::Repository<Recipe = SpecRecipe, Package = Spec>;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Normalized(repo) => *repo,
+            Self::Verbatim(repo) => *repo,
+        }
+    }
+}
+
 /// Return the local packages repository used for development.
 pub async fn local_repository() -> Result<SpfsRepository<NormalizedTagStrategy>> {
     let config = spfs::get_config()?;


### PR DESCRIPTION
In particular, `spk export --local-repo-only ...` would export packages from the origin repo.

This necessitated adding another level of "handle" indirection to deal with the different type flavors of SpfsRepository.