### PR TITLE
Add `--output-to-dir <path>` for solvers' output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4448,6 +4448,7 @@ dependencies = [
  "async-recursion",
  "async-stream",
  "async-trait",
+ "chrono",
  "colored",
  "console",
  "crossterm",

--- a/crates/spk-cli/common/src/flags.rs
+++ b/crates/spk-cli/common/src/flags.rs
@@ -36,7 +36,8 @@ mod flags_test;
 
 static SPK_NO_RUNTIME: &str = "SPK_NO_RUNTIME";
 static SPK_KEEP_RUNTIME: &str = "SPK_KEEP_RUNTIME";
-static SPK_OUTPUT_TO_FILE: &str = "SPK_OUTPUT_TO_FILE";
+static SPK_OUTPUT_TO_DIR: &str = "SPK_OUTPUT_TO_DIR";
+static SPK_OUTPUT_TO_DIR_MIN_VERBOSITY: &str = "SPK_OUTPUT_TO_DIR_MIN_VERBOSITY";
 
 #[derive(Args, Clone)]
 pub struct Runtime {
@@ -1132,11 +1133,17 @@ pub struct DecisionFormatterSettings {
     #[clap(long, alias = "decision")]
     step_on_decision: bool,
 
-    /// Capture each solver's output to a separate file each time a
-    /// solver is run. The files will be in the current directory and
-    /// named `solver_YYYYmmdd_HHMMSS_<solver_kind>`.
-    #[clap(long, env = SPK_OUTPUT_TO_FILE)]
-    output_to_file: bool,
+    /// Set to capture each solver's output to a separate file in each
+    /// time a solver is run. The files will be in the the given
+    /// directory and named `spk_solver_run_YYYYmmdd_HHMMSS_<solver_kind>`.
+    #[clap(long, env = SPK_OUTPUT_TO_DIR, value_hint = ValueHint::FilePath)]
+    output_to_dir: Option<std::path::PathBuf>,
+
+    /// Set the minimum verbosity for solver's when outputting to a
+    /// file. Has no affect unless --output-to-file is also specified.
+    /// Verbosities set (-v) higher than this minimum will override it.
+    #[clap(long, default_value_t=2, env = SPK_OUTPUT_TO_DIR_MIN_VERBOSITY)]
+    output_to_dir_min_verbosity: u8,
 }
 
 impl DecisionFormatterSettings {
@@ -1178,7 +1185,8 @@ impl DecisionFormatterSettings {
             .with_stop_on_block(self.stop_on_block)
             .with_step_on_block(self.step_on_block)
             .with_step_on_decision(self.step_on_decision)
-            .with_output_to_file(self.output_to_file)
+            .with_output_to_dir(self.output_to_dir.clone())
+            .with_output_to_dir_min_verbosity(self.output_to_dir_min_verbosity)
             .with_compare_solvers(self.compare_solvers);
         Ok(builder)
     }

--- a/crates/spk-cli/common/src/flags.rs
+++ b/crates/spk-cli/common/src/flags.rs
@@ -1147,7 +1147,7 @@ pub struct DecisionFormatterSettings {
     #[clap(long, env = SPK_OUTPUT_TO_DIR, value_hint = ValueHint::FilePath)]
     output_to_dir: Option<std::path::PathBuf>,
 
-    /// Set the minimum verbosity for solver's when outputting to a
+    /// Set the minimum verbosity for solvers when outputting to a
     /// file. Has no affect unless --output-to-file is also specified.
     /// Verbosity set (-v) higher than this minimum will override it.
     #[clap(long, default_value_t=2, env = SPK_OUTPUT_TO_DIR_MIN_VERBOSITY)]

--- a/crates/spk-cli/common/src/flags.rs
+++ b/crates/spk-cli/common/src/flags.rs
@@ -1130,6 +1130,12 @@ pub struct DecisionFormatterSettings {
     /// Pause the solver each time it makes a decision, until the user hits Enter.
     #[clap(long, alias = "decision")]
     step_on_decision: bool,
+
+    /// Capture each solver's output to a separate file each time a
+    /// solver is run. The files will be in the current directory and
+    /// named `solver_YYYYmmdd_HHMMSS_<solverkind>`.
+    #[clap(long)]
+    output_to_file: bool,
 }
 
 impl DecisionFormatterSettings {
@@ -1171,6 +1177,7 @@ impl DecisionFormatterSettings {
             .with_stop_on_block(self.stop_on_block)
             .with_step_on_block(self.step_on_block)
             .with_step_on_decision(self.step_on_decision)
+            .with_output_to_file(self.output_to_file)
             .with_compare_solvers(self.compare_solvers);
         Ok(builder)
     }

--- a/crates/spk-cli/common/src/flags.rs
+++ b/crates/spk-cli/common/src/flags.rs
@@ -1133,7 +1133,7 @@ pub struct DecisionFormatterSettings {
 
     /// Capture each solver's output to a separate file each time a
     /// solver is run. The files will be in the current directory and
-    /// named `solver_YYYYmmdd_HHMMSS_<solverkind>`.
+    /// named `solver_YYYYmmdd_HHMMSS_<solver_kind>`.
     #[clap(long)]
     output_to_file: bool,
 }

--- a/crates/spk-cli/common/src/flags.rs
+++ b/crates/spk-cli/common/src/flags.rs
@@ -36,6 +36,7 @@ mod flags_test;
 
 static SPK_NO_RUNTIME: &str = "SPK_NO_RUNTIME";
 static SPK_KEEP_RUNTIME: &str = "SPK_KEEP_RUNTIME";
+static SPK_OUTPUT_TO_FILE: &str = "SPK_OUTPUT_TO_FILE";
 
 #[derive(Args, Clone)]
 pub struct Runtime {
@@ -1134,7 +1135,7 @@ pub struct DecisionFormatterSettings {
     /// Capture each solver's output to a separate file each time a
     /// solver is run. The files will be in the current directory and
     /// named `solver_YYYYmmdd_HHMMSS_<solver_kind>`.
-    #[clap(long)]
+    #[clap(long, env = SPK_OUTPUT_TO_FILE)]
     output_to_file: bool,
 }
 

--- a/crates/spk-cli/common/src/flags.rs
+++ b/crates/spk-cli/common/src/flags.rs
@@ -41,9 +41,9 @@ mod flags_test;
 
 static SPK_NO_RUNTIME: &str = "SPK_NO_RUNTIME";
 static SPK_KEEP_RUNTIME: &str = "SPK_KEEP_RUNTIME";
-static SPK_OUTPUT_TO_DIR: &str = "SPK_OUTPUT_TO_DIR";
-static SPK_OUTPUT_TO_DIR_MIN_VERBOSITY: &str = "SPK_OUTPUT_TO_DIR_MIN_VERBOSITY";
-static SPK_OUTPUT_FILE_PREFIX: &str = "SPK_OUTPUT_FILE_PREFIX";
+static SPK_SOLVER_OUTPUT_TO_DIR: &str = "SPK_SOLVER_OUTPUT_TO_DIR";
+static SPK_SOLVER_OUTPUT_TO_DIR_MIN_VERBOSITY: &str = "SPK_SOLVER_OUTPUT_TO_DIR_MIN_VERBOSITY";
+static SPK_SOLVER_OUTPUT_FILE_PREFIX: &str = "SPK_SOLVER_OUTPUT_FILE_PREFIX";
 
 #[derive(Args, Clone)]
 pub struct Runtime {
@@ -1144,19 +1144,19 @@ pub struct DecisionFormatterSettings {
     /// directory and named
     /// `<solver_file_prefix>_YYYYmmdd_HHMMSS_nnnnnnnn_<solver_kind>`. See
     /// --output-file-prefix for the default prefix and how to override it.
-    #[clap(long, env = SPK_OUTPUT_TO_DIR, value_hint = ValueHint::FilePath)]
+    #[clap(long, env = SPK_SOLVER_OUTPUT_TO_DIR, value_hint = ValueHint::FilePath)]
     output_to_dir: Option<std::path::PathBuf>,
 
     /// Set the minimum verbosity for solvers when outputting to a
-    /// file. Has no affect unless --output-to-file is also specified.
+    /// file. Has no effect unless --output-to-file is also specified.
     /// Verbosity set (-v) higher than this minimum will override it.
-    #[clap(long, default_value_t=2, env = SPK_OUTPUT_TO_DIR_MIN_VERBOSITY)]
+    #[clap(long, default_value_t=2, env = SPK_SOLVER_OUTPUT_TO_DIR_MIN_VERBOSITY)]
     output_to_dir_min_verbosity: u8,
 
     /// Override the default solver output filename prefix. The
     /// current date, time, and solver kind name will be appended to
     /// this prefix to produce the file name for each solver.
-    #[clap(long, default_value_t=String::from(DEFAULT_SOLVER_RUN_FILE_PREFIX), env = SPK_OUTPUT_FILE_PREFIX)]
+    #[clap(long, default_value_t=String::from(DEFAULT_SOLVER_RUN_FILE_PREFIX), env = SPK_SOLVER_OUTPUT_FILE_PREFIX)]
     output_file_prefix: String,
 }
 

--- a/crates/spk-solve/Cargo.toml
+++ b/crates/spk-solve/Cargo.toml
@@ -29,6 +29,7 @@ statsd = ["dep:statsd"]
 async-recursion = "1.0"
 async-stream = "0.3"
 async-trait = { workspace = true }
+chrono = { workspace = true }
 colored = { workspace = true }
 console = { workspace = true }
 crossterm = "0.24"

--- a/crates/spk-solve/src/error.rs
+++ b/crates/spk-solve/src/error.rs
@@ -57,6 +57,8 @@ pub enum Error {
     SpkStorageError(#[from] spk_storage::Error),
     #[error("Error: {0}")]
     String(String),
+    #[error("Error: {0} is not supported")]
+    NotSupported(String),
 }
 
 #[derive(Diagnostic, Debug, Error)]

--- a/crates/spk-solve/src/error.rs
+++ b/crates/spk-solve/src/error.rs
@@ -63,6 +63,8 @@ pub enum Error {
     IncludingThisOutputNotSupported(String),
     #[error("Error: Solver log file not created: {1} - {0}")]
     SolverLogFileIOError(#[source] std::io::Error, PathBuf),
+    #[error("Error: Flushing solver log file: {0}")]
+    SolverLogFileFlushError(#[source] std::io::Error),
 }
 
 #[derive(Diagnostic, Debug, Error)]

--- a/crates/spk-solve/src/error.rs
+++ b/crates/spk-solve/src/error.rs
@@ -60,7 +60,7 @@ pub enum Error {
     #[error("Error: {0}")]
     String(String),
     #[error("Error: {0} is not supported")]
-    NotSupported(String),
+    IncludingThisOutputNotSupported(String),
     #[error("Error: Solver log file not created: {1} - {0}")]
     SolverLogFileIOError(#[source] std::io::Error, PathBuf),
 }

--- a/crates/spk-solve/src/error.rs
+++ b/crates/spk-solve/src/error.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/spkenv/spk
 
+use std::path::PathBuf;
+
 use colored::Colorize;
 use miette::Diagnostic;
 use spk_schema::foundation::format::FormatError;
@@ -59,6 +61,8 @@ pub enum Error {
     String(String),
     #[error("Error: {0} is not supported")]
     NotSupported(String),
+    #[error("Error: Solver log file not created: {1} - {0}")]
+    SolverLogFileIOError(#[source] std::io::Error, PathBuf),
 }
 
 #[derive(Diagnostic, Debug, Error)]

--- a/crates/spk-solve/src/io.rs
+++ b/crates/spk-solve/src/io.rs
@@ -800,23 +800,23 @@ impl OutputKind {
         match other_output {
             OutputKind::Println => match self {
                 OutputKind::Println => Ok(self.clone()),
-                OutputKind::Tracing => Err(Error::NotSupported(
+                OutputKind::Tracing => Err(Error::IncludingThisOutputNotSupported(
                     "Cannot add Println output kind to a Tracing output kind. It".to_string(),
                 )),
                 OutputKind::LogFile(f) => Ok(OutputKind::PrintlnAndToFile(f.clone())),
                 OutputKind::PrintlnAndToFile(_) => Ok(self.clone()),
-                OutputKind::TracingAndToFile(_) => Err(Error::NotSupported(
+                OutputKind::TracingAndToFile(_) => Err(Error::IncludingThisOutputNotSupported(
                     "Cannot add Println output kind to a TrackingAndToFile output kind. It"
                         .to_string(),
                 )),
             },
             OutputKind::Tracing => match self {
-                OutputKind::Println => Err(Error::NotSupported(
+                OutputKind::Println => Err(Error::IncludingThisOutputNotSupported(
                     "Cannot add Tracing output kind to a Println output kind. It".to_string(),
                 )),
                 OutputKind::Tracing => Ok(self.clone()),
                 OutputKind::LogFile(f) => Ok(OutputKind::TracingAndToFile(f.clone())),
-                OutputKind::PrintlnAndToFile(_) => Err(Error::NotSupported(
+                OutputKind::PrintlnAndToFile(_) => Err(Error::IncludingThisOutputNotSupported(
                     "Cannot add Tracing output kind to a PrintlnAndToFile output kind. It"
                         .to_string(),
                 )),
@@ -825,7 +825,7 @@ impl OutputKind {
             _ => {
                 // OutputKinds other than Println or Tracing are not
                 // valid for combining with the current output kind here.
-                Err(Error::NotSupported("OutputKind::ensure_output must be called with a Println or Tracing other_output. Including other kinds".to_string()))
+                Err(Error::IncludingThisOutputNotSupported("OutputKind::ensure_output must be called with a Println or Tracing other_output. Including other kinds".to_string()))
             }
         }
     }

--- a/crates/spk-solve/src/io.rs
+++ b/crates/spk-solve/src/io.rs
@@ -754,7 +754,7 @@ impl OutputKind {
                     .expect(UNABLE_TO_WRITE_OUTPUT_MESSAGE);
                 file_lock
                     .write_all("\n".as_bytes())
-                    .expect("Unable to write solver output newline to file");
+                    .expect(UNABLE_TO_WRITE_OUTPUT_MESSAGE);
             }
             OutputKind::PrintlnAndToFile(f) => {
                 let mut file_lock = f.lock().expect(UNABLE_TO_GET_OUTPUT_FILE_LOCK);
@@ -796,7 +796,7 @@ impl OutputKind {
     /// output if any.
     ///
     /// This will error if any other output kind is given as the parameter.
-    fn include_output(&self, other_output: &OutputKind) -> Result<Self> {
+    fn include_output(self, other_output: &OutputKind) -> Result<Self> {
         match other_output {
             OutputKind::Println => match self {
                 OutputKind::Println => Ok(self.clone()),

--- a/crates/spk-solve/src/lib.rs
+++ b/crates/spk-solve/src/lib.rs
@@ -14,7 +14,12 @@ use std::sync::Arc;
 
 pub use error::{Error, Result};
 use graph::Graph;
-pub use io::{DecisionFormatter, DecisionFormatterBuilder, MultiSolverKind};
+pub use io::{
+    DecisionFormatter,
+    DecisionFormatterBuilder,
+    MultiSolverKind,
+    DEFAULT_SOLVER_RUN_FILE_PREFIX,
+};
 #[cfg(feature = "statsd")]
 pub use metrics::{
     get_metrics_client,

--- a/cspell.json
+++ b/cspell.json
@@ -270,6 +270,7 @@
     "Hasher",
     "helmignore",
     "HFSBQEYR",
+    "HHMMSS",
     "Howto",
     "HRESULT",
     "idents",


### PR DESCRIPTION
Adds `--output-to-dir <path>` flag for logging each solver's output to a separate file for each solver run, and the ` SPK_OUTPUT_TO_DIR` env avr. The output files will be put in the given path.

It extends the `OutputKind` enum to have entries that output to a file, or `println!` and a file, or `tracing!` and a file. The interface allows for anything with the `Write` trait (and some thread-safe/task required traits). The `Copy` trait was removed from the enum in favour of cloning while wrangling the tasks, threads, mutability, and task communication messages. Let me know if there's a better way to do this.

A method was added to the enum to allow the initial output kind, i.e. `Println` or `Tracing`, to be combined with an output to file enum entry. This is used to make things appear in the right places when a background solver finishes the solve first and needs to print the solve results for the user (`Installed Packages: ...`).

The solve output files are named with the date and time the solve started, and the name of the kind of solver,  e.g.
- `<path>`/`spk_solver_run_20240704_131234_12004596_Unchanged`
- `<path>`/`spk_solver_run_20240704_131234_23142152_All-Impossible-Checks`

The verbosity level is increased to at least 2 when `--output-to-dir ...` is used. This helps ensure the files contain enough solver information to be useful when debugging issues. This minimum verbosity level is configurable via `--output-to-dir-min-verbosity <n>` or the `SPK.SPK_OUTPUT_TO_DIR_MIN_VERBOSITY` env var).
