### PR TITLE
Stop using .completed file for renders

### DIFF
--- a/crates/spfs/src/storage/fs/hash_store.rs
+++ b/crates/spfs/src/storage/fs/hash_store.rs
@@ -137,7 +137,8 @@ impl FsHashStore {
             while let Some(name) = subdir.next_entry().await.map_err(|err| Error::StorageReadError("next_entry on hash store directory", entry.path(), err))? {
                 let digest_str = format!("{entry_filename}{}", name.file_name().to_string_lossy());
                 if digest_str.ends_with(".completed") {
-                    // We're operating on a renders store.
+                    // We're operating on a renders store. These files used to be created
+                    // to mark the render as completed before we used atomic renames.
                     continue;
                 }
 

--- a/crates/spfs/src/storage/fs/renderer_test.rs
+++ b/crates/spfs/src/storage/fs/renderer_test.rs
@@ -118,7 +118,7 @@ async fn test_render_manifest_with_repo(
         .await
         .unwrap();
     assert!(render.exists(), "render should be seen as existing");
-    assert!(was_render_completed(&render));
+    assert!(was_render_completed(&render).await);
     let rendered_manifest = tracking::compute_manifest(&render).await.unwrap();
     let diffs = tracking::compute_diff(&expected_manifest, &rendered_manifest);
     println!("DIFFS:");

--- a/crates/spfs/src/storage/fs/renderer_win.rs
+++ b/crates/spfs/src/storage/fs/renderer_win.rs
@@ -50,7 +50,7 @@ impl OpenFsRepository {
             None => return false,
         };
         let rendered_dir = renders.build_digest_path(&digest);
-        was_render_completed(rendered_dir)
+        was_render_completed(rendered_dir).await
     }
 
     pub fn iter_rendered_manifests<'db>(
@@ -105,7 +105,6 @@ impl OpenFsRepository {
             };
         }
 
-        unmark_render_completed(&dirpath).await?;
         open_perms_and_remove_all(&working_dirpath).await
     }
 
@@ -296,7 +295,7 @@ where
     ) -> Result<PathBuf> {
         let render_store = self.repo.render_store()?;
         let rendered_dirpath = render_store.renders.build_digest_path(&manifest.digest()?);
-        if was_render_completed(&rendered_dirpath) {
+        if was_render_completed(&rendered_dirpath).await {
             tracing::trace!(path = ?rendered_dirpath, "render already completed");
             return Ok(rendered_dirpath);
         }
@@ -347,7 +346,6 @@ where
             },
         }
 
-        mark_render_completed(&rendered_dirpath).await?;
         Ok(rendered_dirpath)
     }
 
@@ -402,60 +400,6 @@ pub async fn open_perms_and_remove_all(root: &Path) -> Result<()> {
     Ok(())
 }
 
-fn was_render_completed<P: AsRef<Path>>(render_path: P) -> bool {
-    let mut name = render_path
-        .as_ref()
-        .file_name()
-        .expect("must have a file name")
-        .to_os_string();
-    name.push(".completed");
-    let marker_path = render_path.as_ref().with_file_name(name);
-    marker_path.exists()
-}
-
-/// panics if the given path does not have a directory name
-async fn mark_render_completed<P: AsRef<Path>>(render_path: P) -> Result<()> {
-    let mut name = render_path
-        .as_ref()
-        .file_name()
-        .expect("must have a file name")
-        .to_os_string();
-    name.push(".completed");
-    let marker_path = render_path.as_ref().with_file_name(name);
-    // create if it doesn't exist but don't fail if it already exists (no exclusive open)
-    tokio::fs::OpenOptions::new()
-        .create(true)
-        .write(true)
-        .open(&marker_path)
-        .await
-        .map_err(|err| {
-            Error::StorageWriteError(
-                "open render completed marker path for write",
-                marker_path,
-                err,
-            )
-        })?;
-    Ok(())
-}
-
-async fn unmark_render_completed<P: AsRef<Path>>(render_path: P) -> Result<()> {
-    let mut name = render_path
-        .as_ref()
-        .file_name()
-        .expect("must have a file name")
-        .to_os_string();
-    name.push(".completed");
-    let marker_path = render_path.as_ref().with_file_name(name);
-    if let Err(err) = tokio::fs::remove_file(&marker_path).await {
-        match err.kind() {
-            std::io::ErrorKind::NotFound => Ok(()),
-            _ => Err(Error::StorageWriteError(
-                "remove file on render completed marker",
-                marker_path,
-                err,
-            )),
-        }
-    } else {
-        Ok(())
-    }
+async fn was_render_completed<P: AsRef<Path>>(render_path: P) -> bool {
+    tokio::fs::try_exists(render_path).await.unwrap_or_default()
 }


### PR DESCRIPTION
As per #673 we have been using atomic renames for renders for some time and so no longer have a purpose for these .completed marker files.

closes #673

FYI @dcookspi 