### PR TITLE
Use Cow to avoid annotation cloning

### DIFF
--- a/crates/spfs-cli/main/src/cmd_run.rs
+++ b/crates/spfs-cli/main/src/cmd_run.rs
@@ -11,7 +11,7 @@ use clap::{ArgGroup, Args};
 use miette::{miette, Context, IntoDiagnostic, Result};
 use spfs::graph::object::EncodingFormat;
 use spfs::prelude::*;
-use spfs::runtime::KeyValuePair;
+use spfs::runtime::KeyValuePairBuf;
 use spfs::storage::FromConfig;
 use spfs::tracking::EnvSpec;
 use spfs_cli_common as cli;
@@ -59,8 +59,8 @@ impl Annotation {
     /// the annotation related command line arguments. The same keys,
     /// and values, can appear multiple times in the list if specified
     /// multiple times in various command line arguments.
-    pub fn get_data(&self) -> Result<Vec<KeyValuePair>> {
-        let mut data: Vec<KeyValuePair> = Vec::new();
+    pub fn get_data(&self) -> Result<Vec<KeyValuePairBuf>> {
+        let mut data: Vec<KeyValuePairBuf> = Vec::new();
 
         for filename in self.annotation_file.iter() {
             let reader: Box<dyn io::Read> =
@@ -258,7 +258,7 @@ impl CmdRun {
                 for (key, value) in data.into_iter().rev() {
                     tracing::trace!("annotation being added: {key}: {value}");
                     runtime
-                        .add_annotation(key, value, config.filesystem.annotation_size_limit)
+                        .add_annotation(&key, &value, config.filesystem.annotation_size_limit)
                         .await?;
                 }
                 tracing::trace!(" with annotation: {:?}", runtime);

--- a/crates/spfs-proto/src/digest.rs
+++ b/crates/spfs-proto/src/digest.rs
@@ -88,7 +88,7 @@ impl Digest {
         self.0
     }
 
-    /// Create a digest from the provided bytes.
+    /// Create an owned digest from the provided bytes.
     ///
     /// The exact [`DIGEST_SIZE`] number of bytes must
     /// be given.
@@ -96,6 +96,21 @@ impl Digest {
         match digest_bytes.try_into() {
             Err(_err) => Err(Error::InvalidDigestLength(digest_bytes.len())),
             Ok(bytes) => Ok(Self(bytes)),
+        }
+    }
+
+    /// Create a digest reference from the provided bytes.
+    ///
+    /// The exact [`DIGEST_SIZE`] number of bytes must
+    /// be given.
+    pub fn from_bytes_shared(digest_bytes: &[u8]) -> Result<&Self> {
+        match digest_bytes.len() {
+            DIGEST_SIZE => unsafe {
+                // Safety: buffer must contain a valid digest. We just checked
+                // the length and any sequence of bytes is a valid digest.
+                Ok(flatbuffers::follow_cast_ref::<Digest>(digest_bytes, 0))
+            },
+            len => Err(Error::InvalidDigestLength(len)),
         }
     }
 

--- a/crates/spfs-proto/src/lib.rs
+++ b/crates/spfs-proto/src/lib.rs
@@ -6,8 +6,22 @@
 #![allow(unsafe_op_in_unsafe_fn)]
 #![allow(clippy::all)]
 
+use std::borrow::Cow;
+
 include!(concat!(env!("OUT_DIR"), "/spfs_generated.rs"));
 
 pub mod digest;
 
 pub use digest::{parse_digest, DIGEST_SIZE, EMPTY_DIGEST, NULL_DIGEST};
+
+impl From<Digest> for Cow<'static, Digest> {
+    fn from(value: Digest) -> Self {
+        Cow::Owned(value)
+    }
+}
+
+impl<'a> From<&'a Digest> for Cow<'a, Digest> {
+    fn from(value: &'a Digest) -> Self {
+        Cow::Borrowed(value)
+    }
+}

--- a/crates/spfs/src/check.rs
+++ b/crates/spfs/src/check.rs
@@ -394,10 +394,10 @@ where
         let res = match annotation.value() {
             AnnotationValue::String(_) => CheckAnnotationResult::InternalValue,
             AnnotationValue::Blob(d) => {
-                let blob = self.repo.read_blob(d).await?;
+                let blob = self.repo.read_blob(*d).await?;
                 let result = unsafe { self.check_blob(&blob).await? };
                 CheckAnnotationResult::Checked {
-                    digest: d,
+                    digest: *d,
                     result,
                     repaired: false,
                 }

--- a/crates/spfs/src/graph/annotation_test.rs
+++ b/crates/spfs/src/graph/annotation_test.rs
@@ -10,8 +10,7 @@ use crate::encoding;
 
 #[rstest]
 fn test_annotation_value_string() {
-    let value = String::from("value");
-    let string_value = AnnotationValue::String(value);
+    let string_value = AnnotationValue::string("value");
 
     assert!(string_value.is_string());
     assert!(!string_value.is_blob());
@@ -21,7 +20,7 @@ fn test_annotation_value_string() {
 fn test_annotation_value_blob() {
     let digest: Digest = encoding::EMPTY_DIGEST.into();
 
-    let blob_value = AnnotationValue::Blob(digest);
+    let blob_value = AnnotationValue::blob(digest);
 
     assert!(blob_value.is_blob());
     assert!(!blob_value.is_string());

--- a/crates/spfs/src/graph/layer_test.rs
+++ b/crates/spfs/src/graph/layer_test.rs
@@ -36,10 +36,7 @@ fn test_layer_encoding_annotation_only(
     config.storage.digest_strategy = write_digest_strategy;
     config.make_current().unwrap();
 
-    let expected = Layer::new_with_annotation(
-        "key".to_string(),
-        AnnotationValue::String("value".to_string()),
-    );
+    let expected = Layer::new_with_annotation("key", AnnotationValue::string("value"));
 
     let mut stream = Vec::new();
     match expected.encode(&mut stream) {
@@ -80,10 +77,7 @@ fn test_layer_encoding_manifest_and_annotations(
 
     let expected = Layer::new_with_manifest_and_annotations(
         encoding::EMPTY_DIGEST.into(),
-        vec![(
-            "key".to_string(),
-            AnnotationValue::String("value".to_string()),
-        )],
+        vec![("key", AnnotationValue::string("value"))],
     );
     println!("Expected: {:?}", expected);
 

--- a/crates/spfs/src/runtime/mod.rs
+++ b/crates/spfs/src/runtime/mod.rs
@@ -25,6 +25,7 @@ pub use storage::{
     Config,
     Data,
     KeyValuePair,
+    KeyValuePairBuf,
     LiveLayer,
     LiveLayerFile,
     MountBackend,

--- a/crates/spfs/src/runtime/storage_test.rs
+++ b/crates/spfs/src/runtime/storage_test.rs
@@ -211,10 +211,7 @@ async fn test_storage_runtime_with_annotation(
     // Test - insert data
     let key = "some_field".to_string();
     let value = "some value".to_string();
-    match runtime
-        .add_annotation(key.clone(), value.clone(), limit)
-        .await
-    {
+    match runtime.add_annotation(&key, &value, limit).await {
         Ok(_) if write_encoding_format == EncodingFormat::Legacy => {
             panic!("Writing annotations should fail when using EncodingFormat::Legacy")
         }
@@ -230,10 +227,7 @@ async fn test_storage_runtime_with_annotation(
 
     // Test - insert some more data
     let value2 = "some other value".to_string();
-    assert!(runtime
-        .add_annotation(key.clone(), value2, limit)
-        .await
-        .is_ok());
+    assert!(runtime.add_annotation(&key, &value2, limit).await.is_ok());
 
     // Test - retrieve data - the first inserted data should be the
     // what is retrieved because of how adding to the runtime stack
@@ -286,8 +280,7 @@ async fn test_storage_runtime_add_annotations_list(
     let key2 = "some_other_field".to_string();
     let value2 = "some other value".to_string();
 
-    let annotations: Vec<KeyValuePair> =
-        vec![(key.clone(), value.clone()), (key2.clone(), value2.clone())];
+    let annotations: Vec<KeyValuePair> = vec![(&key, &value), (&key2, &value2)];
 
     match runtime.add_annotations(annotations, limit).await {
         Ok(_) if write_encoding_format == EncodingFormat::Legacy => {
@@ -346,10 +339,10 @@ async fn test_storage_runtime_with_nested_annotation(
     );
 
     // make an annotation layer
-    let key = "some_field".to_string();
-    let value = "somevalue".to_string();
-    let annotation_value = AnnotationValue::String(value.clone());
-    let layer = Layer::new_with_annotation(key.clone(), annotation_value);
+    let key = "some_field";
+    let value = "somevalue";
+    let annotation_value = AnnotationValue::string(value);
+    let layer = Layer::new_with_annotation(key, annotation_value);
     match repo.write_object(&layer).await {
         Ok(_) if write_encoding_format == EncodingFormat::Legacy => {
             panic!("Writing annotations should fail when using EncodingFormat::Legacy")
@@ -385,10 +378,10 @@ async fn test_storage_runtime_with_nested_annotation(
 
     // Test - retrieve the data even though it is nested inside a
     // platform object in the runtime.
-    let result = runtime.annotation(&key).await.unwrap();
+    let result = runtime.annotation(key).await.unwrap();
     assert!(result.is_some());
 
-    assert!(value == *result.unwrap());
+    assert!(value == result.unwrap());
 }
 
 #[rstest(
@@ -424,13 +417,10 @@ async fn test_storage_runtime_with_annotation_all(
         .expect("failed to create runtime in storage");
 
     // Test - insert two distinct data values
-    let key = "some_field".to_string();
-    let value = "somevalue".to_string();
+    let key = "some_field";
+    let value = "somevalue";
 
-    match runtime
-        .add_annotation(key.clone(), value.clone(), limit)
-        .await
-    {
+    match runtime.add_annotation(key, value, limit).await {
         Ok(_) if write_encoding_format == EncodingFormat::Legacy => {
             panic!("Writing annotations should fail when using EncodingFormat::Legacy")
         }
@@ -444,12 +434,9 @@ async fn test_storage_runtime_with_annotation_all(
         }
     };
 
-    let key2 = "some_field2".to_string();
-    let value2 = "somevalue2".to_string();
-    assert!(runtime
-        .add_annotation(key2.clone(), value2.clone(), limit)
-        .await
-        .is_ok());
+    let key2 = "some_field2";
+    let value2 = "somevalue2";
+    assert!(runtime.add_annotation(key2, value2, limit).await.is_ok());
 
     // Test - get all the data back out
     if write_encoding_format == EncodingFormat::Legacy {
@@ -460,8 +447,8 @@ async fn test_storage_runtime_with_annotation_all(
 
     assert!(result.len() == 2);
     for (expected_key, expected_value) in [(key, value), (key2, value2)].iter() {
-        assert!(result.contains_key(expected_key));
-        match result.get(expected_key) {
+        assert!(result.contains_key(*expected_key));
+        match result.get(*expected_key) {
             Some(v) => {
                 assert!(v == expected_value);
             }
@@ -495,10 +482,10 @@ async fn test_storage_runtime_with_nested_annotation_all(
     );
 
     // make two distinct data values
-    let key = "some_field".to_string();
-    let value = "somevalue".to_string();
-    let annotation_value = AnnotationValue::String(value.clone());
-    let layer = Layer::new_with_annotation(key.clone(), annotation_value);
+    let key = "some_field";
+    let value = "somevalue";
+    let annotation_value = AnnotationValue::string(value);
+    let layer = Layer::new_with_annotation(key, annotation_value);
     match repo.write_object(&layer.clone()).await {
         Ok(_) if write_encoding_format == EncodingFormat::Legacy => {
             panic!("Writing annotations should fail when using EncodingFormat::Legacy")
@@ -513,10 +500,10 @@ async fn test_storage_runtime_with_nested_annotation_all(
         }
     };
 
-    let key2 = "some_field2".to_string();
-    let value2 = "somevalue2".to_string();
-    let annotation_value2 = AnnotationValue::String(value2.clone());
-    let layer2 = Layer::new_with_annotation(key2.clone(), annotation_value2);
+    let key2 = "some_field2";
+    let value2 = "somevalue2";
+    let annotation_value2 = AnnotationValue::string(value2);
+    let layer2 = Layer::new_with_annotation(key2, annotation_value2);
     repo.write_object(&layer2.clone()).await.unwrap();
 
     // make a platform with one annotation layer
@@ -550,8 +537,8 @@ async fn test_storage_runtime_with_nested_annotation_all(
     let result = runtime.all_annotations().await.unwrap();
     assert!(result.len() == 2);
     for (expected_key, expected_value) in [(key, value), (key2, value2)].iter() {
-        assert!(result.contains_key(expected_key));
-        match result.get(expected_key) {
+        assert!(result.contains_key(*expected_key));
+        match result.get(*expected_key) {
             Some(v) => {
                 assert!(v == expected_value);
             }

--- a/crates/spfs/src/sync.rs
+++ b/crates/spfs/src/sync.rs
@@ -392,13 +392,13 @@ where
         match annotation.value() {
             AnnotationValue::String(_) => Ok(SyncAnnotationResult::InternalValue),
             AnnotationValue::Blob(digest) => {
-                if !self.processed_digests.insert(digest) {
+                if !self.processed_digests.insert(*digest) {
                     return Ok(SyncAnnotationResult::Duplicate);
                 }
                 self.reporter.visit_annotation(&annotation);
-                let sync_result = self.sync_digest(digest).await?;
+                let sync_result = self.sync_digest(*digest).await?;
                 let res = SyncAnnotationResult::Synced {
-                    digest,
+                    digest: *digest,
                     result: Box::new(sync_result),
                 };
                 self.reporter.synced_annotation(&res);

--- a/crates/spk-exec/src/exec.rs
+++ b/crates/spk-exec/src/exec.rs
@@ -308,8 +308,8 @@ pub async fn setup_runtime(rt: &mut spfs::runtime::Runtime, solution: &Solution)
         let solve_data = serde_json::to_string(&solution.packages_to_solve_data())
             .map_err(|err| Error::String(err.to_string()))?;
         rt.add_annotation(
-            SPK_SOLVE_EXTRA_DATA_KEY.to_string(),
-            solve_data,
+            SPK_SOLVE_EXTRA_DATA_KEY,
+            &solve_data,
             spfs_config.filesystem.annotation_size_limit,
         )
         .await?;


### PR DESCRIPTION
Annotations are built into flatbuffers, which typically requires a copy from the source string into the buffer. Previously, we were cloning strings an additional time into the annotation builder/value structs which we can now avoid in most circumstances by using a Cow::Borrowed instance.

resolves #986 

requires additional spelling fixes from #1071