### PR TITLE
spk-convert-pip updates for handling open3d

### DIFF
--- a/packages/spk-convert-pip/requirements.txt
+++ b/packages/spk-convert-pip/requirements.txt
@@ -1,4 +1,5 @@
-pkginfo==1.7.0
+# 1.10.0 is the last version that supports python 3.7
+pkginfo==1.10.0
 packaging==20.9
 # 0.40.0 latest at time of writing but no implied requirement for exactly this
 # version.

--- a/packages/spk-convert-pip/spk-convert-pip
+++ b/packages/spk-convert-pip/spk-convert-pip
@@ -286,6 +286,7 @@ class PipImporter:
     def _process_package(
         self, requester: Requirement, info: pkginfo.Distribution
     ) -> List[Dict[str, Any]]:
+        assert info.name, "A package name is required"
         assert not info.requires, "No support for installation requirements"
         assert not info.requires_external, "No support for external requirements"
         assert not info.supported_platforms, "No support for supported platforms field"

--- a/packages/spk-convert-pip/spk-convert-pip.spk.yaml
+++ b/packages/spk-convert-pip/spk-convert-pip.spk.yaml
@@ -1,4 +1,4 @@
-pkg: spk-convert-pip/1.4.0
+pkg: spk-convert-pip/1.4.2
 api: v0/package
 build:
   script:


### PR DESCRIPTION
Extend the timeout for pip download and update pkginfo to fix the package name not getting set.