### PR TITLE
Remove imageworks-specific sentry configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4164,6 +4164,7 @@ dependencies = [
  "rstest 0.15.0",
  "serde",
  "serde_json",
+ "spfs",
  "thiserror",
  "tokio",
  "whoami",

--- a/crates/spfs/src/config.rs
+++ b/crates/spfs/src/config.rs
@@ -403,6 +403,26 @@ impl Default for Monitor {
     }
 }
 
+#[derive(Clone, Default, Debug, Deserialize, Serialize)]
+#[serde(default)]
+pub struct Sentry {
+    /// Sentry DSN
+    pub dsn: String,
+
+    /// Sentry environment
+    pub environment: Option<String>,
+
+    /// Environment variable name to use as sentry username, if set.
+    ///
+    /// This is useful in CI if the CI system has a variable that contains
+    /// the username of the person who triggered the build.
+    pub username_override_var: Option<String>,
+
+    /// Set the email address domain used to generate email addresses for
+    /// sentry events.
+    pub email_domain: Option<String>,
+}
+
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(default)]
 pub struct Config {
@@ -412,6 +432,7 @@ pub struct Config {
     pub remote: std::collections::HashMap<String, Remote>,
     pub fuse: Fuse,
     pub monitor: Monitor,
+    pub sentry: Sentry,
 }
 
 impl Config {

--- a/crates/spfs/src/lib.rs
+++ b/crates/spfs/src/lib.rs
@@ -83,4 +83,5 @@ pub use self::config::{
     Config,
     RemoteAddress,
     RemoteConfig,
+    Sentry,
 };

--- a/crates/spk-cli/common/src/env.rs
+++ b/crates/spk-cli/common/src/env.rs
@@ -234,6 +234,11 @@ pub fn configure_sentry() -> Option<sentry::ClientInitGuard> {
 
     sentry::configure_scope(|scope| {
         scope.set_user(Some(sentry::User {
+            email: config
+                .sentry
+                .email_domain
+                .as_ref()
+                .map(|domain| format!("{username}@{domain}")),
             username: Some(username),
             ..Default::default()
         }));

--- a/crates/spk-config/Cargo.toml
+++ b/crates/spk-config/Cargo.toml
@@ -15,6 +15,7 @@ config = { workspace = true }
 dirs = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+spfs = { workspace = true }
 once_cell = { workspace = true }
 thiserror = { workspace = true }
 miette = { workspace = true }

--- a/crates/spk-config/src/config.rs
+++ b/crates/spk-config/src/config.rs
@@ -7,6 +7,7 @@ use std::sync::{Arc, RwLock};
 use config::Environment;
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
+use spfs::Sentry;
 
 use crate::Result;
 
@@ -15,22 +16,6 @@ use crate::Result;
 mod config_test;
 
 static CONFIG: OnceCell<RwLock<Arc<Config>>> = OnceCell::new();
-
-#[derive(Clone, Default, Debug, Deserialize, Serialize)]
-#[serde(default)]
-pub struct Sentry {
-    /// Sentry DSN
-    pub dsn: String,
-
-    /// Sentry environment
-    pub environment: Option<String>,
-
-    /// Environment variable name to use as sentry username, if set.
-    ///
-    /// This is useful in CI if the CI system has a variable that contains
-    /// the username of the person who triggered the build.
-    pub username_override_var: Option<String>,
-}
 
 #[derive(Clone, Default, Debug, Deserialize, Serialize)]
 #[serde(default)]


### PR DESCRIPTION
Relocate the `Sentry` config type to the spfs crate so it can be reused.

Expect sentry configuration to exist in both the spfs and spk configs (the sentry configuration can be different DSNs between spfs and spk).