### PR TITLE
Fix deprecation warnings in latest cargo version

### DIFF
--- a/crates/spfs-encoding/Cargo.toml
+++ b/crates/spfs-encoding/Cargo.toml
@@ -16,5 +16,5 @@ thiserror = { workspace = true }
 miette = { workspace = true }
 
 [dev-dependencies]
-rstest = { version = "0.15.0", default_features = false }
+rstest = { version = "0.15.0", default-features = false }
 rand = { workspace = true }

--- a/crates/spfs-proto/Cargo.toml
+++ b/crates/spfs-proto/Cargo.toml
@@ -23,4 +23,4 @@ flatc-rust = "0.2"
 
 [dev-dependencies]
 ring = { workspace = true }
-rstest = { version = "0.15.0", default_features = false }
+rstest = { version = "0.15.0", default-features = false }

--- a/crates/spfs/Cargo.toml
+++ b/crates/spfs/Cargo.toml
@@ -109,7 +109,7 @@ tonic-build = { workspace = true }
 
 [dev-dependencies]
 criterion = { version = "0.3", features = ["async_tokio", "html_reports"] }
-rstest = { version = "0.15.0", default_features = false }
+rstest = { version = "0.15.0", default-features = false }
 serial_test = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 static_assertions = { workspace = true }

--- a/crates/spk-schema/Cargo.toml
+++ b/crates/spk-schema/Cargo.toml
@@ -14,7 +14,7 @@ migration-to-components = ["spk-schema-foundation/migration-to-components"]
 data-encoding = "2.3"
 dunce = { workspace = true }
 enum_dispatch = "0.3.8"
-format_serde_error = { version = "0.3", default_features = false, features = [
+format_serde_error = { version = "0.3", default-features = false, features = [
     "serde_yaml",
     "colored",
 ] }

--- a/crates/spk-schema/crates/foundation/Cargo.toml
+++ b/crates/spk-schema/crates/foundation/Cargo.toml
@@ -18,7 +18,7 @@ arc-swap = { workspace = true }
 colored = { workspace = true }
 data-encoding = "2.3"
 enum_dispatch = "0.3.8"
-format_serde_error = { version = "0.3", default_features = false, features = [
+format_serde_error = { version = "0.3", default-features = false, features = [
     "serde_yaml",
     "colored",
 ] }

--- a/crates/spk-schema/crates/ident/Cargo.toml
+++ b/crates/spk-schema/crates/ident/Cargo.toml
@@ -12,7 +12,7 @@ migration-to-components = ["spk-schema-foundation/migration-to-components"]
 
 [dependencies]
 colored = { workspace = true }
-format_serde_error = { version = "0.3", default_features = false, features = [
+format_serde_error = { version = "0.3", default-features = false, features = [
     "serde_yaml",
     "colored",
 ] }

--- a/crates/spk-storage/Cargo.toml
+++ b/crates/spk-storage/Cargo.toml
@@ -18,7 +18,7 @@ colored = { workspace = true }
 dashmap = "5.4.0"
 data-encoding = "2.3.0"
 enum_dispatch = "0.3.8"
-format_serde_error = { version = "0.3", default_features = false, features = [
+format_serde_error = { version = "0.3", default-features = false, features = [
     "serde_yaml",
     "colored",
 ] }


### PR DESCRIPTION
Apparently this spelling is going away