### PR TITLE
Changes needed for using Rust 1.80

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.78.0
+          toolchain: 1.80.0
           target: x86_64-pc-windows-gnu
           override: true
       - name: Prepare VM
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     container:
-      image: rust:1.78.0
+      image: rust:1.80.0
       options: --security-opt seccomp=unconfined --privileged
     env:
       # Disable cnproc because we're in a container

--- a/.site/spi/.spdev.yaml
+++ b/.site/spi/.spdev.yaml
@@ -6,7 +6,7 @@ release_notes: |
 
 toolchain:
   - kind: Rust
-    toolchain: 1.78.0
+    toolchain: 1.80.0
     additional_toolchains:
       - nightly
   - kind: Shell

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,9 +235,9 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.9",
+ "http-body 0.4.5",
+ "hyper 0.14.27",
  "itoa",
  "matchit",
  "memchr",
@@ -246,7 +246,7 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "tower",
  "tower-layer",
  "tower-service",
@@ -261,8 +261,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.9",
+ "http-body 0.4.5",
  "mime",
  "rustversion",
  "tower-layer",
@@ -298,6 +298,12 @@ name = "base64"
 version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bindgen"
@@ -1115,15 +1121,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "enum_dispatch"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1443,7 +1440,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.9",
  "indexmap 2.2.3",
  "slab",
  "tokio",
@@ -1517,13 +1514,13 @@ dependencies = [
 
 [[package]]
 name = "hostname"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+checksum = "f9c7c7c8ac16c798734b8a24560c1362120597c40d5e1459f09498f8f6c8f2ba"
 dependencies = [
+ "cfg-if",
  "libc",
- "match_cfg",
- "winapi 0.3.9",
+ "windows 0.52.0",
 ]
 
 [[package]]
@@ -1538,13 +1535,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.9",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1580,8 +1611,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 0.2.9",
+ "http-body 0.4.5",
  "httparse",
  "httpdate",
  "itoa",
@@ -1594,12 +1625,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper",
+ "hyper 0.14.27",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -1607,15 +1657,38 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
- "hyper",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-util",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "hyper 1.4.1",
+ "pin-project-lite",
+ "socket2 0.5.5",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1629,7 +1702,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.51.1",
 ]
 
 [[package]]
@@ -1883,12 +1956,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
-name = "match_cfg"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
-
-[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2065,6 +2132,12 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-format"
@@ -2823,20 +2896,21 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.22"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
+checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
- "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
  "hyper-tls",
+ "hyper-util",
  "ipnet",
  "js-sys",
  "log",
@@ -2845,10 +2919,11 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "system-configuration",
+ "sync_wrapper 1.0.1",
  "tokio",
  "tokio-native-tls",
  "tower-service",
@@ -2879,7 +2954,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
- "base64",
+ "base64 0.21.5",
  "bitflags 2.4.1",
  "serde",
  "serde_derive",
@@ -2984,6 +3059,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+dependencies = [
+ "base64 0.22.1",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+
+[[package]]
 name = "rustversion"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3077,45 +3168,45 @@ checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "sentry"
-version = "0.32.2"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "766448f12e44d68e675d5789a261515c46ac6ccd240abdd451a9c46c84a49523"
+checksum = "5484316556650182f03b43d4c746ce0e3e48074a21e2f51244b648b6542e1066"
 dependencies = [
  "httpdate",
  "native-tls",
  "reqwest",
  "sentry-backtrace",
  "sentry-contexts",
- "sentry-core",
+ "sentry-core 0.34.0",
  "sentry-panic",
- "sentry-tracing",
+ "sentry-tracing 0.34.0",
  "tokio",
  "ureq",
 ]
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.32.2"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32701cad8b3c78101e1cd33039303154791b0ff22e7802ed8cc23212ef478b45"
+checksum = "40aa225bb41e2ec9d7c90886834367f560efc1af028f1c5478a6cce6a59c463a"
 dependencies = [
  "backtrace",
  "once_cell",
  "regex",
- "sentry-core",
+ "sentry-core 0.34.0",
 ]
 
 [[package]]
 name = "sentry-contexts"
-version = "0.32.2"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ddd2a91a13805bd8dab4ebf47323426f758c35f7bf24eacc1aded9668f3824"
+checksum = "1a8dd746da3d16cb8c39751619cefd4fcdbd6df9610f3310fd646b55f6e39910"
 dependencies = [
  "hostname",
  "libc",
  "os_info",
  "rustc_version",
- "sentry-core",
+ "sentry-core 0.34.0",
  "uname",
 ]
 
@@ -3127,7 +3218,20 @@ checksum = "b1189f68d7e7e102ef7171adf75f83a59607fafd1a5eecc9dc06c026ff3bdec4"
 dependencies = [
  "once_cell",
  "rand",
- "sentry-types",
+ "sentry-types 0.32.2",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "sentry-core"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "161283cfe8e99c8f6f236a402b9ccf726b201f365988b5bb637ebca0abbd4a30"
+dependencies = [
+ "once_cell",
+ "rand",
+ "sentry-types 0.34.0",
  "serde",
  "serde_json",
 ]
@@ -3138,16 +3242,17 @@ version = "0.1.0"
 dependencies = [
  "miette",
  "sentry",
+ "time",
 ]
 
 [[package]]
 name = "sentry-panic"
-version = "0.32.2"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1c18d0b5fba195a4950f2f4c31023725c76f00aabb5840b7950479ece21b5ca"
+checksum = "bc74f229c7186dd971a9491ffcbe7883544aa064d1589bd30b83fb856cd22d63"
 dependencies = [
  "sentry-backtrace",
- "sentry-core",
+ "sentry-core 0.34.0",
 ]
 
 [[package]]
@@ -3156,8 +3261,19 @@ version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3012699a9957d7f97047fd75d116e22d120668327db6e7c59824582e16e791b2"
 dependencies = [
+ "sentry-core 0.32.2",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "sentry-tracing"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c5faf2103cd01eeda779ea439b68c4ee15adcdb16600836e97feafab362ec"
+dependencies = [
  "sentry-backtrace",
- "sentry-core",
+ "sentry-core 0.34.0",
  "tracing-core",
  "tracing-subscriber",
 ]
@@ -3167,6 +3283,23 @@ name = "sentry-types"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7173fd594569091f68a7c37a886e202f4d0c1db1e1fa1d18a051ba695b2e2ec"
+dependencies = [
+ "debugid",
+ "hex",
+ "rand",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "time",
+ "url",
+ "uuid 1.5.0",
+]
+
+[[package]]
+name = "sentry-types"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d68cdf6bc41b8ff3ae2a9c4671e97426dcdd154cc1d4b6b72813f285d6b163f"
 dependencies = [
  "debugid",
  "hex",
@@ -3462,7 +3595,7 @@ dependencies = [
  "futures-core",
  "gitignore",
  "glob",
- "hyper",
+ "hyper 0.14.27",
  "indicatif",
  "itertools 0.10.5",
  "libc",
@@ -3510,7 +3643,7 @@ dependencies = [
  "uuid 1.5.0",
  "walkdir",
  "whoami",
- "windows",
+ "windows 0.51.1",
 ]
 
 [[package]]
@@ -3539,7 +3672,7 @@ dependencies = [
  "once_cell",
  "sentry",
  "sentry-miette",
- "sentry-tracing",
+ "sentry-tracing 0.32.2",
  "serde_json",
  "serde_yaml 0.9.27",
  "spfs",
@@ -3605,7 +3738,7 @@ dependencies = [
  "colored",
  "dunce",
  "futures",
- "hyper",
+ "hyper 0.14.27",
  "itertools 0.10.5",
  "libc",
  "miette",
@@ -3626,7 +3759,7 @@ dependencies = [
  "tracing",
  "unix_mode",
  "url",
- "windows",
+ "windows 0.51.1",
 ]
 
 [[package]]
@@ -3676,7 +3809,7 @@ dependencies = [
  "tower",
  "tracing",
  "url",
- "windows",
+ "windows 0.51.1",
  "winfsp",
  "winfsp-sys",
 ]
@@ -3731,7 +3864,7 @@ dependencies = [
  "tonic-build",
  "tracing",
  "url",
- "windows",
+ "windows 0.51.1",
  "winfsp",
  "winfsp-sys",
 ]
@@ -3825,7 +3958,7 @@ dependencies = [
  "once_cell",
  "rstest 0.18.2",
  "sentry",
- "sentry-tracing",
+ "sentry-tracing 0.32.2",
  "serde_json",
  "serde_yaml 0.9.27",
  "spfs",
@@ -4612,6 +4745,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+
+[[package]]
 name = "sys-info"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4630,27 +4769,6 @@ dependencies = [
  "libc",
  "tracing-core",
  "tracing-subscriber",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -4761,12 +4879,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.30"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
+ "num-conv",
  "powerfmt",
  "serde",
  "time-core",
@@ -4781,10 +4900,11 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.15"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 
@@ -4951,12 +5071,12 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64",
+ "base64 0.21.5",
  "bytes",
  "h2",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.9",
+ "http-body 0.4.5",
+ "hyper 0.14.27",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -5254,7 +5374,7 @@ version = "2.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11f214ce18d8b2cbe84ed3aa6486ed3f5b285cf8d8fbdbce9f3f767a724adc35"
 dependencies = [
- "base64",
+ "base64 0.21.5",
  "log",
  "native-tls",
  "once_cell",
@@ -5554,8 +5674,18 @@ version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca229916c5ee38c2f2bc1e9d8f04df975b4bd93f9955dc69fabb5d91270045c9"
 dependencies = [
- "windows-core",
+ "windows-core 0.51.1",
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core 0.52.0",
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -5565,6 +5695,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -5710,7 +5849,7 @@ dependencies = [
  "static_assertions",
  "thiserror",
  "widestring",
- "windows",
+ "windows 0.51.1",
  "winfsp-sys",
 ]
 
@@ -5735,9 +5874,9 @@ dependencies = [
 
 [[package]]
 name = "winreg"
-version = "0.50.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ regex = "1.6"
 relative-path = "1.3"
 ring = "0.17.7"
 rstest = "0.18.2"
-sentry = { version = "0.32.2", default-features = false, features = [
+sentry = { version = "0.34.0", default-features = false, features = [
     # all the default features except `debug-images` which causes a deadlock on
     # centos 7: https://github.com/getsentry/sentry-rust/issues/358
     "backtrace",

--- a/crates/sentry-miette/Cargo.toml
+++ b/crates/sentry-miette/Cargo.toml
@@ -6,4 +6,8 @@ version = "0.1.0"
 
 [dependencies]
 miette = { workspace = true }
+# Pick up a fix for compiling in Rust 1.80.
+# https://github.com/time-rs/time/issues/693
+# This is a transitive dependency of sentry.
+time = "0.3.36"
 sentry = { workspace = true }

--- a/crates/spfs/src/graph/annotation.rs
+++ b/crates/spfs/src/graph/annotation.rs
@@ -92,18 +92,14 @@ impl<'a> AnnotationValue<'a> {
     }
 
     /// Note: This is used for legacy and new style digest calculations
-    pub fn legacy_encode(&self, mut writer: &mut impl std::io::Write) -> Result<()> {
+    pub fn legacy_encode(&self, writer: &mut impl std::io::Write) -> Result<()> {
         match self {
             AnnotationValue::String(v) => {
-                // Clippy doesn't realize `writer` can't be moved here.
-                #[allow(clippy::needless_borrows_for_generic_args)]
-                encoding::write_uint8(&mut writer, AnnotationValueKind::String as u8)?;
+                encoding::write_uint8(&mut *writer, AnnotationValueKind::String as u8)?;
                 Ok(encoding::write_string(writer, v)?)
             }
             AnnotationValue::Blob(v) => {
-                // Clippy doesn't realize `writer` can't be moved here.
-                #[allow(clippy::needless_borrows_for_generic_args)]
-                encoding::write_uint8(&mut writer, AnnotationValueKind::Blob as u8)?;
+                encoding::write_uint8(&mut *writer, AnnotationValueKind::Blob as u8)?;
                 Ok(encoding::write_digest(writer, v)?)
             }
         }
@@ -191,9 +187,7 @@ impl<'buf> Annotation<'buf> {
 
     // Note: This is used for legacy and new style digest calculations
     pub fn legacy_encode(&self, mut writer: &mut impl std::io::Write) -> Result<()> {
-        // Clippy doesn't realize `writer` can't be moved here.
-        #[allow(clippy::needless_borrows_for_generic_args)]
-        encoding::write_string(&mut writer, self.key())?;
+        encoding::write_string(&mut *writer, self.key())?;
         self.value().legacy_encode(&mut writer)?;
         Ok(())
     }

--- a/crates/spfs/src/graph/annotation.rs
+++ b/crates/spfs/src/graph/annotation.rs
@@ -95,10 +95,14 @@ impl<'a> AnnotationValue<'a> {
     pub fn legacy_encode(&self, mut writer: &mut impl std::io::Write) -> Result<()> {
         match self {
             AnnotationValue::String(v) => {
+                // Clippy doesn't realize `writer` can't be moved here.
+                #[allow(clippy::needless_borrows_for_generic_args)]
                 encoding::write_uint8(&mut writer, AnnotationValueKind::String as u8)?;
                 Ok(encoding::write_string(writer, v)?)
             }
             AnnotationValue::Blob(v) => {
+                // Clippy doesn't realize `writer` can't be moved here.
+                #[allow(clippy::needless_borrows_for_generic_args)]
                 encoding::write_uint8(&mut writer, AnnotationValueKind::Blob as u8)?;
                 Ok(encoding::write_digest(writer, v)?)
             }
@@ -187,6 +191,8 @@ impl<'buf> Annotation<'buf> {
 
     // Note: This is used for legacy and new style digest calculations
     pub fn legacy_encode(&self, mut writer: &mut impl std::io::Write) -> Result<()> {
+        // Clippy doesn't realize `writer` can't be moved here.
+        #[allow(clippy::needless_borrows_for_generic_args)]
         encoding::write_string(&mut writer, self.key())?;
         self.value().legacy_encode(&mut writer)?;
         Ok(())

--- a/crates/spfs/src/graph/blob.rs
+++ b/crates/spfs/src/graph/blob.rs
@@ -49,10 +49,8 @@ impl Blob {
         self.proto().size_()
     }
 
-    pub(super) fn legacy_encode(&self, mut writer: &mut impl std::io::Write) -> Result<()> {
-        // Clippy doesn't realize `writer` can't be moved here.
-        #[allow(clippy::needless_borrows_for_generic_args)]
-        encoding::write_digest(&mut writer, self.payload())?;
+    pub(super) fn legacy_encode(&self, writer: &mut impl std::io::Write) -> Result<()> {
+        encoding::write_digest(&mut *writer, self.payload())?;
         encoding::write_uint64(writer, self.size())?;
         Ok(())
     }
@@ -133,11 +131,9 @@ impl BlobBuilder {
 
     /// Read a data encoded using the legacy format, and
     /// use the data to fill and complete this builder
-    pub fn legacy_decode(self, mut reader: &mut impl std::io::Read) -> Result<Blob> {
-        // Clippy doesn't realize `reader` can't be moved here.
-        #[allow(clippy::needless_borrows_for_generic_args)]
+    pub fn legacy_decode(self, reader: &mut impl std::io::Read) -> Result<Blob> {
         Ok(self
-            .with_payload(encoding::read_digest(&mut reader)?)
+            .with_payload(encoding::read_digest(&mut *reader)?)
             .with_size(encoding::read_uint64(reader)?)
             .build())
     }

--- a/crates/spfs/src/graph/blob.rs
+++ b/crates/spfs/src/graph/blob.rs
@@ -50,6 +50,8 @@ impl Blob {
     }
 
     pub(super) fn legacy_encode(&self, mut writer: &mut impl std::io::Write) -> Result<()> {
+        // Clippy doesn't realize `writer` can't be moved here.
+        #[allow(clippy::needless_borrows_for_generic_args)]
         encoding::write_digest(&mut writer, self.payload())?;
         encoding::write_uint64(writer, self.size())?;
         Ok(())
@@ -132,6 +134,8 @@ impl BlobBuilder {
     /// Read a data encoded using the legacy format, and
     /// use the data to fill and complete this builder
     pub fn legacy_decode(self, mut reader: &mut impl std::io::Read) -> Result<Blob> {
+        // Clippy doesn't realize `reader` can't be moved here.
+        #[allow(clippy::needless_borrows_for_generic_args)]
         Ok(self
             .with_payload(encoding::read_digest(&mut reader)?)
             .with_size(encoding::read_uint64(reader)?)

--- a/crates/spfs/src/graph/entry.rs
+++ b/crates/spfs/src/graph/entry.rs
@@ -180,6 +180,8 @@ impl<'buf> encoding::Digestible for Entry<'buf> {
 }
 
 impl<'buf> Entry<'buf> {
+    // Clippy doesn't realize `writer` can't be moved here.
+    #[allow(clippy::needless_borrows_for_generic_args)]
     pub(super) fn digest_encode(&self, mut writer: &mut impl std::io::Write) -> Result<()> {
         encoding::write_digest(&mut writer, self.object())?;
         self.kind().encode(&mut writer)?;
@@ -189,6 +191,8 @@ impl<'buf> Entry<'buf> {
         Ok(())
     }
 
+    // Clippy doesn't realize `writer` can't be moved here.
+    #[allow(clippy::needless_borrows_for_generic_args)]
     pub(super) fn legacy_encode(&self, mut writer: &mut impl std::io::Write) -> Result<()> {
         encoding::write_digest(&mut writer, self.object())?;
         self.kind().encode(&mut writer)?;
@@ -198,6 +202,8 @@ impl<'buf> Entry<'buf> {
         Ok(())
     }
 
+    // Clippy doesn't realize `reader` can't be moved here.
+    #[allow(clippy::needless_borrows_for_generic_args)]
     pub(super) fn legacy_decode<'builder>(
         builder: &mut flatbuffers::FlatBufferBuilder<'builder>,
         mut reader: &mut impl BufRead,

--- a/crates/spfs/src/graph/layer.rs
+++ b/crates/spfs/src/graph/layer.rs
@@ -123,6 +123,8 @@ impl Layer {
         // Includes any annotations regardless of the EncodingFormat setting
         let annotations = self.annotations();
         let result = if let Some(manifest_digest) = self.manifest() {
+            // Clippy doesn't realize `writer` can't be moved here.
+            #[allow(clippy::needless_borrows_for_generic_args)]
             let manifest_result =
                 encoding::write_digest(&mut writer, manifest_digest).map_err(Error::Encoding);
             for entry in annotations {

--- a/crates/spfs/src/graph/layer.rs
+++ b/crates/spfs/src/graph/layer.rs
@@ -119,23 +119,21 @@ impl Layer {
         children
     }
 
-    pub(super) fn digest_encode(&self, mut writer: &mut impl std::io::Write) -> Result<()> {
+    pub(super) fn digest_encode(&self, writer: &mut impl std::io::Write) -> Result<()> {
         // Includes any annotations regardless of the EncodingFormat setting
         let annotations = self.annotations();
         let result = if let Some(manifest_digest) = self.manifest() {
-            // Clippy doesn't realize `writer` can't be moved here.
-            #[allow(clippy::needless_borrows_for_generic_args)]
             let manifest_result =
-                encoding::write_digest(&mut writer, manifest_digest).map_err(Error::Encoding);
+                encoding::write_digest(&mut *writer, manifest_digest).map_err(Error::Encoding);
             for entry in annotations {
                 let annotation: Annotation = entry.into();
-                annotation.legacy_encode(&mut writer)?;
+                annotation.legacy_encode(&mut *writer)?;
             }
             manifest_result
         } else if !annotations.is_empty() {
             for entry in annotations {
                 let annotation: Annotation = entry.into();
-                annotation.legacy_encode(&mut writer)?;
+                annotation.legacy_encode(&mut *writer)?;
             }
             Ok(())
         } else {

--- a/crates/spfs/src/graph/manifest.rs
+++ b/crates/spfs/src/graph/manifest.rs
@@ -156,9 +156,7 @@ impl Manifest {
         // this method encodes the root tree first, and does not
         // include it in the count of remaining trees since at least
         // one root is always required
-        // Clippy doesn't realize `writer` can't be moved here.
-        #[allow(clippy::needless_borrows_for_generic_args)]
-        encoding::write_uint64(&mut writer, self.proto().trees().len() as u64 - 1)?;
+        encoding::write_uint64(&mut *writer, self.proto().trees().len() as u64 - 1)?;
         // skip the root tree when saving the rest
         for tree in self.iter_trees().skip(1) {
             tree.digest_encode(writer)?;
@@ -171,9 +169,7 @@ impl Manifest {
         // this method encodes the root tree first, and does not
         // include it in the count of remaining trees since at least
         // one root is always required
-        // Clippy doesn't realize `writer` can't be moved here.
-        #[allow(clippy::needless_borrows_for_generic_args)]
-        encoding::write_uint64(&mut writer, self.proto().trees().len() as u64 - 1)?;
+        encoding::write_uint64(&mut *writer, self.proto().trees().len() as u64 - 1)?;
         // skip the root tree when saving the rest
         for tree in self.iter_trees().skip(1) {
             tree.legacy_encode(writer)?;
@@ -250,9 +246,7 @@ impl ManifestBuilder {
             // historically, the root tree was stored first an not included in the count
             // since it is an error to not have at least one root tree
             let root = Tree::legacy_decode(builder, &mut reader)?;
-            // Clippy doesn't realize `reader` can't be moved here.
-            #[allow(clippy::needless_borrows_for_generic_args)]
-            let num_trees = encoding::read_uint64(&mut reader)?;
+            let num_trees = encoding::read_uint64(&mut *reader)?;
             let mut trees = Vec::with_capacity(num_trees as usize + 1);
             trees.push(root);
             for _ in 0..num_trees {

--- a/crates/spfs/src/graph/manifest.rs
+++ b/crates/spfs/src/graph/manifest.rs
@@ -156,6 +156,8 @@ impl Manifest {
         // this method encodes the root tree first, and does not
         // include it in the count of remaining trees since at least
         // one root is always required
+        // Clippy doesn't realize `writer` can't be moved here.
+        #[allow(clippy::needless_borrows_for_generic_args)]
         encoding::write_uint64(&mut writer, self.proto().trees().len() as u64 - 1)?;
         // skip the root tree when saving the rest
         for tree in self.iter_trees().skip(1) {
@@ -169,6 +171,8 @@ impl Manifest {
         // this method encodes the root tree first, and does not
         // include it in the count of remaining trees since at least
         // one root is always required
+        // Clippy doesn't realize `writer` can't be moved here.
+        #[allow(clippy::needless_borrows_for_generic_args)]
         encoding::write_uint64(&mut writer, self.proto().trees().len() as u64 - 1)?;
         // skip the root tree when saving the rest
         for tree in self.iter_trees().skip(1) {
@@ -246,6 +250,8 @@ impl ManifestBuilder {
             // historically, the root tree was stored first an not included in the count
             // since it is an error to not have at least one root tree
             let root = Tree::legacy_decode(builder, &mut reader)?;
+            // Clippy doesn't realize `reader` can't be moved here.
+            #[allow(clippy::needless_borrows_for_generic_args)]
             let num_trees = encoding::read_uint64(&mut reader)?;
             let mut trees = Vec::with_capacity(num_trees as usize + 1);
             trees.push(root);

--- a/crates/spfs/src/graph/platform.rs
+++ b/crates/spfs/src/graph/platform.rs
@@ -55,32 +55,28 @@ impl Platform {
         self.iter_bottom_up().copied().collect()
     }
 
-    // Clippy doesn't realize `writer` can't be moved here.
-    #[allow(clippy::needless_borrows_for_generic_args)]
-    pub(super) fn digest_encode(&self, mut writer: &mut impl std::io::Write) -> Result<()> {
+    pub(super) fn digest_encode(&self, writer: &mut impl std::io::Write) -> Result<()> {
         // use a vec to know the name ahead of time and
         // avoid iterating the stack twice
         let digests = self.iter_bottom_up().collect::<Vec<_>>();
-        encoding::write_uint64(&mut writer, digests.len() as u64)?;
+        encoding::write_uint64(&mut *writer, digests.len() as u64)?;
         // for historical reasons, and to remain backward-compatible, platform
         // stacks are stored in reverse (top-down) order
         for digest in digests.into_iter().rev() {
-            encoding::write_digest(&mut writer, digest)?;
+            encoding::write_digest(&mut *writer, digest)?;
         }
         Ok(())
     }
 
-    // Clippy doesn't realize `writer` can't be moved here.
-    #[allow(clippy::needless_borrows_for_generic_args)]
-    pub(super) fn legacy_encode(&self, mut writer: &mut impl std::io::Write) -> Result<()> {
+    pub(super) fn legacy_encode(&self, writer: &mut impl std::io::Write) -> Result<()> {
         // use a vec to know the name ahead of time and
         // avoid iterating the stack twice
         let digests = self.iter_bottom_up().collect::<Vec<_>>();
-        encoding::write_uint64(&mut writer, digests.len() as u64)?;
+        encoding::write_uint64(&mut *writer, digests.len() as u64)?;
         // for historical reasons, and to remain backward-compatible, platform
         // stacks are stored in reverse (top-down) order
         for digest in digests.into_iter().rev() {
-            encoding::write_digest(&mut writer, digest)?;
+            encoding::write_digest(&mut *writer, digest)?;
         }
         Ok(())
     }
@@ -173,13 +169,11 @@ impl PlatformBuilder {
 
     /// Read a data encoded using the legacy format, and
     /// use the data to fill and complete this builder
-    // Clippy doesn't realize `reader` can't be moved here.
-    #[allow(clippy::needless_borrows_for_generic_args)]
-    pub fn legacy_decode(self, mut reader: &mut impl std::io::Read) -> Result<Platform> {
-        let num_layers = encoding::read_uint64(&mut reader)?;
+    pub fn legacy_decode(self, reader: &mut impl std::io::Read) -> Result<Platform> {
+        let num_layers = encoding::read_uint64(&mut *reader)?;
         let mut layers = Vec::with_capacity(num_layers as usize);
         for _ in 0..num_layers {
-            layers.push(encoding::read_digest(&mut reader)?);
+            layers.push(encoding::read_digest(&mut *reader)?);
         }
         // for historical reasons, and to remain backward-compatible, platform
         // stacks are stored in reverse (top-down) order

--- a/crates/spfs/src/graph/platform.rs
+++ b/crates/spfs/src/graph/platform.rs
@@ -55,6 +55,8 @@ impl Platform {
         self.iter_bottom_up().copied().collect()
     }
 
+    // Clippy doesn't realize `writer` can't be moved here.
+    #[allow(clippy::needless_borrows_for_generic_args)]
     pub(super) fn digest_encode(&self, mut writer: &mut impl std::io::Write) -> Result<()> {
         // use a vec to know the name ahead of time and
         // avoid iterating the stack twice
@@ -68,6 +70,8 @@ impl Platform {
         Ok(())
     }
 
+    // Clippy doesn't realize `writer` can't be moved here.
+    #[allow(clippy::needless_borrows_for_generic_args)]
     pub(super) fn legacy_encode(&self, mut writer: &mut impl std::io::Write) -> Result<()> {
         // use a vec to know the name ahead of time and
         // avoid iterating the stack twice
@@ -169,6 +173,8 @@ impl PlatformBuilder {
 
     /// Read a data encoded using the legacy format, and
     /// use the data to fill and complete this builder
+    // Clippy doesn't realize `reader` can't be moved here.
+    #[allow(clippy::needless_borrows_for_generic_args)]
     pub fn legacy_decode(self, mut reader: &mut impl std::io::Read) -> Result<Platform> {
         let num_layers = encoding::read_uint64(&mut reader)?;
         let mut layers = Vec::with_capacity(num_layers as usize);

--- a/crates/spfs/src/graph/tree.rs
+++ b/crates/spfs/src/graph/tree.rs
@@ -39,6 +39,8 @@ impl<'buf> Tree<'buf> {
 
     pub(super) fn digest_encode(&self, mut writer: &mut impl std::io::Write) -> Result<()> {
         let mut entries: Vec<_> = self.entries().collect();
+        // Clippy doesn't realize `writer` can't be moved here.
+        #[allow(clippy::needless_borrows_for_generic_args)]
         encoding::write_uint64(&mut writer, entries.len() as u64)?;
         // this is not the default sort mode for entries but
         // matches the existing compatible encoding order
@@ -51,6 +53,8 @@ impl<'buf> Tree<'buf> {
 
     pub(super) fn legacy_encode(&self, mut writer: &mut impl std::io::Write) -> Result<()> {
         let mut entries: Vec<_> = self.entries().collect();
+        // Clippy doesn't realize `writer` can't be moved here.
+        #[allow(clippy::needless_borrows_for_generic_args)]
         encoding::write_uint64(&mut writer, entries.len() as u64)?;
         // this is not the default sort mode for entries but
         // matches the existing compatible encoding order
@@ -66,6 +70,8 @@ impl<'buf> Tree<'buf> {
         mut reader: &mut impl BufRead,
     ) -> Result<flatbuffers::WIPOffset<spfs_proto::Tree<'builder>>> {
         let mut entries = Vec::new();
+        // Clippy doesn't realize `reader` can't be moved here.
+        #[allow(clippy::needless_borrows_for_generic_args)]
         let entry_count = encoding::read_uint64(&mut reader)?;
         for _ in 0..entry_count {
             entries.push(Entry::legacy_decode(builder, reader)?);

--- a/crates/spfs/src/graph/tree.rs
+++ b/crates/spfs/src/graph/tree.rs
@@ -37,11 +37,9 @@ impl<'buf> Tree<'buf> {
         self.entries().find(|entry| entry.name() == name.as_ref())
     }
 
-    pub(super) fn digest_encode(&self, mut writer: &mut impl std::io::Write) -> Result<()> {
+    pub(super) fn digest_encode(&self, writer: &mut impl std::io::Write) -> Result<()> {
         let mut entries: Vec<_> = self.entries().collect();
-        // Clippy doesn't realize `writer` can't be moved here.
-        #[allow(clippy::needless_borrows_for_generic_args)]
-        encoding::write_uint64(&mut writer, entries.len() as u64)?;
+        encoding::write_uint64(&mut *writer, entries.len() as u64)?;
         // this is not the default sort mode for entries but
         // matches the existing compatible encoding order
         entries.sort_unstable_by_key(|e| e.name());
@@ -51,11 +49,9 @@ impl<'buf> Tree<'buf> {
         Ok(())
     }
 
-    pub(super) fn legacy_encode(&self, mut writer: &mut impl std::io::Write) -> Result<()> {
+    pub(super) fn legacy_encode(&self, writer: &mut impl std::io::Write) -> Result<()> {
         let mut entries: Vec<_> = self.entries().collect();
-        // Clippy doesn't realize `writer` can't be moved here.
-        #[allow(clippy::needless_borrows_for_generic_args)]
-        encoding::write_uint64(&mut writer, entries.len() as u64)?;
+        encoding::write_uint64(&mut *writer, entries.len() as u64)?;
         // this is not the default sort mode for entries but
         // matches the existing compatible encoding order
         entries.sort_unstable_by_key(|e| e.name());
@@ -67,12 +63,10 @@ impl<'buf> Tree<'buf> {
 
     pub(super) fn legacy_decode<'builder>(
         builder: &mut flatbuffers::FlatBufferBuilder<'builder>,
-        mut reader: &mut impl BufRead,
+        reader: &mut impl BufRead,
     ) -> Result<flatbuffers::WIPOffset<spfs_proto::Tree<'builder>>> {
         let mut entries = Vec::new();
-        // Clippy doesn't realize `reader` can't be moved here.
-        #[allow(clippy::needless_borrows_for_generic_args)]
-        let entry_count = encoding::read_uint64(&mut reader)?;
+        let entry_count = encoding::read_uint64(&mut *reader)?;
         for _ in 0..entry_count {
             entries.push(Entry::legacy_decode(builder, reader)?);
         }

--- a/crates/spfs/src/tracking/manifest.rs
+++ b/crates/spfs/src/tracking/manifest.rs
@@ -365,7 +365,7 @@ impl<'m, T> Iterator for ManifestWalker<'m, T> {
                 if child.kind.is_tree() {
                     self.active_child = Some(
                         ManifestWalker::new(child)
-                            .with_prefix(&self.prefix.join(name))
+                            .with_prefix(self.prefix.join(name))
                             .into(),
                     );
                 }

--- a/crates/spfs/src/tracking/tag.rs
+++ b/crates/spfs/src/tracking/tag.rs
@@ -140,6 +140,8 @@ impl Digestible for Tag {
 impl Encodable for Tag {
     type Error = Error;
 
+    // Clippy doesn't realize `writer` can't be moved here.
+    #[allow(clippy::needless_borrows_for_generic_args)]
     fn encode(&self, mut writer: &mut impl std::io::Write) -> Result<()> {
         if let Some(org) = self.org.as_ref() {
             encoding::write_string(&mut writer, org)?;
@@ -156,6 +158,8 @@ impl Encodable for Tag {
 }
 
 impl encoding::Decodable for Tag {
+    // Clippy doesn't realize `reader` can't be moved here.
+    #[allow(clippy::needless_borrows_for_generic_args)]
     fn decode(mut reader: &mut impl BufRead) -> Result<Self> {
         let org = encoding::read_string(&mut reader)?;
         let org = match org.as_str() {

--- a/crates/spfs/src/tracking/tag.rs
+++ b/crates/spfs/src/tracking/tag.rs
@@ -140,26 +140,22 @@ impl Digestible for Tag {
 impl Encodable for Tag {
     type Error = Error;
 
-    // Clippy doesn't realize `writer` can't be moved here.
-    #[allow(clippy::needless_borrows_for_generic_args)]
-    fn encode(&self, mut writer: &mut impl std::io::Write) -> Result<()> {
+    fn encode(&self, writer: &mut impl std::io::Write) -> Result<()> {
         if let Some(org) = self.org.as_ref() {
-            encoding::write_string(&mut writer, org)?;
+            encoding::write_string(&mut *writer, org)?;
         } else {
-            encoding::write_string(&mut writer, "")?;
+            encoding::write_string(&mut *writer, "")?;
         }
-        encoding::write_string(&mut writer, &self.name)?;
-        encoding::write_digest(&mut writer, &self.target)?;
-        encoding::write_string(&mut writer, &self.user)?;
-        encoding::write_string(&mut writer, &self.time.to_rfc3339())?;
+        encoding::write_string(&mut *writer, &self.name)?;
+        encoding::write_digest(&mut *writer, &self.target)?;
+        encoding::write_string(&mut *writer, &self.user)?;
+        encoding::write_string(&mut *writer, &self.time.to_rfc3339())?;
         encoding::write_digest(writer, &self.parent)?;
         Ok(())
     }
 }
 
 impl encoding::Decodable for Tag {
-    // Clippy doesn't realize `reader` can't be moved here.
-    #[allow(clippy::needless_borrows_for_generic_args)]
     fn decode(mut reader: &mut impl BufRead) -> Result<Self> {
         let org = encoding::read_string(&mut reader)?;
         let org = match org.as_str() {
@@ -168,10 +164,10 @@ impl encoding::Decodable for Tag {
         };
         Ok(Tag {
             org,
-            name: encoding::read_string(&mut reader)?,
-            target: encoding::read_digest(&mut reader)?,
-            user: encoding::read_string(&mut reader)?,
-            time: DateTime::parse_from_rfc3339(&encoding::read_string(&mut reader)?)?.into(),
+            name: encoding::read_string(&mut *reader)?,
+            target: encoding::read_digest(&mut *reader)?,
+            user: encoding::read_string(&mut *reader)?,
+            time: DateTime::parse_from_rfc3339(&encoding::read_string(&mut *reader)?)?.into(),
             parent: encoding::read_digest(reader)?,
         })
     }

--- a/crates/spk-schema/src/spec.rs
+++ b/crates/spk-schema/src/spec.rs
@@ -195,7 +195,7 @@ impl TemplateExt for SpecTemplate {
             Ok(v) => v,
         };
 
-        let api = template_value.get(&serde_yaml::Value::String("api".to_string()));
+        let api = template_value.get(serde_yaml::Value::String("api".to_string()));
 
         if api.is_none() {
             tracing::warn!(
@@ -210,7 +210,7 @@ impl TemplateExt for SpecTemplate {
         };
 
         let pkg = template_value
-            .get(&serde_yaml::Value::String(name_field.to_string()))
+            .get(serde_yaml::Value::String(name_field.to_string()))
             .ok_or_else(|| {
                 crate::Error::String(format!(
                     "Missing {name_field} field in spec file: {file_path:?}"

--- a/crates/spk-storage/src/storage/spfs.rs
+++ b/crates/spk-storage/src/storage/spfs.rs
@@ -878,6 +878,8 @@ where
                     // [Re-]create embedded stubs.
                     if build.can_embed() {
                         let spec = self.read_package(&build).await?;
+                        // spec is not mutated
+                        #[allow(clippy::mutable_key_type)]
                         let providers = self.get_embedded_providers(&spec)?;
                         if !providers.is_empty() {
                             tracing::info!("Creating embedded stubs for {name}...");

--- a/cspell.json
+++ b/cspell.json
@@ -205,6 +205,7 @@
     "euid",
     "evenmoredata",
     "execv",
+    "execve",
     "execvp",
     "faccess",
     "fchmod",

--- a/rpmbuild.Dockerfile
+++ b/rpmbuild.Dockerfile
@@ -9,7 +9,7 @@ RUN yum install -y \
 
 RUN ln -s cmake3 /usr/bin/cmake
 # install rustup for the cargo tool and compile toolchain
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh /dev/stdin -y --default-toolchain=1.78.0
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh /dev/stdin -y --default-toolchain=1.80.0
 ENV PATH="${PATH}:/root/.cargo/bin"
 # install protobuf compiler (protoc command)
 ENV PB_REL="https://github.com/protocolbuffers/protobuf/releases"


### PR DESCRIPTION
This does not bump Rust to 1.80 yet but makes changes necessary to compile and pass lints. The `std::env` related changes may need a closer look, please refer to the individual commits.

Edit: I should mention that I did not want to add the `unsafe` keyword since I didn't think it could be justified as safe.