### PR TITLE
Allow building packages without an origin configured

### DIFF
--- a/crates/spfs/src/config.rs
+++ b/crates/spfs/src/config.rs
@@ -559,6 +559,17 @@ impl Config {
         ))
     }
 
+    /// Get a remote repository by name, returning None if it is not configured
+    pub async fn try_get_remote<S: AsRef<str>>(
+        &self,
+        remote_name: S,
+    ) -> Result<Option<storage::RepositoryHandle>> {
+        match self.get_remote(remote_name).await {
+            Err(crate::Error::UnknownRemoteName(_)) => Ok(None),
+            res => res.map(Some),
+        }
+    }
+
     /// Get a remote repository by name.
     pub async fn get_remote<S: AsRef<str>>(
         &self,


### PR DESCRIPTION
Replaces the default use of the origin repo with a check that only does so if it is actually configured. This will allow for building packages locally on a machine without first setting up a configuration file.

closes #1085 