### PR TITLE
update validation rules for gmp, gcc63 and gcc63

### DIFF
--- a/packages/gnu/gcc/gcc48.spk.yaml
+++ b/packages/gnu/gcc/gcc48.spk.yaml
@@ -43,10 +43,6 @@ build:
     - make install
     # no need to keep extra bloat files in info dir
     - spfs reset /spfs/share/info/**/*
-  validation:
-    disabled:
-      # we are replacing the old gcc version on purpose
-      - MustNotAlterExistingFiles
 
 tests:
   - stage: install

--- a/packages/gnu/gcc/gcc63.spk.yaml
+++ b/packages/gnu/gcc/gcc63.spk.yaml
@@ -41,9 +41,9 @@ build:
     # no need to keep extra bloat files in info dir
     - spfs reset /spfs/share/info/**/*
   validation:
-    disabled:
-      # we are replacing the old gcc version on purpose
-      - MustNotAlterExistingFiles
+    rules:
+      - allow: RecursiveBuild
+      - deny: AlterExistingFiles
 
 tests:
   - stage: install

--- a/packages/gnu/gcc/gcc63.spk.yaml
+++ b/packages/gnu/gcc/gcc63.spk.yaml
@@ -43,8 +43,6 @@ build:
   validation:
     rules:
       - allow: RecursiveBuild
-      - deny: AlterExistingFiles
-
 tests:
   - stage: install
     script:

--- a/packages/gnu/gcc/gcc63.spk.yaml
+++ b/packages/gnu/gcc/gcc63.spk.yaml
@@ -43,6 +43,7 @@ build:
   validation:
     rules:
       - allow: RecursiveBuild
+      - allow: AlterExistingFiles
 tests:
   - stage: install
     script:

--- a/packages/gnu/gcc/gcc93.spk.yaml
+++ b/packages/gnu/gcc/gcc93.spk.yaml
@@ -40,9 +40,7 @@ build:
     - make install
     # no need to keep extra bloat files in info dir
     - spfs reset /spfs/share/info/**/*
-  validation:
-    rules:
-      - deny: AlterExistingFiles
+
 
 tests:
   - stage: install

--- a/packages/gnu/gcc/gcc93.spk.yaml
+++ b/packages/gnu/gcc/gcc93.spk.yaml
@@ -41,9 +41,8 @@ build:
     # no need to keep extra bloat files in info dir
     - spfs reset /spfs/share/info/**/*
   validation:
-    disabled:
-      # we are replacing the old gcc version on purpose
-      - MustNotAlterExistingFiles
+    rules:
+      - deny: AlterExistingFiles
 
 tests:
   - stage: install

--- a/packages/gnu/gcc/gcc93.spk.yaml
+++ b/packages/gnu/gcc/gcc93.spk.yaml
@@ -40,7 +40,9 @@ build:
     - make install
     # no need to keep extra bloat files in info dir
     - spfs reset /spfs/share/info/**/*
-
+  validation:
+    rules:
+      - allow: AlterExistingFiles
 
 tests:
   - stage: install

--- a/packages/gnu/gmp.spk.yaml
+++ b/packages/gnu/gmp.spk.yaml
@@ -25,11 +25,9 @@ build:
     - make install
     # no need to keep these extra files around
     - spfs reset /spfs/share/info/**/*
-  validation:
-    disabled:
-      # gcc will pull in mpfr, which pulls in gmp,
-      # but we are going to replace that
-      - MustNotAlterExistingFiles
+ validation:
+    rules:
+      - deny: AlterExistingFiles
 
 tests:
   - stage: install

--- a/packages/gnu/gmp.spk.yaml
+++ b/packages/gnu/gmp.spk.yaml
@@ -25,6 +25,9 @@ build:
     - make install
     # no need to keep these extra files around
     - spfs reset /spfs/share/info/**/*
+  validation:
+    rules:
+      - allow: AlterExistingFiles
 
 tests:
   - stage: install

--- a/packages/gnu/gmp.spk.yaml
+++ b/packages/gnu/gmp.spk.yaml
@@ -25,9 +25,6 @@ build:
     - make install
     # no need to keep these extra files around
     - spfs reset /spfs/share/info/**/*
- validation:
-    rules:
-      - deny: AlterExistingFiles
 
 tests:
   - stage: install


### PR DESCRIPTION
This PR is meant to update the deprecated `validation` attribut `disable` for the following pckages

- packages/gnu/gmp.spk.yaml
- packages/gnu/gcc/gcc63.spk.yaml
- packages/gnu/gcc/gcc93.spk.yaml

and add `allow` `RecursiveBuild` validation for packages/gnu/gcc/gcc63.spk.yaml