### PR TITLE
Make 'Failed to resolve' solver result message clearer

### DIFF
--- a/crates/spk-solve/crates/graph/src/error.rs
+++ b/crates/spk-solve/crates/graph/src/error.rs
@@ -103,6 +103,9 @@ impl FormatError for Error {
         match self {
             Error::FailedToResolve(_graph) => {
                 // TODO: provide a summary based on the graph
+                msg.push_str(
+                    ": there is no solution for these requests using the available packages",
+                );
             }
             Error::SolverError(reason) => {
                 msg.push_str("\n * ");

--- a/crates/spk-solve/crates/graph/src/graph.rs
+++ b/crates/spk-solve/crates/graph/src/graph.rs
@@ -475,7 +475,7 @@ impl<'state, 'cmpt> DecisionBuilder<'state, 'cmpt> {
 }
 
 #[derive(Clone, Debug, Diagnostic, Error)]
-#[error("Failed to resolve")]
+#[error("Failed to resolve: there is no solution for these requests using the available packages")]
 pub struct Graph {
     pub root: Arc<tokio::sync::RwLock<Arc<Node>>>,
     pub nodes: HashMap<u64, Arc<tokio::sync::RwLock<Arc<Node>>>>,

--- a/crates/spk-solve/crates/validation/src/error.rs
+++ b/crates/spk-solve/crates/validation/src/error.rs
@@ -41,6 +41,9 @@ impl FormatError for Error {
         match self {
             Error::FailedToResolve(_graph) => {
                 // TODO: provide a summary based on the graph
+                msg.push_str(
+                    ": there is no solution for these requests using the available packages",
+                );
             }
             Error::SolverError(reason) => {
                 msg.push_str("\n * ");

--- a/crates/spk-solve/src/solver_test.rs
+++ b/crates/spk-solve/src/solver_test.rs
@@ -887,7 +887,7 @@ async fn test_solver_build_from_source_unsolvable(mut solver: Solver) {
         let msg = strip_ansi_escapes::strip(msg);
         let msg = String::from_utf8_lossy(&msg);
         msg.ends_with(
-            "TRY my-tool/1.2.0/src - cannot resolve build env for source build: Failed to resolve",
+            "TRY my-tool/1.2.0/src - cannot resolve build env for source build: Failed to resolve: there is no solution for these requests using the available packages",
         )
     });
     assert!(


### PR DESCRIPTION
This tries to make the current 'Failed to resolve' solver result message a bit clearer for users. 

spk outputs this when it can't find a solution after trying everything it can:
```
ERROR spk: (link)

  x Failed to resolve
```
This is a fairly rare "error". But recently people have been seeing this message and haven't understood what it means or what they can do to fix it. This doesn't address what they can do to fix it, It just tries to make the message clearer.

It changes the output to:
```
ERROR (link)

  x Failed to resolve: there is no solution for these requests using the available packages
```
