### PR TITLE
Update whoami to address vulerability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5522,6 +5522,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5611,11 +5617,12 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.4.1"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22fc3756b8a9133049b26c7f61ab35416c130e8c09b660f5b3958b446f52cc50"
+checksum = "a44ab49fad634e88f55bf8f9bb3abd2f27d7204172a112c7c9987e01c1c94ea9"
 dependencies = [
- "wasm-bindgen",
+ "redox_syscall 0.4.1",
+ "wasite",
  "web-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,7 +146,7 @@ tracing = "0.1.35"
 tracing-capture = "0.1"
 tracing-subscriber = "0.3.14"
 ulid = "1.0"
-whoami = "1.2"
+whoami = "1.5"
 windows = "0.51"
 winfsp = { version = "0.9.3", default-features = false }
 winfsp-sys = "0.2"

--- a/crates/spfs/src/config.rs
+++ b/crates/spfs/src/config.rs
@@ -63,14 +63,23 @@ static CONFIG: OnceCell<RwLock<Arc<Config>>> = OnceCell::new();
 #[serde(default)]
 pub struct User {
     pub name: String,
-    pub domain: String,
+    pub domain: Option<String>,
 }
 
 impl Default for User {
     fn default() -> Self {
         Self {
             name: whoami::username(),
-            domain: whoami::hostname(),
+            domain: whoami::fallible::hostname().ok(),
+        }
+    }
+}
+
+impl std::fmt::Display for User {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.domain {
+            Some(domain) => write!(f, "{}@{}", self.name, domain),
+            None => write!(f, "{}", self.name),
         }
     }
 }

--- a/crates/spfs/src/runtime/storage.rs
+++ b/crates/spfs/src/runtime/storage.rs
@@ -73,7 +73,8 @@ impl Default for Author {
     fn default() -> Self {
         Self {
             user_name: whoami::username(),
-            host_name: whoami::hostname(),
+            host_name: whoami::fallible::hostname()
+                .unwrap_or_else(|_| format!("unk-{}", ulid::Ulid::new())),
             created: chrono::Local::now(),
         }
     }

--- a/crates/spfs/src/tracking/tag.rs
+++ b/crates/spfs/src/tracking/tag.rs
@@ -41,7 +41,7 @@ impl Tag {
             name: spec.name(),
             target,
             parent: encoding::NULL_DIGEST.into(),
-            user: format!("{}@{}", config.user.name, config.user.domain),
+            user: format!("{}", config.user),
             time: Utc::now().trunc_subsecs(6), // ignore microseconds
         })
     }


### PR DESCRIPTION
https://github.com/spkenv/spk/security/dependabot/7

Err on the safe side and generate a unique hostname if it can't be determined (on the spfs side) so runtime pruning doesn't think two runtimes from different hosts that couldn't determine the hostname are from the same host.