### PR TITLE
Handle when multiple packages embed the same package

### DIFF
--- a/crates/spk-schema/crates/foundation/src/version/compat.rs
+++ b/crates/spk-schema/crates/foundation/src/version/compat.rs
@@ -90,6 +90,10 @@ impl Ord for CompatRule {
 /// Denotes whether or not something is compatible.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum IncompatibleReason {
+    AlreadyEmbeddedPackage {
+        embedded: PkgNameBuf,
+        embedded_by: PkgNameBuf,
+    },
     ConflictingEmbeddedPackage(PkgNameBuf),
     Other(String),
 }
@@ -97,6 +101,15 @@ pub enum IncompatibleReason {
 impl std::fmt::Display for IncompatibleReason {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
+            IncompatibleReason::AlreadyEmbeddedPackage {
+                embedded,
+                embedded_by,
+            } => {
+                write!(
+                    f,
+                    "embedded package {embedded} already embedded by another package in solve: {embedded_by}"
+                )
+            }
             IncompatibleReason::ConflictingEmbeddedPackage(pkg) => {
                 write!(
                     f,


### PR DESCRIPTION
The solver was panicking with "state not found" in the case where it encounters a package that embeds some other package, but that other package has already been embedded by some third package. It wanted to "eject" the real package (again) but no "real" package was in the solution at that point.

Now it checks that the package it wants to "eject" is a not an embedded package. This situation was given its own `IncompatibleReason` so the solver output will detail the packages involved.