### PR TITLE
Add repo name to 'opening repository' debug messages

### DIFF
--- a/crates/spfs/src/config.rs
+++ b/crates/spfs/src/config.rs
@@ -587,11 +587,19 @@ impl Config {
         match self.remote.get(remote_name.as_ref()) {
             Some(Remote::Address(remote)) => {
                 let config = RemoteConfig::from_address(remote.address.clone()).await?;
-                tracing::debug!(?config, "opening '{}' repository", remote_name.as_ref());
+                tracing::debug!(
+                    ?config,
+                    "opening '{}' repository via address",
+                    remote_name.as_ref()
+                );
                 config.open().await
             }
             Some(Remote::Config(config)) => {
-                tracing::debug!(?config, "opening '{}' repository", remote_name.as_ref());
+                tracing::debug!(
+                    ?config,
+                    "opening '{}' repository via config",
+                    remote_name.as_ref()
+                );
                 config.open().await
             }
             None => {

--- a/crates/spfs/src/config.rs
+++ b/crates/spfs/src/config.rs
@@ -587,11 +587,11 @@ impl Config {
         match self.remote.get(remote_name.as_ref()) {
             Some(Remote::Address(remote)) => {
                 let config = RemoteConfig::from_address(remote.address.clone()).await?;
-                tracing::debug!(?config, "opening repository");
+                tracing::debug!(?config, "opening '{}' repository", remote_name.as_ref());
                 config.open().await
             }
             Some(Remote::Config(config)) => {
-                tracing::debug!(?config, "opening repository");
+                tracing::debug!(?config, "opening '{}' repository", remote_name.as_ref());
                 config.open().await
             }
             None => {


### PR DESCRIPTION
This adds the repo's name to the 'opening repository ... ' debug messages to make each mesasge clearer. It can be tricky to work out which repo each message refers to when you have complicated multi-repo configurations.