### PR TITLE
Add `--allow-already-editable` flag to `spfs edit`

### DIFF
--- a/crates/spfs-cli/main/src/cmd_edit.rs
+++ b/crates/spfs-cli/main/src/cmd_edit.rs
@@ -38,9 +38,7 @@ impl CmdEdit {
         if !self.off {
             match spfs::make_active_runtime_editable().await {
                 Ok(_) => tracing::info!("edit mode enabled"),
-                Err(Error::RuntimeAlreadyEditable) => {
-                    return Ok(0);
-                }
+                Err(Error::RuntimeAlreadyEditable) => {}
                 Err(err) => {
                     return Err(err.into());
                 }

--- a/crates/spfs-cli/main/src/cmd_edit.rs
+++ b/crates/spfs-cli/main/src/cmd_edit.rs
@@ -4,6 +4,7 @@
 
 use clap::Args;
 use miette::Result;
+use spfs::Error;
 
 /// Make the current runtime editable
 #[derive(Debug, Args)]
@@ -37,15 +38,11 @@ impl CmdEdit {
         if !self.off {
             match spfs::make_active_runtime_editable().await {
                 Ok(_) => tracing::info!("edit mode enabled"),
+                Err(Error::RuntimeAlreadyEditable) => {
+                    return Ok(0);
+                }
                 Err(err) => {
-                    if self.keep_runtime {
-                        // When --keep-runtime was also given, being
-                        // already editable isn't an error, but still
-                        // want to tell the user about it
-                        tracing::info!("{err}")
-                    } else {
-                        return Err(err.into());
-                    }
+                    return Err(err.into());
                 }
             };
         } else {


### PR DESCRIPTION
This adds the `--allow-already-editable` flag to `spfs edit`. The flag stops `spfs edit` from exiting with an error code when the runtime environment it was run in is already editable. The allows scripts and other tools to use `spfs edit` without needing to handle the already edityable case as an error. 

Example,:
```
# Inside a runtime environment that is not editable to start with

# make it editable
> spfs edit

# without the new flag
> spfs edit
Error: (link)

  × Runtime is already editable

> echo $?
1

# with the new flag
> spfs edit --allow-already-editable
> echo $?
0
```