### PR TITLE
Adds support for parsing a comma-separated list of range idents

### DIFF
--- a/crates/spk-schema/crates/foundation/src/ident_ops/parsing/mod.rs
+++ b/crates/spk-schema/crates/foundation/src/ident_ops/parsing/mod.rs
@@ -67,7 +67,7 @@ where
         // package name instead of as a repository name.
         let r = version_parser
             .parse(input)
-            .and_then(|(input, _)| alt((tag("]"), eof::<&str, _>))(input));
+            .and_then(|(input, _)| alt((tag("]"), tag(","), eof::<&str, _>))(input));
         if r.is_ok() {
             return fail("could be version");
         }
@@ -80,7 +80,7 @@ where
         let r = version_and_build_parser
             .parse(input)
             .and_then(|(input, v_and_b)| {
-                alt((tag("]"), eof))(input).map(|(input, _)| (input, v_and_b))
+                alt((tag("]"), tag(","), eof))(input).map(|(input, _)| (input, v_and_b))
             });
         if let Ok((_, (_version, Some(_build)))) = r {
             return fail("could be a build");

--- a/crates/spk-schema/crates/foundation/src/version/version_test.rs
+++ b/crates/spk-schema/crates/foundation/src/version/version_test.rs
@@ -40,6 +40,9 @@ fn test_is_gt(#[case] base: &str, #[case] test: &str, #[case] expected: bool) {
 #[rstest]
 #[case("1.0.0", Version::new(1, 0, 0))]
 #[case("0.0.0", Version::new(0, 0, 0))]
+#[case("20.0.1", Version::new(20, 0, 1))]
+#[case("20.3.0", Version::new(20, 3, 0))]
+#[case("20.3.1", Version::new(20, 3, 1))]
 #[case("1.2.3.4.5.6", Version{
     parts: vec![1, 2, 3, 4, 5, 6].into(), ..Default::default()
 })]

--- a/crates/spk-schema/crates/ident/src/lib.rs
+++ b/crates/spk-schema/crates/ident/src/lib.rs
@@ -20,7 +20,7 @@ pub use ident_any::{parse_ident, AnyIdent, ToAnyWithoutBuild};
 pub use ident_build::{parse_build_ident, BuildIdent};
 pub use ident_located::{LocatedBuildIdent, LocatedVersionIdent};
 pub use ident_version::{parse_version_ident, VersionIdent};
-pub use range_ident::{parse_ident_range, RangeIdent};
+pub use range_ident::{parse_ident_range, parse_ident_range_list, RangeIdent};
 pub use request::{
     is_false,
     InclusionPolicy,

--- a/crates/spk-schema/crates/ident/src/parsing/mod.rs
+++ b/crates/spk-schema/crates/ident/src/parsing/mod.rs
@@ -10,4 +10,9 @@ mod request;
 mod parsing_test;
 
 pub use ident::{build_ident, ident, version_ident};
-pub use request::{range_ident, range_ident_version_filter, version_filter_and_build};
+pub use request::{
+    range_ident,
+    range_ident_comma_separated_list,
+    range_ident_version_filter,
+    version_filter_and_build,
+};

--- a/crates/spk-schema/crates/ident/src/parsing/parsing_test.rs
+++ b/crates/spk-schema/crates/ident/src/parsing/parsing_test.rs
@@ -425,7 +425,7 @@ prop_compose! {
         repo in arb_repo(),
         name in arb_pkg_legal_name(),
         components in arb_components(),
-        version_filter in  arb_opt_version_filter(),
+        version_filter in arb_opt_version_filter(),
         build in weighted(0.9, arb_non_embedded_build()),
     ) -> RangeIdent {
         // what about illegal ones?

--- a/crates/spk-schema/crates/ident/src/parsing/parsing_test.rs
+++ b/crates/spk-schema/crates/ident/src/parsing/parsing_test.rs
@@ -4,6 +4,7 @@
 
 use std::collections::{BTreeSet, HashSet};
 use std::convert::TryFrom;
+use std::iter::zip;
 use std::str::FromStr;
 
 use itertools::Itertools;
@@ -33,7 +34,7 @@ use spk_schema_foundation::version_range::{
     WildcardRange,
 };
 
-use crate::{parse_ident, AnyIdent, RangeIdent, VersionIdent};
+use crate::{parse_ident, parse_ident_range_list, AnyIdent, RangeIdent, VersionIdent};
 
 macro_rules! arb_version_range_struct {
     ($arb_name:ident, $type_name:ident, $($var:ident in $strategy:expr),+ $(,)?) => {
@@ -420,6 +421,89 @@ fn arb_build() -> impl Strategy<Value = Option<Build>> {
 }
 
 prop_compose! {
+    fn arb_range_ident()(
+        repo in arb_repo(),
+        name in arb_pkg_legal_name(),
+        components in arb_components(),
+        version_filter in  arb_opt_version_filter(),
+        build in weighted(0.9, arb_non_embedded_build()),
+    ) -> RangeIdent {
+        // what about illegal ones?
+        // arb_opt_legal_version(),
+
+        // If specifying a build, a version must also be specified
+        let b = if build.is_some() && version_filter.is_none() {
+            None
+        } else {
+            build
+        };
+
+        let version = version_filter.unwrap_or_default();
+
+        RangeIdent { repository_name: repo, name, components, version, build: b }
+        // TODO: return name_is_legal if don't turn this in to a legal
+    }
+}
+
+prop_compose! {
+    fn arb_valid_range_ident_list()(ri_list in vec(arb_range_ident(), 0..5)) -> Vec<RangeIdent> {
+        ri_list
+    }
+}
+
+prop_compose! {
+    fn arb_valid_range_ident_list_separator()(suffix in prop_oneof![","]) -> String {
+        suffix
+    }
+}
+
+prop_compose! {
+    fn arb_invalid_range_ident_list_separator()(suffix in prop_oneof![":", ";", ",,", "====", " ", "\t"]) -> String {
+        suffix
+    }
+}
+
+prop_compose! {
+    fn arb_valid_range_ident_list_suffix()(suffix in prop_oneof![""]) -> String {
+        suffix
+    }
+}
+
+prop_compose! {
+    fn arb_range_ident_list_suffix()(suffix in prop_oneof!["", ",", ",,", "====="]) -> String {
+        suffix
+    }
+}
+
+prop_compose! {
+    fn arb_valid_range_ident_as_string()(
+        range_ident in arb_range_ident()
+    ) -> String {
+        range_ident.to_string()
+    }
+}
+
+prop_compose! {
+    fn arb_invalid_range_ident_as_string()(
+        range_ident in arb_range_ident()
+    ) -> String {
+        format!("======{range_ident}======")
+    }
+}
+
+prop_compose! {
+    fn arb_invalid_range_ident_list()(mut range_ident_list in vec(prop_oneof![arb_valid_range_ident_as_string(), arb_invalid_range_ident_as_string(),], 1..5),
+                                      invalid_range_ident in arb_invalid_range_ident_as_string()
+    ) -> Vec<String> {
+        if range_ident_list.len() == 1 {
+            // Prevents a single valid item list
+            range_ident_list.push(invalid_range_ident)
+        }
+        range_ident_list
+    }
+}
+
+prop_compose! {
     fn arb_wildcard_range()(
         // Here we generate a non-empty Vec<Option<u32>>,
         // then turn the first element into a None (to represent the '*'),
@@ -537,4 +621,50 @@ fn parse_ident_with_basic_errors() {
 fn check_wrong_tag_order_is_a_parse_error() {
     let r = all_consuming(crate::parsing::ident::<(_, ErrorKind)>)("pkg-name/1.0+a.0-b.0");
     assert!(r.is_err(), "expected to fail; got {r:?}");
+}
+
+proptest! {
+    #[test]
+    fn prop_test_parse_valid_ident_range_list(
+        ident_list in arb_valid_range_ident_list(),
+        separator in arb_valid_range_ident_list_separator(),
+        suffix in arb_valid_range_ident_list_suffix(),
+    ) {
+        let comma_separated_list = format!( "{}{suffix}", ident_list.iter().map(ToString::to_string).join(&separator));
+        let parsed_list = parse_ident_range_list(&comma_separated_list);
+
+        // Test the results of the parsing
+        assert!(parsed_list.is_ok(), "parse ident range list '{comma_separated_list}' failure:\n{}", parsed_list.unwrap_err());
+        let list_parsed = parsed_list.unwrap();
+        assert_eq!(ident_list.is_empty(), list_parsed.is_empty(), "parse empty comma separated ident list should result in list");
+        // Each item in the original should match each item in the parsed list, in the same order
+        for (original, parsed) in zip(&ident_list, &list_parsed) {
+            // Have to compare field by field because the parser may
+            // have chosen a different VersionFilter to represent the
+            // version number, and this means the two range ident
+            // objects will not be equal, even though they represent
+            // the same thing.
+            assert_eq!(original.repository_name, parsed.repository_name, "parsed repo name does not match original range ident");
+            assert_eq!(original.name.as_str(), parsed.name.as_str(), "parsed name does not match original range ident");
+            assert_eq!(original.components, parsed.components, "parsed components does not match original range ident");
+            assert_eq!(original.version.clone().flatten(), parsed.version.clone().flatten(), "parsed version does not match original range ident");
+            assert_eq!(original.build, parsed.build, "parsed build does not match original range ident");
+        }
+    }
+}
+
+proptest! {
+    #[test]
+    fn prop_test_parse_invalid_ident_range_list(
+        ident_list in arb_invalid_range_ident_list(),
+        separator in arb_invalid_range_ident_list_separator(),
+        suffix in arb_range_ident_list_suffix(),
+    ) {
+        prop_assume!(separator != "," || !suffix.is_empty());
+
+        let comma_separated_list = format!("{}{suffix}", ident_list.iter().map(ToString::to_string).join(&separator));
+        let parsed_list = parse_ident_range_list(&comma_separated_list);
+
+        assert!(parsed_list.is_err(), "expected '{comma_separated_list}' to fail to parse, but it succeeded");
+    }
 }

--- a/crates/spk-schema/crates/ident/src/range_ident.rs
+++ b/crates/spk-schema/crates/ident/src/range_ident.rs
@@ -387,3 +387,12 @@ impl<'de> Deserialize<'de> for RangeIdent {
 pub fn parse_ident_range<S: AsRef<str>>(source: S) -> Result<RangeIdent> {
     RangeIdent::from_str(source.as_ref())
 }
+
+/// Parse a comma separated list of package identifiers that each
+/// specify a range of versions.
+pub fn parse_ident_range_list<S: AsRef<str>>(source: S) -> Result<Vec<RangeIdent>> {
+    if source.as_ref() == "" {
+        return Ok(Vec::new());
+    }
+    crate::parsing::range_ident_comma_separated_list(&KNOWN_REPOSITORY_NAMES, source.as_ref())
+}

--- a/crates/spk-schema/crates/ident/src/range_ident_test.rs
+++ b/crates/spk-schema/crates/ident/src/range_ident_test.rs
@@ -12,9 +12,12 @@ use super::parse_ident_range;
 
 #[rstest]
 #[case("python/3.1.0", &[])]
+#[case("python/3.1.0,3.2.1", &[])]
+#[case("python/3.1.0", &[])]
 #[case("python:lib/3.1.0", &["lib"])]
 #[case("python:{lib}/3.1.0", &["lib"])]
 #[case("python:{lib,bin}/3.1.0", &["lib", "bin"])]
+#[case("python:{lib,bin}/3.1.0,3.2.1", &["lib", "bin"])]
 #[case("python:{lib,bin,dev}/3.1.0", &["lib", "bin", "dev"])]
 #[should_panic]
 #[case("python.Invalid/3.1.0", &[""])]


### PR DESCRIPTION
This adds an api function for parsing a comma-separated list (csl) of range idents (packages or requests). It required an update to the parser for `package_name_not_version`, and it includes some intial proptests for parsing valid and invalid range ident comma-separated lists.

The background is that SPI had a csl parser for package requests in another tool that uses `spk` as a library. `spk` parsed the package identifiers, and the tool dealt with the list. We hit issue parsing these csl's when some of the requests contained post-releases or multiple version ranges, e.g. `pkgA/1,mypkg/2.3.1+r4,pkgB` or `mypkg/1.2.3,1.3.5,pkgC`. 

This led to the `package_name_not_version` parser. We found it wasn't parsing the packages correctly in these situations and could mistake package names for repo names, e.g. `mypkg` in `mypkg/1.2.3,pkgD` would be treated as a package called `1.2.3` in the repo `mypkg`.  As part of fixing that, we wanted to move the csl parsing into `spk`, and add tests for it, So it could be used in future work and all the `spk` package/request/range ident parsing is kept together.
