### PR TITLE
Add `spk info --variants-with-tests`

### DIFF
--- a/crates/spk-schema/src/test.rs
+++ b/crates/spk-schema/src/test.rs
@@ -22,7 +22,7 @@ pub trait Test {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, strum::EnumIter)]
 pub enum TestStage {
     Sources,
     Build,


### PR DESCRIPTION
An alternate to `spk info --variant` that also includes the counts of tests that would be run in each variant. This can be used by automation to detect if a CI job needs to be generated to run tests.

Resolves #1120.

Example for our python recipe that has two install tests defined:
```json
{"0":{"options":{"abi":"cp39","centos-sqlite":"3.7.17","debug":"off","gcc":"6.3"},"additional_requirements":[{"pkg":"centos-sqlite/3.7.17"}],"tests":{"sources":0,"build":0,"install":2}},"1":{"options":{"abi":"cp39","debug":"off","gcc":"6.3","sqlite":"3.9.0"},"additional_requirements":[],"tests":{"sources":0,"build":0,"install":2}},"2":{"options":{"abi":"cp39","centos-sqlite":"3.7.17","debug":"off","gcc":"9.3"},"additional_requirements":[{"pkg":"centos-sqlite/3.7.17"}],"tests":{"sources":0,"build":0,"install":2}},"3":{"options":{"abi":"cp39","debug":"off","gcc":"9.3","sqlite":"3.9.0"},"additional_requirements":[],"tests":{"sources":0,"build":0,"install":2}}}
```

Altering the recipe to add a selector to one of the tests so it doesn't match any variant results in `"tests":{"sources":0,"build":0,"install":1}` as expected.