### PR TITLE
Adds support to spk commands for requests files

### DIFF
--- a/crates/spk-cli/cmd-env/src/cmd_env.rs
+++ b/crates/spk-cli/cmd-env/src/cmd_env.rs
@@ -69,10 +69,11 @@ impl Run for Env {
 
         let mut solver = self.solver.get_solver(&self.options).await?;
 
-        let requests = self
+        let (requests, extra_options) = self
             .requests
             .parse_requests(&self.requested, &self.options, solver.repositories())
             .await?;
+        solver.update_options(extra_options);
         for request in requests {
             solver.add_request(request)
         }

--- a/crates/spk-cli/cmd-explain/src/cmd_explain.rs
+++ b/crates/spk-cli/cmd-explain/src/cmd_explain.rs
@@ -70,10 +70,11 @@ impl Run for Explain {
 
         let mut solver = self.solver.get_solver(&self.options).await?;
 
-        let requests = self
+        let (requests, extra_options) = self
             .requests
             .parse_requests(&self.requested, &self.options, solver.repositories())
             .await?;
+        solver.update_options(extra_options);
         for request in requests {
             solver.add_request(request)
         }

--- a/crates/spk-cli/cmd-install/src/cmd_install.rs
+++ b/crates/spk-cli/cmd-install/src/cmd_install.rs
@@ -50,11 +50,11 @@ impl Run for Install {
             current_env().map_err(|err| err.into())
         )?;
 
-        let requests = self
+        let (requests, extra_options) = self
             .requests
             .parse_requests(&self.packages, &self.options, solver.repositories())
             .await?;
-
+        solver.update_options(extra_options);
         for solved in env.items() {
             solver.add_request(solved.request.clone().into());
         }

--- a/crates/spk-cli/cmd-make-binary/src/cmd_make_binary.rs
+++ b/crates/spk-cli/cmd-make-binary/src/cmd_make_binary.rs
@@ -139,12 +139,18 @@ impl Run for MakeBinary {
             (!self.options.no_host).then(|| HOST_OPTIONS.get().unwrap_or_default());
 
         for package in packages {
-            let (recipe, filename) = flags::find_package_recipe_from_template_or_repo(
+            let (spec_data, filename) = flags::find_package_recipe_from_template_or_repo(
                 package.as_ref().map(|p| p.get_specifier()),
                 &options,
                 &repos,
             )
             .await?;
+            let recipe = spec_data.into_recipe().wrap_err_with(|| {
+                format!(
+                    "{filename} was expected to contain a recipe",
+                    filename = filename.to_string_lossy()
+                )
+            })?;
             let ident = recipe.ident();
 
             tracing::info!("saving package recipe for {}", ident.format_ident());

--- a/crates/spk-cli/cmd-render/src/cmd_render.rs
+++ b/crates/spk-cli/cmd-render/src/cmd_render.rs
@@ -42,10 +42,11 @@ impl Run for Render {
     async fn run(&mut self) -> Result<Self::Output> {
         let mut solver = self.solver.get_solver(&self.options).await?;
 
-        let requests = self
+        let (requests, extra_options) = self
             .requests
             .parse_requests(&self.packages, &self.options, solver.repositories())
             .await?;
+        solver.update_options(extra_options);
         for name in requests {
             solver.add_request(name);
         }

--- a/crates/spk-cli/cmd-test/src/cmd_test.rs
+++ b/crates/spk-cli/cmd-test/src/cmd_test.rs
@@ -100,9 +100,15 @@ impl Run for CmdTest {
                 }
             };
 
-            let (recipe, filename) =
+            let (spec_data, filename) =
                 flags::find_package_recipe_from_template_or_repo(Some(&name), &options, &repos)
                     .await?;
+            let recipe = spec_data.into_recipe().wrap_err_with(|| {
+                format!(
+                    "{filename} was expected to contain a recipe",
+                    filename = filename.to_string_lossy()
+                )
+            })?;
 
             for stage in stages {
                 tracing::info!("Testing {}@{stage}...", filename.display());

--- a/crates/spk-cli/common/src/flags_test.rs
+++ b/crates/spk-cli/common/src/flags_test.rs
@@ -24,7 +24,6 @@ use spk_schema::foundation::option_map::OptionMap;
 fn test_option_flags_parsing(#[case] args: &[&str], #[case] expected: &[(&str, &str)]) {
     let options = super::Options {
         no_host: true,
-        options_file: Default::default(),
         options: args.iter().map(ToString::to_string).collect(),
     };
     let actual = options.get_options().unwrap();

--- a/crates/spk-cli/group1/src/cmd_bake.rs
+++ b/crates/spk-cli/group1/src/cmd_bake.rs
@@ -224,10 +224,11 @@ impl Bake {
         // with it.
         let mut solver = self.solver.get_solver(&self.options).await?;
 
-        let requests = self
+        let (requests, extra_options) = self
             .requests
             .parse_requests(&self.requested, &self.options, solver.repositories())
             .await?;
+        solver.update_options(extra_options);
         for request in requests {
             solver.add_request(request)
         }

--- a/crates/spk-cli/group4/src/cmd_view.rs
+++ b/crates/spk-cli/group4/src/cmd_view.rs
@@ -473,7 +473,7 @@ impl View {
         let solver = self.solver.get_solver(&self.options).await?;
         let repos = solver.repositories();
 
-        let parsed_request = match self
+        let (parsed_request, _extra_options) = match self
             .requests
             .parse_request(&package, &self.options, repos)
             .await
@@ -613,7 +613,9 @@ impl View {
     async fn print_package_info_from_solve(&self, package: &String) -> Result<i32> {
         let mut solver = self.solver.get_solver(&self.options).await?;
 
-        let request = match self
+        // _extra_option are unused here because getting package info
+        // from a solve is basically deprecated and should be removed soon.
+        let (request, _extra_options) = match self
             .requests
             .parse_request(&package, &self.options, solver.repositories())
             .await

--- a/crates/spk-cli/group4/src/cmd_view.rs
+++ b/crates/spk-cli/group4/src/cmd_view.rs
@@ -226,10 +226,16 @@ impl View {
         options: &OptionMap,
         show_variants_with_tests: bool,
     ) -> Result<i32> {
-        let (_, template) = flags::find_package_template(self.package.as_ref())
+        let (filename, template) = flags::find_package_template(self.package.as_ref())
             .wrap_err("find package template")?
             .must_be_found();
-        let recipe = template.render(options)?;
+        let rendered_data = template.render(options)?;
+        let recipe = rendered_data.into_recipe().wrap_err_with(|| {
+            format!(
+                "{filename} was expected to contain a recipe",
+                filename = filename.to_string_lossy()
+            )
+        })?;
 
         let default_variants = recipe.default_variants(options);
         match &self.format {

--- a/crates/spk-schema/src/error_test.rs
+++ b/crates/spk-schema/src/error_test.rs
@@ -27,7 +27,7 @@ fn test_yaml_short() {
 
     let expected = r#"
  1 | short and wrong
-   | ^ invalid type: string "short and wrong", expected struct YamlMapping
+   | ^ invalid type: string "short and wrong", expected struct DataApiVersionMapping
 "#;
 
     let message = err.to_string();

--- a/crates/spk-schema/src/lib.rs
+++ b/crates/spk-schema/src/lib.rs
@@ -50,7 +50,7 @@ pub use recipe::{BuildEnv, Recipe};
 pub use requirements_list::RequirementsList;
 pub use serde_json;
 pub use source_spec::{GitSource, LocalSource, ScriptSource, SourceSpec, TarSource};
-pub use spec::{Spec, SpecRecipe, SpecTemplate, SpecVariant};
+pub use spec::{ApiVersion, Spec, SpecFileData, SpecRecipe, SpecTemplate, SpecVariant};
 pub use spk_schema_foundation::option_map::{self, OptionMap};
 pub use spk_schema_foundation::{
     self as foundation,

--- a/crates/spk-schema/src/spec_test.rs
+++ b/crates/spk-schema/src/spec_test.rs
@@ -321,7 +321,7 @@ sources:
   - git: https://downloads.testing/my-package/v{{ opt.typo }}
 "#;
     let tpl = SpecTemplate {
-        name: PkgName::new("my-package").unwrap().to_owned(),
+        name: Some(PkgName::new("my-package").unwrap().to_owned()),
         file_path: "my-package.spk.yaml".into(),
         template: SPEC.to_string(),
     };
@@ -345,13 +345,14 @@ fn test_template_namespace_options() {
     format_serde_error::never_color();
     static SPEC: &str = r#"pkg: mypackage/{{ opt.namespace.version }}"#;
     let tpl = SpecTemplate {
-        name: PkgName::new("my-package").unwrap().to_owned(),
+        name: Some(PkgName::new("my-package").unwrap().to_owned()),
         file_path: "my-package.spk.yaml".into(),
         template: SPEC.to_string(),
     };
     let options = option_map! {"namespace.version" => "1.0.0"};
-    let recipe = tpl
+    let rendered_data = tpl
         .render(&options)
         .expect("template should render with sub-object access");
+    let recipe = rendered_data.into_recipe().unwrap();
     assert_eq!(recipe.version().to_string(), "1.0.0");
 }

--- a/crates/spk-schema/src/template.rs
+++ b/crates/spk-schema/src/template.rs
@@ -6,19 +6,16 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use crate::foundation::option_map::OptionMap;
-use crate::foundation::spec_ops::Named;
-use crate::Result;
+use crate::{Result, SpecFileData};
 
 /// Can be rendered into a recipe.
 #[enum_dispatch::enum_dispatch]
-pub trait Template: Named + Sized {
-    type Output: super::Recipe;
-
+pub trait Template: Sized {
     /// Identify the location of this template on disk
     fn file_path(&self) -> &Path;
 
     /// Render this template with the provided values.
-    fn render(&self, options: &OptionMap) -> Result<Self::Output>;
+    fn render(&self, options: &OptionMap) -> Result<SpecFileData>;
 }
 
 pub trait TemplateExt: Template {

--- a/crates/spk-schema/src/v0/mod.rs
+++ b/crates/spk-schema/src/v0/mod.rs
@@ -3,12 +3,14 @@
 // https://github.com/spkenv/spk
 
 mod platform;
+mod requirements;
 mod spec;
 mod test_spec;
 mod variant;
 mod variant_spec;
 
 pub use platform::Platform;
+pub use requirements::Requirements;
 pub use spec::Spec;
 pub use test_spec::TestSpec;
 pub use variant::Variant;

--- a/crates/spk-schema/src/v0/requirements.rs
+++ b/crates/spk-schema/src/v0/requirements.rs
@@ -1,0 +1,23 @@
+// Copyright (c) Contributors to the SPK project.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/spkenv/spk
+
+use serde::{Deserialize, Serialize};
+
+use crate::RequirementsList;
+
+/// For a list of requirements parsed from the requests file
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Ord, PartialOrd, Deserialize, Serialize)]
+pub struct Requirements {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub requirements: RequirementsList,
+    // Could separate override options out:
+    //
+    // // From BuildSpec - Opt has var and pkg items
+    // #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    // pub options: Vec<Opt>,
+    //
+    // // From V0::Variant
+    // #[serde(flatten)]
+    // pub options: OptionMap,
+}

--- a/crates/spk-schema/src/v0/requirements.rs
+++ b/crates/spk-schema/src/v0/requirements.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/spkenv/spk
 
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 
 use crate::RequirementsList;
@@ -9,15 +11,11 @@ use crate::RequirementsList;
 /// For a list of requirements parsed from the requests file
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Ord, PartialOrd, Deserialize, Serialize)]
 pub struct Requirements {
+    /// A list of var or pkg requests
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub requirements: RequirementsList,
-    // Could separate override options out:
-    //
-    // // From BuildSpec - Opt has var and pkg items
-    // #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    // pub options: Vec<Opt>,
-    //
-    // // From V0::Variant
-    // #[serde(flatten)]
-    // pub options: OptionMap,
+
+    /// Additional options for templates and solver's initial options
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub options: BTreeMap<String, String>,
 }

--- a/crates/spk-schema/src/v0/spec.rs
+++ b/crates/spk-schema/src/v0/spec.rs
@@ -610,7 +610,9 @@ impl Recipe for Spec<VersionIdent> {
             Err(err) => return Err(Error::String(format!("Failed to load spk config: {err}"))),
         };
 
-        updated.meta.update_metadata(&config.metadata)?;
+        if let Err(err) = updated.meta.update_metadata(&config.metadata) {
+            tracing::warn!("Failed to collect extra package metadata: {err}");
+        }
 
         let mut missing_build_requirements = HashMap::new();
         let mut missing_runtime_requirements: HashMap<OptNameBuf, (String, Option<String>)> =

--- a/crates/spk-schema/src/v0/spec_test.rs
+++ b/crates/spk-schema/src/v0/spec_test.rs
@@ -40,13 +40,16 @@ fn test_sources_relative_to_spec_file(tmpdir: tempfile::TempDir) {
     file.write_all(b"{pkg: test-pkg}").unwrap();
     drop(file);
 
-    let crate::Spec::V0Package(spec) = SpecTemplate::from_file(&spec_file)
+    let spec = SpecTemplate::from_file(&spec_file)
         .unwrap()
         .render(&OptionMap::default())
+        .unwrap();
+    let crate::Spec::V0Package(recipe) = spec
+        .into_recipe()
         .unwrap()
         .generate_source_build(&spec_dir)
         .unwrap();
-    if let Some(super::SourceSpec::Local(local)) = spec.sources.first() {
+    if let Some(super::SourceSpec::Local(local)) = recipe.sources.first() {
         assert_eq!(local.path, spec_dir);
     } else {
         panic!("expected spec to have one local source spec");

--- a/cspell.json
+++ b/cspell.json
@@ -128,6 +128,7 @@
     "depver",
     "Deque",
     "derserializer",
+    "deserializing",
     "DESTDIR",
     "devel",
     "devs",


### PR DESCRIPTION
This adds support to spk commands (`bake`, `env`, and `explain`) to let them take files of package requests with  a <yaml filepath>` request on their command lines.

The aim is to allow a larger number of package requests to be passed to spk command than would normally fit on a single command line. We're seeing examples of tools calling `spk bake` or `spk explain` with 350+ detailed package requests, e.g. `python/3.10.8+r3/ABCDEF` or `my-long-tool-name:{run,build,with-some-feature}/==1.2.3.4+r1`, not just `python` or `mypkg`. Some of them are starting to hit command line limits and/or are becoming unwieldy to edit.

Each file must a `yaml` formatted list of package or var requests.

Example file (can have whatever is valid for a package request, json blob, '@' specifier, etc.):
```yaml
- python-pytest-watch/4
- python-pytest-cov/>=3.0.0
- python-pytest-asyncio/~1.0.0
- python-pytest-timeout
- mypkg@build
- { pkg: python-pylint/2.0.0, preReleasePolicy: IncludeAll }
```

Example command lines:
```
# 2 packages on the command line
> spk explain python/3 python-pytest

# a number of packages in a file
> spk explain myfile.spk.yaml

# mixing packages on the command line and from files
> spk explain python myfile.spk.yaml python-pytest myotherfile.spk.yaml
```
The package requests in the requests files are added to the list of requests first, before the ones on the command line.

See also:
- https://github.com/spkenv/spk/pull/1136

