### PR TITLE
Fix IncompatibleReason Display issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,7 +600,7 @@ version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.48",
@@ -1481,6 +1481,12 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -2669,7 +2675,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bdf592881d821b83d471f8af290226c8d51402259e9bb5be7f9f8bdebbb11ac"
 dependencies = [
  "bytes",
- "heck",
+ "heck 0.4.1",
  "itertools 0.11.0",
  "log",
  "multimap",
@@ -4696,20 +4702,20 @@ checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "strum"
-version = "0.26.1"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "723b93e8addf9aa965ebe2d11da6d7540fa2283fcea14b3371ff055f7ba13f5f"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.26.1"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a3417fc93d76740d974a01654a09777cb500428cc874ca9f45edfe0c4d4cd18"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,7 +136,7 @@ spk-solve-validation = { path = "crates/spk-solve/crates/validation" }
 spk-storage = { path = "crates/spk-storage" }
 static_assertions = "1.1"
 strip-ansi-escapes = "0.2.0"
-strum = { version = "0.26.1", features = ["derive"] }
+strum = { version = "0.26.3", features = ["derive"] }
 tap = "1.0"
 tempfile = "3.3"
 thiserror = "1.0"

--- a/crates/spk-schema/crates/foundation/src/version/compat/mod.rs
+++ b/crates/spk-schema/crates/foundation/src/version/compat/mod.rs
@@ -198,11 +198,11 @@ pub enum IncompatibleReason {
         name: OptNameBuf,
         inner_reason: Box<IncompatibleReason>,
     },
-    #[strum(to_string = "package does not define requested build options: {missing:?}")]
+    #[strum(to_string = "package does not define requested build options: {0:?}")]
     BuildOptionsMissing(OptionMap),
     #[strum(to_string = "{0}")]
     ComponentsMissing(ComponentsMissingProblem),
-    #[strum(to_string = "embedded package conflicts with existing package in solve: {pkg}")]
+    #[strum(to_string = "embedded package conflicts with existing package in solve: {0}")]
     ConflictingEmbeddedPackage(PkgNameBuf),
     #[strum(
         to_string = "package {0} component {1} embeds {2} and conflicts with existing package in solve: {3}"

--- a/crates/spk-schema/crates/foundation/src/version/compat/problems.rs
+++ b/crates/spk-schema/crates/foundation/src/version/compat/problems.rs
@@ -31,9 +31,9 @@ pub enum VersionForClause {
 
 #[derive(Clone, Debug, Eq, PartialEq, strum::Display)]
 pub enum VersionRangeProblem {
-    #[strum(to_string = "version too high {version_for_clause}")]
+    #[strum(to_string = "version too high {0}")]
     TooHigh(VersionForClause),
-    #[strum(to_string = "version too low {version_for_clause}")]
+    #[strum(to_string = "version too low {0}")]
     TooLow(VersionForClause),
     #[strum(to_string = "not {op} {bound} [too low]")]
     NotHighEnough { op: &'static str, bound: Version },


### PR DESCRIPTION
Update the version of strum to the latest version, the older version didn't support enum variants with unnamed fields. This was hiding a number of places that had been changed from named to unnamed fields without updating the format string.