### PR TITLE
Fix empty Request requester in test requirements

### DIFF
--- a/crates/spk-schema/src/v0/test_spec.rs
+++ b/crates/spk-schema/src/v0/test_spec.rs
@@ -3,6 +3,7 @@
 // https://github.com/spkenv/spk
 
 use serde::{Deserialize, Serialize};
+use spk_schema_ident::{RequestedBy, VersionIdent};
 
 use crate::ident::Request;
 use crate::{Script, TestStage};
@@ -21,6 +22,26 @@ pub struct TestSpec {
     pub selectors: Vec<super::VariantSpec>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub requirements: Vec<Request>,
+}
+
+impl TestSpec {
+    /// Add the given requester to any package requirements present in this
+    /// test spec.
+    pub fn add_requester(&mut self, requester: &VersionIdent) {
+        for requirement in self.requirements.iter_mut() {
+            if let Request::Pkg(pkg_request) = requirement {
+                match self.stage {
+                    TestStage::Sources => pkg_request
+                        .add_requester(RequestedBy::SourceTest(requester.to_any_ident(None))),
+                    TestStage::Build => pkg_request
+                        .add_requester(RequestedBy::BuildTest(requester.to_any_ident(None))),
+                    TestStage::Install => {
+                        pkg_request.add_requester(RequestedBy::InstallTest(requester.clone()))
+                    }
+                }
+            }
+        }
+    }
 }
 
 impl crate::Test for TestSpec {


### PR DESCRIPTION
Any package requirements on an spk recipe test need to have their
requester filled in.

    -RESOLVE python-pytest/7.4.3/UNZ5Q23T  (requested by )
    +RESOLVE python-pytest/7.4.3/UNZ5Q23T  (requested by some-package-name/1.2.1 install test)