### PR TITLE
Updates SPFS_LOG_TIMESTAMP value parsing to allow 1 and true

### DIFF
--- a/crates/spfs-cli/common/src/args.rs
+++ b/crates/spfs-cli/common/src/args.rs
@@ -335,7 +335,7 @@ pub struct Logging {
     pub syslog: bool,
 
     /// Enables timestamp in logging (always enabled in file log)
-    #[clap(long, global = true, env = "SPFS_LOG_TIMESTAMP")]
+    #[clap(long, global = true, value_parser = clap::builder::BoolishValueParser::new(), env = "SPFS_LOG_TIMESTAMP")]
     pub timestamp: bool,
 }
 

--- a/cspell.json
+++ b/cspell.json
@@ -56,6 +56,7 @@
     "BLOSC",
     "BMLX",
     "bools",
+    "Boolish",
     "Bottriell",
     "bufread",
     "buildable",


### PR DESCRIPTION
This updates the `SPFS_LOG_TIMESTAMP` and its command line flag's value parsing to allow a more user-friendly range of number and text values for true, e.g. `1`, `true`, `True` etc..