### PR TITLE
Add blanket implementations for Repository traits

### DIFF
--- a/crates/spfs/src/storage/blob.rs
+++ b/crates/spfs/src/storage/blob.rs
@@ -40,4 +40,5 @@ pub trait BlobStorage: graph::Database + Sync + Send {
     }
 }
 
-impl<T: BlobStorage> BlobStorage for &T {}
+/// Blanket implementation.
+impl<T> BlobStorage for T where T: graph::Database + Sync + Send {}

--- a/crates/spfs/src/storage/fallback/repository.rs
+++ b/crates/spfs/src/storage/fallback/repository.rs
@@ -362,10 +362,6 @@ impl TagStorageMut for FallbackProxy {
     }
 }
 
-impl BlobStorage for FallbackProxy {}
-impl ManifestStorage for FallbackProxy {}
-impl LayerStorage for FallbackProxy {}
-impl PlatformStorage for FallbackProxy {}
 impl Address for FallbackProxy {
     fn address(&self) -> Cow<'_, url::Url> {
         let config = Config {
@@ -383,7 +379,6 @@ impl Address for FallbackProxy {
         )
     }
 }
-impl Repository for FallbackProxy {}
 
 impl LocalRepository for FallbackProxy {
     #[inline]

--- a/crates/spfs/src/storage/fs/repository.rs
+++ b/crates/spfs/src/storage/fs/repository.rs
@@ -258,16 +258,11 @@ impl FsRepository {
     }
 }
 
-impl BlobStorage for FsRepository {}
-impl ManifestStorage for FsRepository {}
-impl LayerStorage for FsRepository {}
-impl PlatformStorage for FsRepository {}
 impl Address for FsRepository {
     fn address(&self) -> Cow<'_, url::Url> {
         Cow::Owned(url::Url::from_directory_path(self.root()).unwrap())
     }
 }
-impl Repository for FsRepository {}
 
 impl std::fmt::Debug for FsRepository {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -535,16 +530,11 @@ impl OpenFsRepository {
     }
 }
 
-impl BlobStorage for OpenFsRepository {}
-impl ManifestStorage for OpenFsRepository {}
-impl LayerStorage for OpenFsRepository {}
-impl PlatformStorage for OpenFsRepository {}
 impl Address for OpenFsRepository {
     fn address(&self) -> Cow<'_, url::Url> {
         Cow::Owned(url::Url::from_directory_path(self.root()).unwrap())
     }
 }
-impl Repository for OpenFsRepository {}
 
 impl std::fmt::Debug for OpenFsRepository {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crates/spfs/src/storage/layer.rs
+++ b/crates/spfs/src/storage/layer.rs
@@ -57,4 +57,5 @@ pub trait LayerStorage: graph::Database + Sync + Send {
     }
 }
 
-impl<T: LayerStorage> LayerStorage for &T {}
+/// Blanket implementation.
+impl<T> LayerStorage for T where T: graph::Database + Sync + Send {}

--- a/crates/spfs/src/storage/manifest.rs
+++ b/crates/spfs/src/storage/manifest.rs
@@ -43,4 +43,5 @@ pub trait ManifestStorage: graph::Database + Sync + Send {
     }
 }
 
-impl<T: ManifestStorage> ManifestStorage for &T {}
+/// Blanket implementation.
+impl<T> ManifestStorage for T where T: graph::Database + Sync + Send {}

--- a/crates/spfs/src/storage/pinned/repository.rs
+++ b/crates/spfs/src/storage/pinned/repository.rs
@@ -150,10 +150,6 @@ where
     }
 }
 
-impl<T> BlobStorage for PinnedRepository<T> where T: BlobStorage + 'static {}
-impl<T> ManifestStorage for PinnedRepository<T> where T: ManifestStorage + 'static {}
-impl<T> LayerStorage for PinnedRepository<T> where T: LayerStorage + 'static {}
-impl<T> PlatformStorage for PinnedRepository<T> where T: PlatformStorage + 'static {}
 impl<T> Address for PinnedRepository<T>
 where
     T: Repository + 'static,
@@ -165,7 +161,6 @@ where
         Cow::Owned(base)
     }
 }
-impl<T> Repository for PinnedRepository<T> where T: Repository + 'static {}
 
 impl<T> std::fmt::Debug for PinnedRepository<T>
 where

--- a/crates/spfs/src/storage/platform.rs
+++ b/crates/spfs/src/storage/platform.rs
@@ -47,4 +47,5 @@ pub trait PlatformStorage: graph::Database + Sync + Send {
     }
 }
 
-impl<T: PlatformStorage> PlatformStorage for &T {}
+/// Blanket implementation.
+impl<T> PlatformStorage for T where T: graph::Database + Sync + Send {}

--- a/crates/spfs/src/storage/proxy/repository.rs
+++ b/crates/spfs/src/storage/proxy/repository.rs
@@ -331,10 +331,6 @@ impl TagStorageMut for ProxyRepository {
     }
 }
 
-impl BlobStorage for ProxyRepository {}
-impl ManifestStorage for ProxyRepository {}
-impl LayerStorage for ProxyRepository {}
-impl PlatformStorage for ProxyRepository {}
 impl Address for ProxyRepository {
     fn address(&self) -> Cow<'_, url::Url> {
         let config = Config {
@@ -348,4 +344,3 @@ impl Address for ProxyRepository {
         Cow::Owned(config.to_address().expect("config creates a valid url"))
     }
 }
-impl Repository for ProxyRepository {}

--- a/crates/spfs/src/storage/repository.rs
+++ b/crates/spfs/src/storage/repository.rs
@@ -111,27 +111,21 @@ pub trait Repository:
     }
 }
 
-#[async_trait::async_trait]
-impl<T: Repository> Repository for &T {
-    async fn has_ref(&self, reference: &str) -> bool {
-        (**self).has_ref(reference).await
-    }
-
-    async fn resolve_ref(&self, reference: &str) -> Result<encoding::Digest> {
-        (**self).resolve_ref(reference).await
-    }
-
-    async fn read_ref(&self, reference: &str) -> Result<graph::Object> {
-        (**self).read_ref(reference).await
-    }
-
-    async fn find_aliases(&self, reference: &str) -> Result<HashSet<Ref>> {
-        (**self).find_aliases(reference).await
-    }
-
-    async fn commit_blob(&self, reader: Pin<Box<dyn BlobRead>>) -> Result<encoding::Digest> {
-        (**self).commit_blob(reader).await
-    }
+/// Blanket implementation.
+impl<T> Repository for T where
+    T: super::Address
+        + super::TagStorage
+        + super::PayloadStorage
+        + super::ManifestStorage
+        + super::BlobStorage
+        + super::LayerStorage
+        + super::PlatformStorage
+        + graph::Database
+        + graph::DatabaseView
+        + std::fmt::Debug
+        + Send
+        + Sync
+{
 }
 
 /// Accessor methods for types only applicable to repositories that have

--- a/crates/spfs/src/storage/rpc/database.rs
+++ b/crates/spfs/src/storage/rpc/database.rs
@@ -9,7 +9,7 @@ use futures::{Stream, TryStreamExt};
 use proto::RpcResult;
 
 use crate::graph::{self, ObjectProto};
-use crate::{encoding, proto, storage, Result};
+use crate::{encoding, proto, Result};
 
 #[async_trait::async_trait]
 impl graph::DatabaseView for super::RpcRepository {
@@ -112,8 +112,3 @@ impl graph::Database for super::RpcRepository {
             .to_result()?)
     }
 }
-
-impl storage::PlatformStorage for super::RpcRepository {}
-impl storage::LayerStorage for super::RpcRepository {}
-impl storage::ManifestStorage for super::RpcRepository {}
-impl storage::BlobStorage for super::RpcRepository {}

--- a/crates/spfs/src/storage/rpc/repository.rs
+++ b/crates/spfs/src/storage/rpc/repository.rs
@@ -175,5 +175,3 @@ impl storage::Address for RpcRepository {
         Cow::Borrowed(&self.address)
     }
 }
-
-impl storage::Repository for RpcRepository {}

--- a/crates/spfs/src/storage/tar/repository.rs
+++ b/crates/spfs/src/storage/tar/repository.rs
@@ -406,10 +406,6 @@ impl TagStorageMut for TarRepository {
     }
 }
 
-impl BlobStorage for TarRepository {}
-impl ManifestStorage for TarRepository {}
-impl LayerStorage for TarRepository {}
-impl PlatformStorage for TarRepository {}
 impl Address for TarRepository {
     fn address(&self) -> Cow<'_, url::Url> {
         Cow::Owned(
@@ -417,4 +413,3 @@ impl Address for TarRepository {
         )
     }
 }
-impl Repository for TarRepository {}


### PR DESCRIPTION
Some of these traits are fully defined and can have blanket implementations that reduce the amount of boilerplate needed.