### PR TITLE
Refactor rendering logic into separate methods

### DIFF
--- a/crates/spfs-cli/cmd-render/src/cmd_render.rs
+++ b/crates/spfs-cli/cmd-render/src/cmd_render.rs
@@ -31,10 +31,10 @@ pub struct CmdRender {
     /// using a local directory and `HardLink` for the repository.
     #[clap(
         long,
-        value_parser = clap::builder::PossibleValuesParser::new(spfs::storage::fs::RenderType::VARIANTS)
-            .map(|s| s.parse::<spfs::storage::fs::RenderType>().unwrap())
+        value_parser = clap::builder::PossibleValuesParser::new(spfs::storage::fs::CliRenderType::VARIANTS)
+            .map(|s| s.parse::<spfs::storage::fs::CliRenderType>().unwrap())
     )]
-    strategy: Option<spfs::storage::fs::RenderType>,
+    strategy: Option<spfs::storage::fs::CliRenderType>,
 
     /// The tag or digest of what to render, use a '+' to join multiple layers
     reference: String,
@@ -121,7 +121,9 @@ impl CmdRender {
             .render_into_directory(
                 env_spec,
                 &target_dir,
-                self.strategy.unwrap_or(spfs::storage::fs::RenderType::Copy),
+                self.strategy
+                    .map(Into::into)
+                    .unwrap_or(spfs::storage::fs::RenderType::Copy),
             )
             .await?;
         Ok(RenderResult {
@@ -165,7 +167,7 @@ impl CmdRender {
             .collect();
         tracing::trace!("stack: {:?}", stack);
         renderer
-            .render(&stack, self.strategy)
+            .render(&stack, self.strategy.map(Into::into))
             .await
             .map(|paths_rendered| RenderResult {
                 paths_rendered,

--- a/crates/spfs/src/resolve.rs
+++ b/crates/spfs/src/resolve.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use super::config::get_config;
 use crate::prelude::*;
 use crate::storage::fallback::FallbackProxy;
-use crate::storage::fs::{ManifestRenderPath, RenderSummary};
+use crate::storage::fs::{CliRenderType, ManifestRenderPath, RenderSummary};
 use crate::{Error, Result, graph, runtime, storage, tracking};
 
 #[cfg(test)]
@@ -52,7 +52,7 @@ async fn render_via_subcommand(
         // of overlayfs. To avoid any issues editing files and
         // hardlinks the rendering for them switches to Copy.
         cmd.arg("--strategy");
-        cmd.arg::<&str>(crate::storage::fs::RenderType::Copy.into());
+        cmd.arg::<&str>(CliRenderType::Copy.into());
     }
     cmd.arg(spec.to_string());
     tracing::debug!("{:?}", cmd);

--- a/crates/spfs/src/storage/fs/mod.rs
+++ b/crates/spfs/src/storage/fs/mod.rs
@@ -26,8 +26,10 @@ pub use render_reporter::{
 };
 pub use render_summary::{RenderSummary, RenderSummaryReporter};
 pub use renderer::{
+    CliRenderType,
     DEFAULT_MAX_CONCURRENT_BLOBS,
     DEFAULT_MAX_CONCURRENT_BRANCHES,
+    HardLinkRenderType,
     RenderType,
     Renderer,
 };


### PR DESCRIPTION
This change was prompted by wanting to refactor the code to work towards
having different trait bounds for the functions that need a repository
that supports renders (e.g., rendering into a repository) versus
functions that render into a plain directory.

Rework `RenderType` so the method that renders into a hardlink doesn't
need to worry about getting a `RenderType::Copy` value.