### PR TITLE
Refactor FsRepository's renders

### DIFF
--- a/crates/spfs-cli/cmd-render/src/cmd_render.rs
+++ b/crates/spfs-cli/cmd-render/src/cmd_render.rs
@@ -4,9 +4,10 @@
 
 use clap::builder::TypedValueParser;
 use clap::Parser;
-use miette::{Context, Result};
+use miette::{Context, IntoDiagnostic, Result};
 use spfs::prelude::*;
 use spfs::storage::fallback::FallbackProxy;
+use spfs::storage::fs::{MaybeRenderStore, RenderStore};
 use spfs::{graph, Error, RenderResult};
 use spfs_cli_common as cli;
 use spfs_cli_common::CommandName;
@@ -74,7 +75,11 @@ impl CmdRender {
 
         let rendered = match &self.target {
             Some(target) => self.render_to_dir(fallback, env_spec, target).await?,
-            None => self.render_to_repo(fallback, env_spec).await?,
+            None => {
+                // This path requires a repository that supports renders.
+                let fallback: FallbackProxy<RenderStore> = fallback.try_into().into_diagnostic()?;
+                self.render_to_repo(fallback, env_spec).await?
+            }
         };
 
         tracing::debug!("render(s) completed successfully");
@@ -85,7 +90,7 @@ impl CmdRender {
 
     async fn render_to_dir(
         &self,
-        repo: FallbackProxy,
+        repo: FallbackProxy<MaybeRenderStore>,
         env_spec: spfs::tracking::EnvSpec,
         target: &std::path::Path,
     ) -> Result<RenderResult> {
@@ -134,7 +139,7 @@ impl CmdRender {
 
     async fn render_to_repo(
         &self,
-        repo: FallbackProxy,
+        repo: FallbackProxy<RenderStore>,
         env_spec: spfs::tracking::EnvSpec,
     ) -> Result<RenderResult> {
         let mut stack = graph::Stack::default();

--- a/crates/spfs-cli/common/src/args.rs
+++ b/crates/spfs-cli/common/src/args.rs
@@ -11,7 +11,7 @@ use miette::{Error, IntoDiagnostic, Result, WrapErr};
 #[cfg(feature = "sentry")]
 use once_cell::sync::OnceCell;
 use spfs::io::Pluralize;
-use spfs::storage::LocalRepository;
+use spfs::storage::LocalPayloads;
 use tracing_subscriber::prelude::*;
 
 const SPFS_LOG: &str = "SPFS_LOG";
@@ -138,7 +138,7 @@ impl Render {
         reporter: Reporter,
     ) -> spfs::storage::fs::Renderer<'repo, Repo, Reporter>
     where
-        Repo: spfs::storage::Repository + LocalRepository,
+        Repo: spfs::storage::Repository + LocalPayloads,
         Reporter: spfs::storage::fs::RenderReporter,
     {
         spfs::storage::fs::Renderer::new(repo)

--- a/crates/spfs-cli/main/src/cmd_init.rs
+++ b/crates/spfs-cli/main/src/cmd_init.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 
 use clap::{Args, Subcommand};
 use miette::Result;
+use spfs::storage::fs::NoRenderStore;
 
 /// Create an empty filesystem repository
 #[derive(Debug, Args)]
@@ -36,7 +37,7 @@ impl InitSubcommand {
     pub async fn run(&self, _config: &spfs::Config) -> Result<i32> {
         match self {
             Self::Repo { path } => {
-                spfs::storage::fs::MaybeOpenFsRepository::create(&path).await?;
+                spfs::storage::fs::MaybeOpenFsRepository::<NoRenderStore>::create(&path).await?;
                 Ok(0)
             }
         }

--- a/crates/spfs-cli/main/src/cmd_search.rs
+++ b/crates/spfs-cli/main/src/cmd_search.rs
@@ -5,6 +5,7 @@
 use clap::Args;
 use miette::Result;
 use spfs::prelude::*;
+use spfs::storage::fs::NoRenderStore;
 use tokio_stream::StreamExt;
 
 /// Search for available tags by substring
@@ -29,7 +30,10 @@ impl CmdSearch {
             };
             repos.push(remote);
         }
-        repos.insert(0, config.get_local_repository().await?.into());
+        repos.insert(
+            0,
+            config.get_local_repository::<NoRenderStore>().await?.into(),
+        );
         for repo in repos.into_iter() {
             let mut tag_streams = repo.iter_tags();
             while let Some(tag) = tag_streams.next().await {

--- a/crates/spfs-vfs/src/fuse.rs
+++ b/crates/spfs-vfs/src/fuse.rs
@@ -29,7 +29,7 @@ use fuser::{
     Request,
 };
 use spfs::prelude::*;
-use spfs::storage::LocalRepository;
+use spfs::storage::LocalPayloads;
 #[cfg(feature = "fuse-backend-abi-7-31")]
 use spfs::tracking::BlobRead;
 use spfs::tracking::{Entry, EntryKind, EnvSpec, Manifest};
@@ -377,7 +377,7 @@ impl Filesystem {
         let mut flags = FOPEN_KEEP_CACHE;
         for repo in self.repos.iter() {
             match &**repo {
-                spfs::storage::RepositoryHandle::FS(fs_repo) => {
+                spfs::storage::RepositoryHandle::FSWithRenders(fs_repo) => {
                     let Ok(fs_repo) = fs_repo.opened().await else {
                         reply.error(libc::ENOENT);
                         return;

--- a/crates/spfs/src/bootstrap_test.rs
+++ b/crates/spfs/src/bootstrap_test.rs
@@ -11,6 +11,7 @@ use super::build_shell_initialized_command;
 use crate::fixtures::*;
 use crate::resolve::which;
 use crate::runtime;
+use crate::storage::fs::RenderStore;
 
 #[rstest(
     shell,
@@ -37,7 +38,7 @@ async fn test_shell_initialization_startup_scripts(
     };
     let root = tmpdir.path().to_string_lossy().to_string();
     let repo = crate::storage::RepositoryHandle::from(
-        crate::storage::fs::MaybeOpenFsRepository::create(&root)
+        crate::storage::fs::MaybeOpenFsRepository::<RenderStore>::create(&root)
             .await
             .unwrap(),
     );
@@ -113,7 +114,7 @@ async fn test_shell_initialization_no_startup_scripts(shell: &str, tmpdir: tempf
     };
     let root = tmpdir.path().to_string_lossy().to_string();
     let repo = crate::storage::RepositoryHandle::from(
-        crate::storage::fs::MaybeOpenFsRepository::create(&root)
+        crate::storage::fs::MaybeOpenFsRepository::<RenderStore>::create(&root)
             .await
             .unwrap(),
     );

--- a/crates/spfs/src/clean.rs
+++ b/crates/spfs/src/clean.rs
@@ -570,7 +570,7 @@ where
     /// remove data that is still being used
     async unsafe fn remove_unvisited_renders_and_proxies(&self) -> Result<CleanResult> {
         let mut result = CleanResult::default();
-        let storage::RepositoryHandle::FS(repo) = self.repo else {
+        let storage::RepositoryHandle::FSWithRenders(repo) = self.repo else {
             return Ok(result);
         };
         let repo = repo.opened().await?;
@@ -715,8 +715,10 @@ where
                 let future = async move {
                     if !self.dry_run {
                         tracing::trace!(?path, "removing proxy render");
-                        storage::fs::OpenFsRepository::remove_dir_atomically(&path, &workdir)
-                            .await?;
+                        storage::fs::OpenFsRepository::<storage::fs::RenderStore>::remove_dir_atomically(
+                            &path, &workdir,
+                        )
+                        .await?;
                     }
                     Ok(digest)
                 };

--- a/crates/spfs/src/clean_test.rs
+++ b/crates/spfs/src/clean_test.rs
@@ -13,6 +13,7 @@ use tokio::time::sleep;
 use super::{Cleaner, TracingCleanReporter};
 use crate::encoding::prelude::*;
 use crate::fixtures::*;
+use crate::storage::fs::RenderStore;
 use crate::{storage, tracking, Error};
 
 #[rstest]
@@ -225,7 +226,7 @@ async fn test_clean_untagged_objects_layers_platforms(#[future] tmprepo: TempRep
 async fn test_clean_manifest_renders(tmpdir: tempfile::TempDir) {
     init_logging();
     let tmprepo = Arc::new(
-        storage::fs::MaybeOpenFsRepository::create(tmpdir.path())
+        storage::fs::MaybeOpenFsRepository::<RenderStore>::create(tmpdir.path())
             .await
             .unwrap()
             .into(),
@@ -249,7 +250,7 @@ async fn test_clean_manifest_renders(tmpdir: tempfile::TempDir) {
         .unwrap();
 
     let fs_repo = match &*tmprepo {
-        RepositoryHandle::FS(fs) => fs,
+        RepositoryHandle::FSWithRenders(fs) => fs,
         _ => panic!("Unexpected tmprepo type!"),
     };
     let fs_repo = fs_repo.opened().await.unwrap();
@@ -269,7 +270,7 @@ async fn test_clean_manifest_renders(tmpdir: tempfile::TempDir) {
         .expect("failed to clean repo");
     println!("{result:#?}");
 
-    let files = list_files(fs_repo.fs_impl.renders.as_ref().unwrap().renders.root());
+    let files = list_files(fs_repo.fs_impl.rs_impl.renders.root());
     assert_eq!(
         files,
         Vec::<String>::new(),

--- a/crates/spfs/src/commit_test.rs
+++ b/crates/spfs/src/commit_test.rs
@@ -6,6 +6,7 @@ use rstest::rstest;
 
 use super::Committer;
 use crate::fixtures::*;
+use crate::storage::fs::RenderStore;
 use crate::Error;
 
 #[rstest]
@@ -13,13 +14,13 @@ use crate::Error;
 async fn test_commit_empty(tmpdir: tempfile::TempDir) {
     let root = tmpdir.path().to_string_lossy().to_string();
     let repo = crate::storage::RepositoryHandle::from(
-        crate::storage::fs::MaybeOpenFsRepository::create(&root)
+        crate::storage::fs::MaybeOpenFsRepository::<RenderStore>::create(&root)
             .await
             .unwrap(),
     );
     let storage = crate::runtime::Storage::new(repo).unwrap();
     let repo = crate::storage::RepositoryHandle::from(
-        crate::storage::fs::MaybeOpenFsRepository::create(root)
+        crate::storage::fs::MaybeOpenFsRepository::<RenderStore>::create(root)
             .await
             .unwrap(),
     );

--- a/crates/spfs/src/config.rs
+++ b/crates/spfs/src/config.rs
@@ -311,9 +311,13 @@ impl RemoteConfig {
             inner,
         } = self;
         let mut handle: storage::RepositoryHandle = match inner.clone() {
-            RepositoryConfig::Fs(config) => storage::fs::MaybeOpenFsRepository::from_config(config)
-                .await?
-                .into(),
+            // Remote repositories never have a render store (from our
+            // perspective).
+            RepositoryConfig::Fs(config) => <storage::fs::MaybeOpenFsRepository<
+                storage::fs::NoRenderStore,
+            > as Into<storage::RepositoryHandle>>::into(
+                storage::fs::MaybeOpenFsRepository::from_config(config).await?,
+            ),
             RepositoryConfig::Tar(config) => storage::tar::TarRepository::from_config(config)
                 .await?
                 .into(),
@@ -532,7 +536,12 @@ impl Config {
     }
 
     /// Get the local repository instance as configured, creating it if needed.
-    pub async fn get_opened_local_repository(&self) -> Result<storage::fs::OpenFsRepository> {
+    pub async fn get_opened_local_repository<RS>(&self) -> Result<storage::fs::OpenFsRepository<RS>>
+    where
+        RS: storage::DefaultRenderStoreCreationPolicy
+            + storage::RenderStoreForUser<RenderStore = RS>
+            + Clone,
+    {
         // Possibly use a different path for the local repository, depending
         // on enabled features.
         #[allow(unused_mut)]
@@ -544,7 +553,7 @@ impl Config {
                 Some(self.storage.root.join("ci").join(format!("pipeline_{id}")));
         }
 
-        let mut local_repo = storage::fs::OpenFsRepository::create(
+        let mut local_repo = storage::fs::OpenFsRepository::<RS>::create(
             use_ci_isolated_storage_path
                 .as_ref()
                 .unwrap_or(&self.storage.root),
@@ -565,16 +574,24 @@ impl Config {
     ///
     /// The returned repo is guaranteed to be created, valid and open already. Ie
     /// the local repository is not allowed to be lazily opened.
-    pub async fn get_local_repository(&self) -> Result<storage::fs::OpenFsRepository> {
+    pub async fn get_local_repository<RS>(&self) -> Result<storage::fs::OpenFsRepository<RS>>
+    where
+        RS: storage::DefaultRenderStoreCreationPolicy
+            + storage::RenderStoreForUser<RenderStore = RS>
+            + Clone,
+    {
         self.get_opened_local_repository().await.map(Into::into)
     }
 
-    /// Get the local repository handle as configured,  creating it if needed.
+    /// Get the local repository handle as configured, creating it if needed.
     ///
     /// The returned repo is guaranteed to be created, valid and open already. Ie
     /// the local repository is not allowed to be lazily opened.
     pub async fn get_local_repository_handle(&self) -> Result<storage::RepositoryHandle> {
-        Ok(self.get_local_repository().await?.into())
+        Ok(self
+            .get_local_repository::<storage::fs::MaybeRenderStore>()
+            .await?
+            .into())
     }
 
     /// Get a remote repository by name, or the local repository.
@@ -590,14 +607,18 @@ impl Config {
     {
         match name {
             Some(name) => self.get_remote(name).await,
-            None => Ok(self.get_local_repository().await?.into()),
+            None => Ok(self
+                .get_local_repository::<storage::fs::MaybeRenderStore>()
+                .await?
+                .into()),
         }
     }
 
     /// Get the local runtime storage, as configured.
     pub async fn get_runtime_storage(&self) -> Result<runtime::Storage> {
         runtime::Storage::new(storage::RepositoryHandle::from(
-            self.get_local_repository().await?,
+            self.get_local_repository::<storage::fs::MaybeRenderStore>()
+                .await?,
         ))
     }
 

--- a/crates/spfs/src/config_test.rs
+++ b/crates/spfs/src/config_test.rs
@@ -5,6 +5,7 @@
 use rstest::rstest;
 
 use super::{Config, Remote, RemoteConfig, RepositoryConfig};
+use crate::storage::fs::NoRenderStore;
 use crate::storage::prelude::*;
 use crate::storage::RepositoryHandle;
 use crate::{get_config, load_config};
@@ -41,7 +42,7 @@ async fn test_config_get_remote() {
         .tempdir()
         .unwrap();
     let remote = tmpdir.path().join("remote");
-    let _ = crate::storage::fs::MaybeOpenFsRepository::create(&remote)
+    let _ = crate::storage::fs::MaybeOpenFsRepository::<NoRenderStore>::create(&remote)
         .await
         .unwrap();
 

--- a/crates/spfs/src/fixtures.rs
+++ b/crates/spfs/src/fixtures.rs
@@ -10,6 +10,7 @@ use rstest::fixture;
 use tempfile::TempDir;
 
 use crate as spfs;
+use crate::storage::fs::RenderStore;
 
 pub enum TempRepo {
     FS(Arc<spfs::storage::RepositoryHandle>, Arc<TempDir>),
@@ -39,13 +40,14 @@ impl TempRepo {
     {
         match self {
             TempRepo::FS(_, tempdir) => {
-                let repo = spfs::storage::fs::MaybeOpenFsRepository {
+                let repo = spfs::storage::fs::MaybeOpenFsRepository::<RenderStore> {
                     fs_impl: {
-                        let mut fs_impl = spfs::storage::fs::MaybeOpenFsRepositoryImpl::open(
-                            tempdir.path().join("repo"),
-                        )
-                        .await
-                        .unwrap();
+                        let mut fs_impl =
+                            spfs::storage::fs::MaybeOpenFsRepositoryImpl::<RenderStore>::open(
+                                tempdir.path().join("repo"),
+                            )
+                            .await
+                            .unwrap();
                         fs_impl.set_tag_namespace(Some(spfs::storage::TagNamespaceBuf::new(
                             namespace.as_ref(),
                         )));
@@ -143,10 +145,12 @@ pub async fn tmprepo(kind: &str) -> TempRepo {
     let tmpdir = tmpdir();
     match kind {
         "fs" => {
-            let repo = spfs::storage::fs::MaybeOpenFsRepository::create(tmpdir.path().join("repo"))
-                .await
-                .unwrap()
-                .into();
+            let repo = spfs::storage::fs::MaybeOpenFsRepository::<RenderStore>::create(
+                tmpdir.path().join("repo"),
+            )
+            .await
+            .unwrap()
+            .into();
             TempRepo::FS(Arc::new(repo), Arc::new(tmpdir))
         }
         "tar" => {
@@ -159,10 +163,12 @@ pub async fn tmprepo(kind: &str) -> TempRepo {
         #[cfg(feature = "server")]
         "rpc" => {
             use crate::storage::prelude::*;
-            let repo = std::sync::Arc::new(spfs::storage::RepositoryHandle::FS(
-                spfs::storage::fs::MaybeOpenFsRepository::create(tmpdir.path().join("repo"))
-                    .await
-                    .unwrap(),
+            let repo = std::sync::Arc::new(spfs::storage::RepositoryHandle::FSWithRenders(
+                spfs::storage::fs::MaybeOpenFsRepository::<RenderStore>::create(
+                    tmpdir.path().join("repo"),
+                )
+                .await
+                .unwrap(),
             ));
             let listen: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
             let http_listener = std::net::TcpListener::bind(listen).unwrap();

--- a/crates/spfs/src/resolve.rs
+++ b/crates/spfs/src/resolve.rs
@@ -4,6 +4,7 @@
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use futures::{FutureExt, TryFutureExt, TryStreamExt};
 use itertools::Itertools;
@@ -93,8 +94,10 @@ async fn render_via_subcommand(
 /// Compute or load the spfs manifest representation for a saved reference.
 pub async fn compute_manifest<R: AsRef<str>>(reference: R) -> Result<tracking::Manifest> {
     let config = get_config()?;
-    let mut repos: Vec<storage::RepositoryHandle> =
-        vec![config.get_local_repository().await?.into()];
+    let mut repos: Vec<storage::RepositoryHandle> = vec![config
+        .get_local_repository::<storage::fs::NoRenderStore>()
+        .await?
+        .into()];
     for name in config.list_remote_names() {
         match config.get_remote(&name).await {
             Ok(repo) => repos.push(repo),
@@ -364,13 +367,24 @@ where
 /// runtime is unconditionally saved shortly after calling this function.
 // Allow: not used on Windows.
 #[allow(dead_code)]
-pub(crate) async fn resolve_and_render_overlay_dirs(
+pub(crate) async fn resolve_and_render_overlay_dirs<RS>(
     runtime: &mut runtime::Runtime,
     skip_runtime_save: bool,
-) -> Result<RenderResult> {
+) -> Result<RenderResult>
+where
+    Arc<storage::fs::OpenFsRepository<RS>>: Into<storage::RepositoryHandle> + ManifestRenderPath,
+    RS: storage::DefaultRenderStoreCreationPolicy
+        + storage::LocalRenderStore<RenderStore = RS>
+        + Clone
+        + std::fmt::Debug
+        + Send
+        + Sync,
+{
     let config = get_config()?;
-    let (repo, remotes) =
-        tokio::try_join!(config.get_opened_local_repository(), config.list_remotes())?;
+    let (repo, remotes) = tokio::try_join!(
+        config.get_opened_local_repository::<RS>(),
+        config.list_remotes()
+    )?;
     let fallback_repo = FallbackProxy::new(repo, remotes);
 
     let manifests = resolve_overlay_dirs(runtime, &fallback_repo, skip_runtime_save).await?;
@@ -402,15 +416,27 @@ pub async fn resolve_stack_to_layers<'repo>(
         Some(repo) => repo,
         None => {
             let config = get_config()?;
-            owned_handle = storage::RepositoryHandle::from(config.get_local_repository().await?);
+            owned_handle = storage::RepositoryHandle::from(
+                config
+                    .get_local_repository::<storage::fs::NoRenderStore>()
+                    .await?,
+            );
             &owned_handle
         }
     };
     match repo {
-        storage::RepositoryHandle::FS(r) => resolve_stack_to_layers_with_repo(stack, r).await,
+        storage::RepositoryHandle::FSWithMaybeRenders(r) => {
+            resolve_stack_to_layers_with_repo(stack, r).await
+        }
+        storage::RepositoryHandle::FSWithRenders(r) => {
+            resolve_stack_to_layers_with_repo(stack, r).await
+        }
+        storage::RepositoryHandle::FSWithoutRenders(r) => {
+            resolve_stack_to_layers_with_repo(stack, r).await
+        }
         storage::RepositoryHandle::Tar(r) => resolve_stack_to_layers_with_repo(stack, r).await,
         storage::RepositoryHandle::Rpc(r) => resolve_stack_to_layers_with_repo(stack, r).await,
-        storage::RepositoryHandle::FallbackProxy(r) => {
+        storage::RepositoryHandle::FallbackProxyWithRenders(r) => {
             resolve_stack_to_layers_with_repo(stack, &**r).await
         }
         storage::RepositoryHandle::Proxy(r) => resolve_stack_to_layers_with_repo(stack, &**r).await,

--- a/crates/spfs/src/resolve_test.rs
+++ b/crates/spfs/src/resolve_test.rs
@@ -10,6 +10,7 @@ use super::resolve_stack_to_layers;
 use crate::fixtures::*;
 use crate::io::DigestFormat;
 use crate::prelude::*;
+use crate::storage::fs::RenderStore;
 use crate::{encoding, graph, io};
 
 #[rstest]
@@ -36,7 +37,7 @@ async fn test_auto_merge_layers(tmpdir: tempfile::TempDir) {
     // This test must use the "local" repository for spfs-render to succeed.
     let config = crate::get_config().expect("get config");
     let fs_repo = config
-        .get_opened_local_repository()
+        .get_opened_local_repository::<RenderStore>()
         .await
         .expect("open local repository");
     let repo = Arc::new(fs_repo.clone().into());
@@ -87,7 +88,7 @@ async fn test_auto_merge_layers_with_edit(tmpdir: tempfile::TempDir) {
     // This test must use the "local" repository for spfs-render to succeed.
     let config = crate::get_config().expect("get config");
     let fs_repo = config
-        .get_opened_local_repository()
+        .get_opened_local_repository::<RenderStore>()
         .await
         .expect("open local repository");
     let repo = Arc::new(fs_repo.clone().into());

--- a/crates/spfs/src/runtime/storage.rs
+++ b/crates/spfs/src/runtime/storage.rs
@@ -1177,7 +1177,7 @@ impl Storage {
 
     pub async fn durable_path(&self, name: String) -> Result<PathBuf> {
         match &*self.inner {
-            RepositoryHandle::FS(repo) => {
+            RepositoryHandle::FSWithRenders(repo) => {
                 let mut upper_root_path = repo.fs_impl.root();
                 upper_root_path.push(DURABLE_EDITS_DIR);
                 upper_root_path.push(name);

--- a/crates/spfs/src/runtime/storage_test.rs
+++ b/crates/spfs/src/runtime/storage_test.rs
@@ -16,6 +16,7 @@ use crate::fixtures::*;
 use crate::graph::object::{DigestStrategy, EncodingFormat};
 use crate::graph::{AnnotationValue, Layer, Platform};
 use crate::runtime::{BindMount, KeyValuePair, LiveLayer, LiveLayerContents, SpecApiVersion};
+use crate::storage::fs::RenderStore;
 use crate::storage::prelude::DatabaseExt;
 use crate::{encoding, Config};
 
@@ -35,7 +36,7 @@ fn test_config_serialization() {
 async fn test_storage_create_runtime(tmpdir: tempfile::TempDir) {
     let root = tmpdir.path().to_string_lossy().to_string();
     let repo = crate::storage::RepositoryHandle::from(
-        crate::storage::fs::MaybeOpenFsRepository::create(root)
+        crate::storage::fs::MaybeOpenFsRepository::<RenderStore>::create(root)
             .await
             .unwrap(),
     );
@@ -73,7 +74,7 @@ async fn test_storage_runtime_with_annotation(
 
     let root = tmpdir.path().to_string_lossy().to_string();
     let repo = crate::storage::RepositoryHandle::from(
-        crate::storage::fs::MaybeOpenFsRepository::create(root)
+        crate::storage::fs::MaybeOpenFsRepository::<RenderStore>::create(root)
             .await
             .unwrap(),
     );
@@ -139,7 +140,7 @@ async fn test_storage_runtime_add_annotations_list(
 
     let root = tmpdir.path().to_string_lossy().to_string();
     let repo = crate::storage::RepositoryHandle::from(
-        crate::storage::fs::MaybeOpenFsRepository::create(root)
+        crate::storage::fs::MaybeOpenFsRepository::<RenderStore>::create(root)
             .await
             .unwrap(),
     );
@@ -212,7 +213,7 @@ async fn test_storage_runtime_with_nested_annotation(
     // Setup the objects needed for the runtime used in the test
     let root = tmpdir.path().to_string_lossy().to_string();
     let repo = crate::storage::RepositoryHandle::from(
-        crate::storage::fs::MaybeOpenFsRepository::create(root)
+        crate::storage::fs::MaybeOpenFsRepository::<RenderStore>::create(root)
             .await
             .unwrap(),
     );
@@ -281,7 +282,7 @@ async fn test_storage_runtime_with_annotation_all(
 
     let root = tmpdir.path().to_string_lossy().to_string();
     let repo = crate::storage::RepositoryHandle::from(
-        crate::storage::fs::MaybeOpenFsRepository::create(root)
+        crate::storage::fs::MaybeOpenFsRepository::<RenderStore>::create(root)
             .await
             .unwrap(),
     );
@@ -355,7 +356,7 @@ async fn test_storage_runtime_with_nested_annotation_all(
     // setup the objects needed for the runtime used in the test
     let root = tmpdir.path().to_string_lossy().to_string();
     let repo = crate::storage::RepositoryHandle::from(
-        crate::storage::fs::MaybeOpenFsRepository::create(root)
+        crate::storage::fs::MaybeOpenFsRepository::<RenderStore>::create(root)
             .await
             .unwrap(),
     );
@@ -431,7 +432,7 @@ async fn test_storage_runtime_with_nested_annotation_all(
 async fn test_storage_remove_runtime(tmpdir: tempfile::TempDir) {
     let root = tmpdir.path().to_string_lossy().to_string();
     let repo = crate::storage::RepositoryHandle::from(
-        crate::storage::fs::MaybeOpenFsRepository::create(root)
+        crate::storage::fs::MaybeOpenFsRepository::<RenderStore>::create(root)
             .await
             .unwrap(),
     );
@@ -452,7 +453,7 @@ async fn test_storage_remove_runtime(tmpdir: tempfile::TempDir) {
 async fn test_storage_iter_runtimes(tmpdir: tempfile::TempDir) {
     let root = tmpdir.path().to_string_lossy().to_string();
     let repo = crate::storage::RepositoryHandle::from(
-        crate::storage::fs::MaybeOpenFsRepository::create(root)
+        crate::storage::fs::MaybeOpenFsRepository::<RenderStore>::create(root)
             .await
             .unwrap(),
     );
@@ -504,7 +505,7 @@ async fn test_storage_iter_runtimes(tmpdir: tempfile::TempDir) {
 async fn test_runtime_reset(tmpdir: tempfile::TempDir) {
     let root = tmpdir.path().to_string_lossy().to_string();
     let repo = crate::storage::RepositoryHandle::from(
-        crate::storage::fs::MaybeOpenFsRepository::create(root)
+        crate::storage::fs::MaybeOpenFsRepository::<RenderStore>::create(root)
             .await
             .unwrap(),
     );
@@ -551,7 +552,7 @@ async fn test_runtime_reset(tmpdir: tempfile::TempDir) {
 async fn test_runtime_ensure_extra_bind_mount_locations_exist(tmpdir: tempfile::TempDir) {
     let root = tmpdir.path().to_string_lossy().to_string();
     let repo = crate::storage::RepositoryHandle::from(
-        crate::storage::fs::MaybeOpenFsRepository::create(root)
+        crate::storage::fs::MaybeOpenFsRepository::<RenderStore>::create(root)
             .await
             .unwrap(),
     );

--- a/crates/spfs/src/status_unix.rs
+++ b/crates/spfs/src/status_unix.rs
@@ -3,7 +3,7 @@
 // https://github.com/spkenv/spk
 
 use crate::resolve::{resolve_and_render_overlay_dirs, RenderResult};
-use crate::storage::fs::RenderSummary;
+use crate::storage::fs::{RenderStore, RenderSummary};
 use crate::{bootstrap, env, runtime, Error, Result};
 
 /// Remount the given runtime as configured.
@@ -102,7 +102,7 @@ pub async fn change_to_durable_runtime(rt: &mut runtime::Runtime) -> Result<Rend
     // remount the overlayfs only, using its new durable path settings
     let render_result = match rt.config.mount_backend {
         runtime::MountBackend::OverlayFsWithRenders => {
-            resolve_and_render_overlay_dirs(rt, false).await?
+            resolve_and_render_overlay_dirs::<RenderStore>(rt, false).await?
         }
         runtime::MountBackend::OverlayFsWithFuse
         | runtime::MountBackend::FuseOnly
@@ -128,7 +128,7 @@ pub async fn change_to_durable_runtime(rt: &mut runtime::Runtime) -> Result<Rend
 pub async fn reinitialize_runtime(rt: &mut runtime::Runtime) -> Result<RenderSummary> {
     let render_result = match rt.config.mount_backend {
         runtime::MountBackend::OverlayFsWithRenders => {
-            resolve_and_render_overlay_dirs(rt, false).await?
+            resolve_and_render_overlay_dirs::<RenderStore>(rt, false).await?
         }
         runtime::MountBackend::OverlayFsWithFuse
         | runtime::MountBackend::FuseOnly
@@ -197,7 +197,7 @@ pub async fn initialize_runtime(rt: &mut runtime::Runtime) -> Result<RenderSumma
 
     let render_result = match rt.config.mount_backend {
         runtime::MountBackend::OverlayFsWithRenders => {
-            resolve_and_render_overlay_dirs(
+            resolve_and_render_overlay_dirs::<RenderStore>(
                 rt,
                 // skip saving the runtime in this step because we will save it after
                 // learning the mount namespace below

--- a/crates/spfs/src/storage/fallback/repository.rs
+++ b/crates/spfs/src/storage/fallback/repository.rs
@@ -13,9 +13,27 @@ use relative_path::RelativePath;
 use crate::config::ToAddress;
 use crate::graph::ObjectProto;
 use crate::prelude::*;
-use crate::storage::fs::{FsHashStore, ManifestRenderPath, OpenFsRepository, RenderStore};
+use crate::storage::fs::{
+    FsHashStore,
+    ManifestRenderPath,
+    MaybeRenderStore,
+    OpenFsRepository,
+    RenderStore,
+    RenderStoreCreationPolicy,
+};
 use crate::storage::tag::TagSpecAndTagStream;
-use crate::storage::{EntryType, LocalRepository, TagNamespace, TagNamespaceBuf, TagStorageMut};
+use crate::storage::{
+    EntryType,
+    LocalPayloads,
+    LocalRenderStore,
+    OpenRepositoryError,
+    OpenRepositoryResult,
+    RenderStoreForUser,
+    TagNamespace,
+    TagNamespaceBuf,
+    TagStorageMut,
+    TryRenderStore,
+};
 use crate::sync::reporter::SyncReporters;
 use crate::tracking::BlobRead;
 use crate::{encoding, graph, storage, tracking, Error, Result};
@@ -64,18 +82,18 @@ impl storage::FromUrl for Config {
 /// payloads are copied into the primary repository. Missing blobs are also
 /// repaired in the same way.
 #[derive(Debug)]
-pub struct FallbackProxy {
+pub struct FallbackProxy<RS> {
     // Why isn't this a RepositoryHandle?
     //
-    // It needs to be something that implements LocalRepository so this
+    // It needs to be something that implements LocalPayloads so this
     // struct can implement it too. RepositoryHandle can't implement that
     // trait.
-    primary: Arc<OpenFsRepository>,
+    primary: Arc<OpenFsRepository<RS>>,
     secondary: Vec<crate::storage::RepositoryHandle>,
 }
 
-impl FallbackProxy {
-    pub fn new<P: Into<Arc<OpenFsRepository>>>(
+impl<RS> FallbackProxy<RS> {
+    pub fn new<P: Into<Arc<OpenFsRepository<RS>>>>(
         primary: P,
         secondary: Vec<crate::storage::RepositoryHandle>,
     ) -> Self {
@@ -87,7 +105,10 @@ impl FallbackProxy {
 }
 
 #[async_trait::async_trait]
-impl graph::DatabaseView for FallbackProxy {
+impl<RS> graph::DatabaseView for FallbackProxy<RS>
+where
+    RS: Send + Sync,
+{
     async fn has_object(&self, digest: encoding::Digest) -> bool {
         if self.primary.has_object(digest).await {
             return true;
@@ -156,7 +177,10 @@ impl graph::DatabaseView for FallbackProxy {
 }
 
 #[async_trait::async_trait]
-impl graph::Database for FallbackProxy {
+impl<RS> graph::Database for FallbackProxy<RS>
+where
+    RS: Send + Sync,
+{
     async fn remove_object(&self, digest: encoding::Digest) -> Result<()> {
         self.primary.remove_object(digest).await?;
         Ok(())
@@ -175,7 +199,10 @@ impl graph::Database for FallbackProxy {
 }
 
 #[async_trait::async_trait]
-impl graph::DatabaseExt for FallbackProxy {
+impl<RS> graph::DatabaseExt for FallbackProxy<RS>
+where
+    RS: Send + Sync,
+{
     async fn write_object<T: ObjectProto>(&self, obj: &graph::FlatObject<T>) -> Result<()> {
         self.primary.write_object(obj).await?;
         Ok(())
@@ -183,7 +210,11 @@ impl graph::DatabaseExt for FallbackProxy {
 }
 
 #[async_trait::async_trait]
-impl PayloadStorage for FallbackProxy {
+impl<RS> PayloadStorage for FallbackProxy<RS>
+where
+    Arc<OpenFsRepository<RS>>: Into<crate::storage::RepositoryHandle>,
+    RS: Send + Sync,
+{
     async fn has_payload(&self, digest: encoding::Digest) -> bool {
         if self.primary.has_payload(digest).await {
             return true;
@@ -289,7 +320,10 @@ impl PayloadStorage for FallbackProxy {
 }
 
 #[async_trait::async_trait]
-impl TagStorage for FallbackProxy {
+impl<RS> TagStorage for FallbackProxy<RS>
+where
+    RS: Send + Sync,
+{
     #[inline]
     fn get_tag_namespace(&self) -> Option<Cow<'_, TagNamespace>> {
         self.primary.get_tag_namespace()
@@ -356,7 +390,10 @@ impl TagStorage for FallbackProxy {
     }
 }
 
-impl TagStorageMut for FallbackProxy {
+impl<RS> TagStorageMut for FallbackProxy<RS>
+where
+    RS: Clone,
+{
     fn try_set_tag_namespace(
         &mut self,
         tag_namespace: Option<TagNamespaceBuf>,
@@ -366,7 +403,7 @@ impl TagStorageMut for FallbackProxy {
     }
 }
 
-impl Address for FallbackProxy {
+impl<RS> Address for FallbackProxy<RS> {
     fn address(&self) -> Cow<'_, url::Url> {
         let config = Config {
             primary: self.primary.address().to_string(),
@@ -384,20 +421,61 @@ impl Address for FallbackProxy {
     }
 }
 
-impl LocalRepository for FallbackProxy {
+impl<RS> LocalPayloads for FallbackProxy<RS> {
     #[inline]
     fn payloads(&self) -> &FsHashStore {
         self.primary.fs_impl.payloads()
     }
+}
 
+impl<RS> LocalRenderStore for FallbackProxy<RS>
+where
+    RS: LocalRenderStore + RenderStoreForUser<RenderStore = RS>,
+{
     #[inline]
-    fn render_store(&self) -> Result<&RenderStore> {
-        self.primary.fs_impl.render_store()
+    fn render_store(&self) -> &RenderStore {
+        self.primary.fs_impl.rs_impl.render_store()
     }
 }
 
-impl ManifestRenderPath for FallbackProxy {
+impl<RS> ManifestRenderPath for FallbackProxy<RS>
+where
+    Arc<OpenFsRepository<RS>>: ManifestRenderPath,
+{
     fn manifest_render_path(&self, manifest: &graph::Manifest) -> Result<std::path::PathBuf> {
         self.primary.manifest_render_path(manifest)
+    }
+}
+
+impl<RS> RenderStoreForUser for FallbackProxy<RS>
+where
+    RS: RenderStoreForUser<RenderStore = RS>,
+{
+    type RenderStore = RS;
+
+    fn render_store_for_user(
+        _creation_policy: RenderStoreCreationPolicy,
+        _url: url::Url,
+        _root: &std::path::Path,
+        _username: &std::path::Path,
+    ) -> OpenRepositoryResult<Self::RenderStore> {
+        todo!()
+    }
+}
+
+impl<RS> TryRenderStore for FallbackProxy<RS>
+where
+    RS: TryRenderStore,
+{
+    fn try_render_store(&self) -> Result<&RenderStore> {
+        self.primary.fs_impl.rs_impl.try_render_store()
+    }
+}
+
+impl TryFrom<FallbackProxy<MaybeRenderStore>> for FallbackProxy<RenderStore> {
+    type Error = OpenRepositoryError;
+
+    fn try_from(_value: FallbackProxy<MaybeRenderStore>) -> OpenRepositoryResult<Self> {
+        todo!()
     }
 }

--- a/crates/spfs/src/storage/fallback/repository_test.rs
+++ b/crates/spfs/src/storage/fallback/repository_test.rs
@@ -8,6 +8,7 @@ use rstest::rstest;
 
 use crate::fixtures::*;
 use crate::prelude::*;
+use crate::storage::fs::RenderStore;
 
 #[rstest]
 #[tokio::test]
@@ -15,14 +16,16 @@ async fn test_proxy_payload_repair(tmpdir: tempfile::TempDir) {
     init_logging();
 
     let primary = Arc::new(
-        crate::storage::fs::OpenFsRepository::create(tmpdir.path().join("primary"))
+        crate::storage::fs::OpenFsRepository::<RenderStore>::create(tmpdir.path().join("primary"))
             .await
             .unwrap(),
     );
     let secondary = Arc::new(
-        crate::storage::fs::OpenFsRepository::create(tmpdir.path().join("secondary"))
-            .await
-            .unwrap(),
+        crate::storage::fs::OpenFsRepository::<RenderStore>::create(
+            tmpdir.path().join("secondary"),
+        )
+        .await
+        .unwrap(),
     );
 
     let digest = primary
@@ -44,7 +47,7 @@ async fn test_proxy_payload_repair(tmpdir: tempfile::TempDir) {
     assert!(err.is_err());
 
     // Loading the payload through the fallback should succeed.
-    let proxy = super::FallbackProxy::new(primary, vec![secondary.into()]);
+    let proxy = super::FallbackProxy::<RenderStore>::new(primary, vec![secondary.into()]);
     proxy
         .open_payload(digest)
         .await

--- a/crates/spfs/src/storage/fs/database.rs
+++ b/crates/spfs/src/storage/fs/database.rs
@@ -12,11 +12,20 @@ use encoding::prelude::*;
 use futures::{Stream, StreamExt, TryFutureExt};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
+use super::DefaultRenderStoreCreationPolicy;
 use crate::graph::{DatabaseView, Object, ObjectProto};
+use crate::storage::RenderStoreForUser;
 use crate::{encoding, graph, Error, Result};
 
 #[async_trait::async_trait]
-impl DatabaseView for super::MaybeOpenFsRepository {
+impl<RS> DatabaseView for super::MaybeOpenFsRepository<RS>
+where
+    RS: DefaultRenderStoreCreationPolicy
+        + RenderStoreForUser<RenderStore = RS>
+        + Send
+        + Sync
+        + 'static,
+{
     async fn has_object(&self, digest: encoding::Digest) -> bool {
         let Ok(opened) = self.opened().await else {
             return false;
@@ -55,7 +64,14 @@ impl DatabaseView for super::MaybeOpenFsRepository {
 }
 
 #[async_trait::async_trait]
-impl graph::Database for super::MaybeOpenFsRepository {
+impl<RS> graph::Database for super::MaybeOpenFsRepository<RS>
+where
+    RS: DefaultRenderStoreCreationPolicy
+        + RenderStoreForUser<RenderStore = RS>
+        + Send
+        + Sync
+        + 'static,
+{
     async fn remove_object(&self, digest: encoding::Digest) -> crate::Result<()> {
         self.opened().await?.remove_object(digest).await
     }
@@ -73,14 +89,24 @@ impl graph::Database for super::MaybeOpenFsRepository {
 }
 
 #[async_trait::async_trait]
-impl graph::DatabaseExt for super::MaybeOpenFsRepository {
+impl<RS> graph::DatabaseExt for super::MaybeOpenFsRepository<RS>
+where
+    RS: DefaultRenderStoreCreationPolicy
+        + RenderStoreForUser<RenderStore = RS>
+        + Send
+        + Sync
+        + 'static,
+{
     async fn write_object<T: ObjectProto>(&self, obj: &graph::FlatObject<T>) -> Result<()> {
         self.opened().await?.write_object(obj).await
     }
 }
 
 #[async_trait::async_trait]
-impl DatabaseView for super::OpenFsRepository {
+impl<RS> DatabaseView for super::OpenFsRepository<RS>
+where
+    RS: Send + Sync,
+{
     async fn has_object(&self, digest: encoding::Digest) -> bool {
         let filepath = self.fs_impl.objects.build_digest_path(&digest);
         tokio::fs::symlink_metadata(filepath).await.is_ok()
@@ -129,7 +155,10 @@ impl DatabaseView for super::OpenFsRepository {
 }
 
 #[async_trait::async_trait]
-impl graph::Database for super::OpenFsRepository {
+impl<RS> graph::Database for super::OpenFsRepository<RS>
+where
+    RS: Send + Sync,
+{
     async fn remove_object(&self, digest: encoding::Digest) -> crate::Result<()> {
         let filepath = self.fs_impl.objects.build_digest_path(&digest);
 
@@ -200,7 +229,10 @@ impl graph::Database for super::OpenFsRepository {
 }
 
 #[async_trait::async_trait]
-impl graph::DatabaseExt for super::OpenFsRepository {
+impl<RS> graph::DatabaseExt for super::OpenFsRepository<RS>
+where
+    RS: Send + Sync,
+{
     async fn write_object<T: ObjectProto>(&self, obj: &graph::FlatObject<T>) -> Result<()> {
         let digest = obj.digest()?;
         let filepath = self.fs_impl.objects.build_digest_path(&digest);

--- a/crates/spfs/src/storage/fs/hash_store.rs
+++ b/crates/spfs/src/storage/fs/hash_store.rs
@@ -36,6 +36,7 @@ pub(crate) enum PersistableObject {
     },
 }
 
+#[derive(Debug)]
 pub struct FsHashStore {
     root: PathBuf,
     /// permissions used when creating new directories

--- a/crates/spfs/src/storage/fs/manifest_render_path.rs
+++ b/crates/spfs/src/storage/fs/manifest_render_path.rs
@@ -3,6 +3,7 @@
 // https://github.com/spkenv/spk
 
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use crate::{graph, Result};
 
@@ -13,6 +14,16 @@ pub trait ManifestRenderPath {
 }
 
 impl<T> ManifestRenderPath for &T
+where
+    T: ManifestRenderPath,
+{
+    #[inline]
+    fn manifest_render_path(&self, manifest: &graph::Manifest) -> Result<PathBuf> {
+        T::manifest_render_path(self, manifest)
+    }
+}
+
+impl<T> ManifestRenderPath for Arc<T>
 where
     T: ManifestRenderPath,
 {

--- a/crates/spfs/src/storage/fs/mod.rs
+++ b/crates/spfs/src/storage/fs/mod.rs
@@ -38,10 +38,14 @@ pub use repository::MaybeOpenFsRepositoryImpl;
 pub use repository::{
     read_last_migration_version,
     Config,
+    DefaultRenderStoreCreationPolicy,
     FsRepositoryOps,
     MaybeOpenFsRepository,
+    MaybeRenderStore,
+    NoRenderStore,
     OpenFsRepository,
     Params,
     RenderStore,
+    RenderStoreCreationPolicy,
     DURABLE_EDITS_DIR,
 };

--- a/crates/spfs/src/storage/fs/payloads.rs
+++ b/crates/spfs/src/storage/fs/payloads.rs
@@ -8,13 +8,21 @@ use std::pin::Pin;
 use futures::future::ready;
 use futures::{Stream, StreamExt, TryFutureExt};
 
-use super::{MaybeOpenFsRepository, OpenFsRepository};
+use super::{DefaultRenderStoreCreationPolicy, MaybeOpenFsRepository, OpenFsRepository};
 use crate::storage::prelude::*;
+use crate::storage::RenderStoreForUser;
 use crate::tracking::BlobRead;
 use crate::{encoding, graph, Error, Result};
 
 #[async_trait::async_trait]
-impl crate::storage::PayloadStorage for MaybeOpenFsRepository {
+impl<RS> crate::storage::PayloadStorage for MaybeOpenFsRepository<RS>
+where
+    RS: DefaultRenderStoreCreationPolicy
+        + RenderStoreForUser<RenderStore = RS>
+        + Send
+        + Sync
+        + 'static,
+{
     async fn has_payload(&self, digest: encoding::Digest) -> bool {
         let Ok(opened) = self.opened().await else {
             return false;
@@ -52,7 +60,10 @@ impl crate::storage::PayloadStorage for MaybeOpenFsRepository {
 }
 
 #[async_trait::async_trait]
-impl crate::storage::PayloadStorage for OpenFsRepository {
+impl<RS> crate::storage::PayloadStorage for OpenFsRepository<RS>
+where
+    RS: Send + Sync,
+{
     async fn has_payload(&self, digest: encoding::Digest) -> bool {
         let path = self.fs_impl.payloads.build_digest_path(&digest);
         tokio::fs::symlink_metadata(path).await.is_ok()

--- a/crates/spfs/src/storage/fs/renderer.rs
+++ b/crates/spfs/src/storage/fs/renderer.rs
@@ -25,7 +25,7 @@ use crate::storage::fs::{
     RenderReporter,
     SilentRenderReporter,
 };
-use crate::storage::LocalRepository;
+use crate::storage::{LocalPayloads, LocalRenderStore, TryRenderStore};
 use crate::{encoding, graph, tracking, Error, OsError, Result};
 
 #[cfg(test)]
@@ -73,19 +73,16 @@ impl From<CliRenderType> for RenderType {
     }
 }
 
-impl OpenFsRepository {
+impl<RS> OpenFsRepository<RS>
+where
+    RS: LocalRenderStore + Send + Sync,
+{
     fn get_render_storage(&self) -> Result<&crate::storage::fs::FsHashStore> {
-        match &self.fs_impl.renders {
-            Some(render_store) => Ok(&render_store.renders),
-            None => Err(Error::NoRenderStorage(self.address().into_owned())),
-        }
+        Ok(&self.fs_impl.rs_impl.render_store().renders)
     }
 
     pub async fn has_rendered_manifest(&self, digest: encoding::Digest) -> bool {
-        let renders = match &self.fs_impl.renders {
-            Some(render_store) => &render_store.renders,
-            None => return false,
-        };
+        let renders = &self.fs_impl.rs_impl.render_store().renders;
         let rendered_dir = renders.build_digest_path(&digest);
         was_render_completed(rendered_dir).await
     }
@@ -102,18 +99,12 @@ impl OpenFsRepository {
     }
 
     pub fn proxy_path(&self) -> Option<&std::path::Path> {
-        self.fs_impl
-            .renders
-            .as_ref()
-            .map(|render_store| render_store.proxy.root())
+        Some(self.fs_impl.rs_impl.render_store().proxy.root())
     }
 
     /// Remove the identified render from this storage.
     pub async fn remove_rendered_manifest(&self, digest: crate::encoding::Digest) -> Result<()> {
-        let renders = match &self.fs_impl.renders {
-            Some(render_store) => &render_store.renders,
-            None => return Ok(()),
-        };
+        let renders = &self.fs_impl.rs_impl.render_store().renders;
         let rendered_dirpath = renders.build_digest_path(&digest);
         let workdir = renders.workdir();
         if let Err(err) = makedirs_with_perms(&workdir, renders.directory_permissions) {
@@ -126,33 +117,13 @@ impl OpenFsRepository {
         Self::remove_dir_atomically(&rendered_dirpath, &workdir).await
     }
 
-    pub(crate) async fn remove_dir_atomically(dirpath: &Path, workdir: &Path) -> Result<()> {
-        let uuid = uuid::Uuid::new_v4().to_string();
-        let working_dirpath = workdir.join(uuid);
-        if let Err(err) = tokio::fs::rename(&dirpath, &working_dirpath).await {
-            return match err.kind() {
-                std::io::ErrorKind::NotFound => Ok(()),
-                _ => Err(crate::Error::StorageWriteError(
-                    "rename on render before removal",
-                    working_dirpath,
-                    err,
-                )),
-            };
-        }
-
-        open_perms_and_remove_all(&working_dirpath).await
-    }
-
     /// Returns true if the render was actually removed
     pub async fn remove_rendered_manifest_if_older_than(
         &self,
         older_than: DateTime<Utc>,
         digest: encoding::Digest,
     ) -> Result<bool> {
-        let renders = match &self.fs_impl.renders {
-            Some(render_store) => &render_store.renders,
-            None => return Ok(false),
-        };
+        let renders = &self.fs_impl.rs_impl.render_store().renders;
         let rendered_dirpath = renders.build_digest_path(&digest);
 
         let metadata = match tokio::fs::symlink_metadata(&rendered_dirpath).await {
@@ -184,7 +155,29 @@ impl OpenFsRepository {
     }
 }
 
-impl ManifestRenderPath for OpenFsRepository {
+impl<FS> OpenFsRepository<FS> {
+    pub(crate) async fn remove_dir_atomically(dirpath: &Path, workdir: &Path) -> Result<()> {
+        let uuid = uuid::Uuid::new_v4().to_string();
+        let working_dirpath = workdir.join(uuid);
+        if let Err(err) = tokio::fs::rename(&dirpath, &working_dirpath).await {
+            return match err.kind() {
+                std::io::ErrorKind::NotFound => Ok(()),
+                _ => Err(crate::Error::StorageWriteError(
+                    "rename on render before removal",
+                    working_dirpath,
+                    err,
+                )),
+            };
+        }
+
+        open_perms_and_remove_all(&working_dirpath).await
+    }
+}
+
+impl<RS> ManifestRenderPath for OpenFsRepository<RS>
+where
+    RS: LocalRenderStore + Send + Sync,
+{
     fn manifest_render_path(&self, manifest: &graph::Manifest) -> Result<PathBuf> {
         Ok(self
             .get_render_storage()?
@@ -240,7 +233,7 @@ impl<'repo, Repo> Renderer<'repo, Repo, SilentRenderReporter> {
 
 impl<'repo, Repo, Reporter> Renderer<'repo, Repo, Reporter>
 where
-    Repo: Repository + LocalRepository,
+    Repo: Repository + LocalPayloads,
     Reporter: RenderReporter,
 {
     /// Report progress to the given instance, replacing any existing one
@@ -276,36 +269,13 @@ where
         self.max_concurrent_branches = max_concurrent_branches;
         self
     }
+}
 
-    /// Render all layers in the given env to the render storage of the underlying
-    /// repository, returning the paths to all relevant layers in the appropriate order.
-    pub async fn render(
-        &self,
-        stack: &graph::Stack,
-        render_type: Option<RenderType>,
-    ) -> Result<Vec<PathBuf>> {
-        let layers = crate::resolve::resolve_stack_to_layers_with_repo(stack, self.repo)
-            .await
-            .map_err(|err| err.wrap("resolve stack to layers"))?;
-        let mut futures = futures::stream::FuturesOrdered::new();
-        for layer in layers {
-            if let Some(manifest_digest) = layer.manifest() {
-                let digest = *manifest_digest;
-                let fut = self
-                    .repo
-                    .read_manifest(digest)
-                    .map_err(move |err| err.wrap(format!("read manifest {digest}")))
-                    .and_then(move |manifest| async move {
-                        self.render_manifest(&manifest, render_type)
-                            .await
-                            .map_err(move |err| err.wrap(format!("render manifest {digest}")))
-                    });
-                futures.push_back(fut);
-            }
-        }
-        futures.try_collect().await
-    }
-
+impl<'repo, Repo, Reporter> Renderer<'repo, Repo, Reporter>
+where
+    Repo: Repository + LocalPayloads + TryRenderStore,
+    Reporter: RenderReporter,
+{
     /// Recreate the full structure of a stored environment on disk
     pub async fn render_into_directory<E: Into<tracking::EnvSpec>, P: AsRef<Path>>(
         &self,
@@ -335,6 +305,41 @@ where
         self.render_manifest_into_dir(&manifest, target_dir, render_type)
             .await
     }
+}
+
+impl<'repo, Repo, Reporter> Renderer<'repo, Repo, Reporter>
+where
+    Repo: Repository + LocalPayloads + LocalRenderStore + TryRenderStore,
+    Reporter: RenderReporter,
+{
+    /// Render all layers in the given env to the render storage of the underlying
+    /// repository, returning the paths to all relevant layers in the appropriate order.
+    pub async fn render(
+        &self,
+        stack: &graph::Stack,
+        render_type: Option<RenderType>,
+    ) -> Result<Vec<PathBuf>> {
+        let layers = crate::resolve::resolve_stack_to_layers_with_repo(stack, self.repo)
+            .await
+            .map_err(|err| err.wrap("resolve stack to layers"))?;
+        let mut futures = futures::stream::FuturesOrdered::new();
+        for layer in layers {
+            if let Some(manifest_digest) = layer.manifest() {
+                let digest = *manifest_digest;
+                let fut = self
+                    .repo
+                    .read_manifest(digest)
+                    .map_err(move |err| err.wrap(format!("read manifest {digest}")))
+                    .and_then(move |manifest| async move {
+                        self.render_manifest(&manifest, render_type)
+                            .await
+                            .map_err(move |err| err.wrap(format!("render manifest {digest}")))
+                    });
+                futures.push_back(fut);
+            }
+        }
+        futures.try_collect().await
+    }
 
     /// Render a manifest into the renders area of the underlying repository,
     /// returning the absolute local path of the directory.
@@ -343,7 +348,7 @@ where
         manifest: &graph::Manifest,
         render_type: Option<RenderType>,
     ) -> Result<PathBuf> {
-        let render_store = self.repo.render_store()?;
+        let render_store = self.repo.render_store();
         let rendered_dirpath = render_store.renders.build_digest_path(&manifest.digest()?);
         if was_render_completed(&rendered_dirpath).await {
             tracing::trace!(path = ?rendered_dirpath, "render already completed");

--- a/crates/spfs/src/storage/fs/renderer_test.rs
+++ b/crates/spfs/src/storage/fs/renderer_test.rs
@@ -10,7 +10,7 @@ use super::was_render_completed;
 use crate::encoding::prelude::*;
 use crate::fixtures::*;
 use crate::graph::object::{DigestStrategy, EncodingFormat};
-use crate::storage::fs::{MaybeOpenFsRepository, OpenFsRepository};
+use crate::storage::fs::{MaybeOpenFsRepository, OpenFsRepository, RenderStore};
 use crate::storage::{RepositoryExt, RepositoryHandle};
 use crate::{tracking, Config};
 
@@ -30,7 +30,7 @@ async fn test_render_manifest(
     config.storage.digest_strategy = write_digest_strategy;
     config.make_current().unwrap();
 
-    let storage = OpenFsRepository::create(tmpdir.path().join("storage"))
+    let storage = OpenFsRepository::<RenderStore>::create(tmpdir.path().join("storage"))
         .await
         .unwrap();
 
@@ -83,7 +83,7 @@ async fn test_render_manifest_with_repo(
     config.make_current().unwrap();
 
     let tmprepo = Arc::new(
-        MaybeOpenFsRepository::create(tmpdir.path().join("repo"))
+        MaybeOpenFsRepository::<RenderStore>::create(tmpdir.path().join("repo"))
             .await
             .unwrap()
             .into(),
@@ -102,15 +102,13 @@ async fn test_render_manifest_with_repo(
 
     // Safety: tmprepo was created as an FsRepository
     let tmprepo = match &*tmprepo {
-        RepositoryHandle::FS(fs) => fs.opened().await.unwrap(),
+        RepositoryHandle::FSWithRenders(fs) => fs.opened().await.unwrap(),
         _ => panic!("Unexpected tmprepo type!"),
     };
 
     let render = tmprepo
         .fs_impl
-        .renders
-        .as_ref()
-        .unwrap()
+        .rs_impl
         .renders
         .build_digest_path(&manifest.digest().unwrap());
     assert!(!render.exists(), "render should NOT be seen as existing");

--- a/crates/spfs/src/storage/fs/renderer_unix.rs
+++ b/crates/spfs/src/storage/fs/renderer_unix.rs
@@ -19,12 +19,12 @@ use super::{BlobSemaphorePermit, HardLinkRenderType, RenderType, Renderer};
 use crate::prelude::*;
 use crate::storage::fs::render_reporter::RenderBlobResult;
 use crate::storage::fs::RenderReporter;
-use crate::storage::LocalRepository;
+use crate::storage::{LocalPayloads, TryRenderStore};
 use crate::{get_config, graph, tracking, Error, OsError, Result};
 
 impl<'repo, Repo, Reporter> Renderer<'repo, Repo, Reporter>
 where
-    Repo: Repository + LocalRepository,
+    Repo: Repository + LocalPayloads + TryRenderStore,
     Reporter: RenderReporter,
 {
     /// Recreate the full structure of a stored manifest on disk.
@@ -227,7 +227,7 @@ where
             let render_blob_result = if matches!(render_type, HardLinkRenderType::WithoutProxy) {
                 // explicitly skip proxy generation
                 RenderBlobResult::PayloadCopiedByRequest
-            } else if let Ok(render_store) = self.repo.render_store() {
+            } else if let Ok(render_store) = self.repo.try_render_store() {
                 let proxy_path = render_store
                     .proxy
                     .build_digest_path(entry.object())

--- a/crates/spfs/src/storage/fs/repository.rs
+++ b/crates/spfs/src/storage/fs/repository.rs
@@ -24,11 +24,14 @@ use crate::config::{pathbuf_deserialize_with_tilde_expansion, ToAddress};
 use crate::runtime::makedirs_with_perms;
 use crate::storage::prelude::*;
 use crate::storage::{
-    LocalRepository,
+    LocalPayloads,
+    LocalRenderStore,
     OpenRepositoryError,
     OpenRepositoryResult,
+    RenderStoreForUser,
     TagNamespace,
     TagNamespaceBuf,
+    TryRenderStore,
 };
 use crate::{Error, Result};
 
@@ -89,32 +92,198 @@ impl FromUrl for Config {
 }
 
 /// Renders need a place for proxy files and the rendered hard links.
+///
+/// An instance of `RenderStore` represents a valid render store that has
+/// already been created.
+#[derive(Debug)]
 pub struct RenderStore {
+    url: url::Url,
     pub proxy: FsHashStore,
     pub renders: FsHashStore,
 }
 
-impl RenderStore {
-    pub fn for_user<P: AsRef<Path>>(root: &Path, username: P) -> Result<Self> {
-        let username = username.as_ref();
+impl DefaultRenderStoreCreationPolicy for RenderStore {
+    fn default_creation_policy() -> RenderStoreCreationPolicy {
+        RenderStoreCreationPolicy::CreateIfMissing
+    }
+}
+
+impl LocalRenderStore for RenderStore {
+    fn render_store(&self) -> &RenderStore {
+        self
+    }
+}
+
+impl RenderStoreForUser for RenderStore {
+    type RenderStore = Self;
+
+    fn render_store_for_user(
+        creation_policy: RenderStoreCreationPolicy,
+        url: url::Url,
+        root: &Path,
+        username: &Path,
+    ) -> OpenRepositoryResult<Self>
+    where
+        Self: Sized,
+    {
         let renders_dir = root.join("renders").join(username);
-        FsHashStore::open(renders_dir.join(PROXY_DIRNAME))
-            .and_then(|proxy| {
-                FsHashStore::open(&renders_dir).map(|renders| RenderStore { proxy, renders })
+        let proxy_dir = renders_dir.join(PROXY_DIRNAME);
+
+        // Verify the renders directory exists.
+        let stat = std::fs::symlink_metadata(&proxy_dir);
+
+        match creation_policy {
+            RenderStoreCreationPolicy::CreateIfMissing => {
+                if stat.is_err() {
+                    makedirs_with_perms(&proxy_dir, 0o777).map_err(|source| {
+                        OpenRepositoryError::PathNotInitialized {
+                            path: proxy_dir.clone(),
+                            source,
+                        }
+                    })?;
+                }
+            }
+            RenderStoreCreationPolicy::DoNotCreate => {
+                if let Err(source) = stat {
+                    return Err(OpenRepositoryError::PathNotInitialized {
+                        path: proxy_dir,
+                        source,
+                    });
+                }
+            }
+        };
+
+        FsHashStore::open(proxy_dir).and_then(|proxy| {
+            FsHashStore::open(&renders_dir).map(|renders| RenderStore {
+                url,
+                proxy,
+                renders,
             })
-            .map_err(|source| Error::FailedToOpenRepository {
-                repository: format!("<Render Storage for {}>", username.display()),
-                source,
-            })
+        })
+    }
+}
+
+impl TryRenderStore for RenderStore {
+    fn try_render_store(&self) -> Result<&RenderStore> {
+        Ok(self)
     }
 }
 
 impl Clone for RenderStore {
     fn clone(&self) -> Self {
         Self {
+            url: self.url.clone(),
             proxy: FsHashStore::open_unchecked(self.proxy.root()),
             renders: FsHashStore::open_unchecked(self.renders.root()),
         }
+    }
+}
+
+#[derive(Clone, Debug)]
+enum InnerMaybeRenderStore {
+    /// The render store has not been created or validated yet.
+    StatusUnknown {
+        url: url::Url,
+        root: PathBuf,
+        username: PathBuf,
+    },
+    /// The render store is known to exist and is valid.
+    Valid { renders: RenderStore },
+    /// The render store does not exist or has some other issue and was not
+    /// expected to be created.
+    Invalid {
+        url: url::Url,
+        root: PathBuf,
+        username: PathBuf,
+    },
+}
+
+pub trait DefaultRenderStoreCreationPolicy {
+    fn default_creation_policy() -> RenderStoreCreationPolicy;
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum RenderStoreCreationPolicy {
+    CreateIfMissing,
+    DoNotCreate,
+}
+
+/// A render store flavor for repositories that may support renders, but the
+/// storage may not have been created or validated.
+#[derive(Clone, Debug)]
+pub struct MaybeRenderStore {
+    /// If the store should be created if necessary.
+    creation_policy: RenderStoreCreationPolicy,
+    inner: Arc<ArcSwap<InnerMaybeRenderStore>>,
+}
+
+impl DefaultRenderStoreCreationPolicy for MaybeRenderStore {
+    fn default_creation_policy() -> RenderStoreCreationPolicy {
+        RenderStoreCreationPolicy::CreateIfMissing
+    }
+}
+
+impl TryRenderStore for MaybeRenderStore {
+    fn try_render_store(&self) -> Result<&RenderStore> {
+        // TODO: create the render store if it doesn't exist (if requested), or
+        // return an error if it doesn't already exist.
+        todo!()
+    }
+}
+
+impl RenderStoreForUser for MaybeRenderStore {
+    type RenderStore = Self;
+
+    fn render_store_for_user(
+        creation_policy: RenderStoreCreationPolicy,
+        url: url::Url,
+        root: &Path,
+        username: &Path,
+    ) -> OpenRepositoryResult<Self> {
+        Ok(Self {
+            creation_policy,
+            inner: Arc::new(ArcSwap::new(Arc::new(
+                InnerMaybeRenderStore::StatusUnknown {
+                    url,
+                    root: root.to_owned(),
+                    username: username.to_owned(),
+                },
+            ))),
+        })
+    }
+}
+
+/// Represents a render store flavor for repositories that don't have renders
+/// and/or don't support renders, like tar repositories, or when accessing a
+/// repository in a way that doesn't require renders.
+#[derive(Clone, Debug)]
+pub struct NoRenderStore {
+    /// The URL of the repository, for error reporting.
+    url: url::Url,
+}
+
+impl DefaultRenderStoreCreationPolicy for NoRenderStore {
+    fn default_creation_policy() -> RenderStoreCreationPolicy {
+        RenderStoreCreationPolicy::DoNotCreate
+    }
+}
+
+impl RenderStoreForUser for NoRenderStore {
+    type RenderStore = Self;
+
+    fn render_store_for_user(
+        _creation_policy: RenderStoreCreationPolicy,
+        url: url::Url,
+        _root: &Path,
+        _username: &Path,
+    ) -> OpenRepositoryResult<Self> {
+        Ok(Self { url })
+    }
+}
+
+impl TryRenderStore for NoRenderStore {
+    fn try_render_store(&self) -> Result<&RenderStore> {
+        Err(Error::NoRenderStorage(self.url.clone()))
     }
 }
 
@@ -236,38 +405,75 @@ where
     }
 }
 
-impl<FS> LocalRepository for FsRepository<FS>
+impl<FS> LocalPayloads for FsRepository<FS>
 where
-    FS: LocalRepository,
+    FS: LocalPayloads,
 {
     fn payloads(&self) -> &FsHashStore {
         self.fs_impl.payloads()
     }
+}
 
-    fn render_store(&self) -> Result<&RenderStore> {
+impl<FS> LocalRenderStore for FsRepository<FS>
+where
+    FS: LocalRenderStore,
+{
+    fn render_store(&self) -> &RenderStore {
         self.fs_impl.render_store()
     }
 }
 
-pub type MaybeOpenFsRepository = FsRepository<MaybeOpenFsRepositoryImpl>;
-pub type OpenFsRepository = FsRepository<OpenFsRepositoryImpl>;
+impl<FS, RS> RenderStoreForUser for FsRepository<FS>
+where
+    FS: RenderStoreForUser<RenderStore = RS>,
+{
+    type RenderStore = RS;
 
-impl MaybeOpenFsRepository {
+    fn render_store_for_user(
+        creation_policy: RenderStoreCreationPolicy,
+        url: url::Url,
+        root: &Path,
+        username: &Path,
+    ) -> OpenRepositoryResult<Self::RenderStore> {
+        FS::render_store_for_user(creation_policy, url, root, username)
+    }
+}
+
+impl<FS> TryRenderStore for FsRepository<FS>
+where
+    FS: TryRenderStore,
+{
+    fn try_render_store(&self) -> Result<&RenderStore> {
+        self.fs_impl.try_render_store()
+    }
+}
+
+pub type MaybeOpenFsRepository<RS> = FsRepository<MaybeOpenFsRepositoryImpl<RS>>;
+pub type OpenFsRepository<RS> = FsRepository<OpenFsRepositoryImpl<RS>>;
+
+impl<RS> MaybeOpenFsRepository<RS>
+where
+    RS: DefaultRenderStoreCreationPolicy
+        + RenderStoreForUser<RenderStore = RS>
+        + Send
+        + Sync
+        + 'static,
+{
     /// Get the opened version of this repository, performing
     /// any required opening and validation as needed
-    pub fn opened(&self) -> impl futures::Future<Output = Result<OpenFsRepository>> + 'static {
+    pub fn opened(&self) -> impl futures::Future<Output = Result<OpenFsRepository<RS>>> + 'static {
         let fs_impl = Arc::clone(&self.fs_impl);
         async move {
             let fs_impl = fs_impl
                 .opened_and_map_err(Error::failed_to_open_repository)
                 .await?;
-            Ok(OpenFsRepository { fs_impl })
+            Ok(OpenFsRepository::<RS> { fs_impl })
         }
     }
 
     /// Open a filesystem repository, creating it if necessary
-    pub async fn create<P: AsRef<Path>>(root: P) -> OpenRepositoryResult<Self> {
-        MaybeOpenFsRepositoryImpl::create(root)
+    pub async fn create(root: impl AsRef<Path>) -> OpenRepositoryResult<Self> {
+        MaybeOpenFsRepositoryImpl::<RS>::create(root)
             .await
             .map(Into::into)
             .map(|fs_impl| FsRepository { fs_impl })
@@ -275,43 +481,49 @@ impl MaybeOpenFsRepository {
 }
 
 #[async_trait::async_trait]
-impl FromConfig for MaybeOpenFsRepository {
+impl<RS> FromConfig for MaybeOpenFsRepository<RS>
+where
+    MaybeOpenFsRepositoryImpl<RS>: FromConfig<Config = Config>,
+{
     type Config = Config;
 
     async fn from_config(config: Self::Config) -> crate::storage::OpenRepositoryResult<Self> {
-        MaybeOpenFsRepositoryImpl::from_config(config)
+        MaybeOpenFsRepositoryImpl::<RS>::from_config(config)
             .await
             .map(Into::into)
             .map(|fs_impl| FsRepository { fs_impl })
     }
 }
 
-impl OpenFsRepository {
+impl<RS> OpenFsRepository<RS>
+where
+    RS: DefaultRenderStoreCreationPolicy + RenderStoreForUser<RenderStore = RS>,
+{
     /// Establish a new filesystem repository
-    pub async fn create<P: AsRef<Path>>(root: P) -> OpenRepositoryResult<Self> {
-        OpenFsRepositoryImpl::create(root)
+    pub async fn create(root: impl AsRef<Path>) -> OpenRepositoryResult<Self> {
+        OpenFsRepositoryImpl::<RS>::create(root)
             .await
             .map(Into::into)
             .map(|fs_impl| FsRepository { fs_impl })
     }
 }
 
-impl From<OpenFsRepository> for MaybeOpenFsRepository {
-    fn from(value: OpenFsRepository) -> Self {
-        MaybeOpenFsRepository {
-            fs_impl: Arc::new(MaybeOpenFsRepositoryImpl(Arc::new(ArcSwap::new(Arc::new(
-                InnerFsRepository::Open(value.fs_impl),
-            ))))),
+impl<RS> From<OpenFsRepository<RS>> for MaybeOpenFsRepository<RS> {
+    fn from(value: OpenFsRepository<RS>) -> Self {
+        MaybeOpenFsRepository::<RS> {
+            fs_impl: Arc::new(MaybeOpenFsRepositoryImpl::<RS>(Arc::new(ArcSwap::new(
+                Arc::new(InnerFsRepository::Open(value.fs_impl)),
+            )))),
         }
     }
 }
 
-impl From<Arc<OpenFsRepository>> for MaybeOpenFsRepository {
-    fn from(value: Arc<OpenFsRepository>) -> Self {
+impl<RS> From<Arc<OpenFsRepository<RS>>> for MaybeOpenFsRepository<RS> {
+    fn from(value: Arc<OpenFsRepository<RS>>) -> Self {
         MaybeOpenFsRepository {
-            fs_impl: Arc::new(MaybeOpenFsRepositoryImpl(Arc::new(ArcSwap::new(Arc::new(
-                InnerFsRepository::Open(Arc::clone(&value.fs_impl)),
-            ))))),
+            fs_impl: Arc::new(MaybeOpenFsRepositoryImpl::<RS>(Arc::new(ArcSwap::new(
+                Arc::new(InnerFsRepository::Open(Arc::clone(&value.fs_impl))),
+            )))),
         }
     }
 }
@@ -324,21 +536,21 @@ impl From<Arc<OpenFsRepository>> for MaybeOpenFsRepository {
 /// An [`OpenFsRepository`] is more useful than this one, but
 /// can also be easily retrieved via the [`Self::opened`].
 #[derive(Clone)]
-pub struct MaybeOpenFsRepositoryImpl(Arc<ArcSwap<InnerFsRepository>>);
+pub struct MaybeOpenFsRepositoryImpl<RS>(Arc<ArcSwap<InnerFsRepository<RS>>>);
 
-enum InnerFsRepository {
+enum InnerFsRepository<RS> {
     Closed(Config),
-    Open(Arc<OpenFsRepositoryImpl>),
+    Open(Arc<OpenFsRepositoryImpl<RS>>),
 }
 
-impl From<OpenFsRepositoryImpl> for MaybeOpenFsRepositoryImpl {
-    fn from(value: OpenFsRepositoryImpl) -> Self {
+impl<RS> From<OpenFsRepositoryImpl<RS>> for MaybeOpenFsRepositoryImpl<RS> {
+    fn from(value: OpenFsRepositoryImpl<RS>) -> Self {
         Arc::new(value).into()
     }
 }
 
-impl From<Arc<OpenFsRepositoryImpl>> for MaybeOpenFsRepositoryImpl {
-    fn from(value: Arc<OpenFsRepositoryImpl>) -> Self {
+impl<RS> From<Arc<OpenFsRepositoryImpl<RS>>> for MaybeOpenFsRepositoryImpl<RS> {
+    fn from(value: Arc<OpenFsRepositoryImpl<RS>>) -> Self {
         Self(Arc::new(ArcSwap::new(Arc::new(InnerFsRepository::Open(
             value,
         )))))
@@ -346,34 +558,49 @@ impl From<Arc<OpenFsRepositoryImpl>> for MaybeOpenFsRepositoryImpl {
 }
 
 #[async_trait::async_trait]
-impl FromConfig for MaybeOpenFsRepositoryImpl {
+impl<RS> FromConfig for MaybeOpenFsRepositoryImpl<RS>
+where
+    OpenFsRepositoryImpl<RS>: FromConfig<Config = Config>,
+{
     type Config = Config;
 
     async fn from_config(config: Self::Config) -> crate::storage::OpenRepositoryResult<Self> {
         if config.params.lazy {
-            Ok(Self(Arc::new(ArcSwap::new(Arc::new(
-                InnerFsRepository::Closed(config),
-            )))))
+            Ok(Self(Arc::new(ArcSwap::new(Arc::new(InnerFsRepository::<
+                RS,
+            >::Closed(
+                config
+            ))))))
         } else {
-            Ok(OpenFsRepositoryImpl::from_config(config).await?.into())
+            Ok(OpenFsRepositoryImpl::<RS>::from_config(config)
+                .await?
+                .into())
         }
     }
 }
 
-impl MaybeOpenFsRepositoryImpl {
+impl<RS> MaybeOpenFsRepositoryImpl<RS>
+where
+    OpenFsRepositoryImpl<RS>: FromConfig<Config = Config>,
+    RS: DefaultRenderStoreCreationPolicy
+        + RenderStoreForUser<RenderStore = RS>
+        + Send
+        + Sync
+        + 'static,
+{
     /// Open a filesystem repository, creating it if necessary
-    pub async fn create<P: AsRef<Path>>(root: P) -> OpenRepositoryResult<Self> {
-        Ok(Self(Arc::new(ArcSwap::new(Arc::new(
-            InnerFsRepository::Open(Arc::new(OpenFsRepositoryImpl::create(root).await?)),
+    pub async fn create(root: impl AsRef<Path>) -> OpenRepositoryResult<Self> {
+        Ok(MaybeOpenFsRepositoryImpl(Arc::new(ArcSwap::new(Arc::new(
+            InnerFsRepository::Open(Arc::new(OpenFsRepositoryImpl::<RS>::create(root).await?)),
         )))))
     }
 
     // Open a repository over the given directory, which must already
     // exist and be properly setup as a repository
-    pub async fn open<P: AsRef<Path>>(root: P) -> OpenRepositoryResult<Self> {
+    pub async fn open(root: impl AsRef<Path>) -> OpenRepositoryResult<Self> {
         let root = root.as_ref();
-        Ok(Self(Arc::new(ArcSwap::new(Arc::new(
-            InnerFsRepository::Open(Arc::new(OpenFsRepositoryImpl::open(&root).await?)),
+        Ok(MaybeOpenFsRepositoryImpl(Arc::new(ArcSwap::new(Arc::new(
+            InnerFsRepository::Open(Arc::new(OpenFsRepositoryImpl::<RS>::open(&root).await?)),
         )))))
     }
 
@@ -381,7 +608,7 @@ impl MaybeOpenFsRepositoryImpl {
     /// any required opening and validation as needed
     pub fn opened(
         &self,
-    ) -> impl futures::Future<Output = Result<Arc<OpenFsRepositoryImpl>>> + 'static {
+    ) -> impl futures::Future<Output = Result<Arc<OpenFsRepositoryImpl<RS>>>> + 'static {
         self.opened_and_map_err(Error::failed_to_open_repository)
     }
 
@@ -389,7 +616,7 @@ impl MaybeOpenFsRepositoryImpl {
     /// any required opening and validation as needed
     pub fn try_open(
         &self,
-    ) -> impl futures::Future<Output = OpenRepositoryResult<Arc<OpenFsRepositoryImpl>>> + 'static
+    ) -> impl futures::Future<Output = OpenRepositoryResult<Arc<OpenFsRepositoryImpl<RS>>>> + 'static
     {
         self.opened_and_map_err(|_, e| e)
     }
@@ -397,7 +624,7 @@ impl MaybeOpenFsRepositoryImpl {
     fn opened_and_map_err<F, E>(
         &self,
         map: F,
-    ) -> impl futures::Future<Output = std::result::Result<Arc<OpenFsRepositoryImpl>, E>> + 'static
+    ) -> impl futures::Future<Output = std::result::Result<Arc<OpenFsRepositoryImpl<RS>>, E>> + 'static
     where
         F: FnOnce(&Self, OpenRepositoryError) -> E + 'static,
     {
@@ -406,26 +633,20 @@ impl MaybeOpenFsRepositoryImpl {
             match &**inner.load() {
                 InnerFsRepository::Closed(config) => {
                     let config = config.clone();
-                    let opened = match OpenFsRepositoryImpl::from_config(config).await {
+                    let opened = match OpenFsRepositoryImpl::<RS>::from_config(config).await {
                         Ok(o) => Arc::new(o),
                         Err(err) => return Err(map(&Self(inner), err)),
                     };
                     inner.rcu(|_| InnerFsRepository::Open(Arc::clone(&opened)));
                     Ok(opened)
                 }
-                InnerFsRepository::Open(o) => Ok(Arc::clone(o)),
+                InnerFsRepository::<RS>::Open(o) => Ok(Arc::clone(o)),
             }
         }
     }
+}
 
-    /// The filesystem root path of this repository
-    pub fn root(&self) -> PathBuf {
-        match &**self.0.load() {
-            InnerFsRepository::Closed(config) => config.path.clone(),
-            InnerFsRepository::Open(o) => o.root(),
-        }
-    }
-
+impl<RS> MaybeOpenFsRepositoryImpl<RS> {
     pub fn get_tag_namespace(&self) -> Option<Cow<'_, TagNamespace>> {
         match &**self.0.load() {
             InnerFsRepository::Open(repo) => repo
@@ -441,6 +662,19 @@ impl MaybeOpenFsRepositoryImpl {
         }
     }
 
+    /// The filesystem root path of this repository
+    pub fn root(&self) -> PathBuf {
+        match &**self.0.load() {
+            InnerFsRepository::Closed(config) => config.path.clone(),
+            InnerFsRepository::Open(o) => o.root(),
+        }
+    }
+}
+
+impl<RS> MaybeOpenFsRepositoryImpl<RS>
+where
+    RS: Clone,
+{
     pub fn set_tag_namespace(
         &mut self,
         tag_namespace: Option<TagNamespaceBuf>,
@@ -463,20 +697,20 @@ impl MaybeOpenFsRepositoryImpl {
     }
 }
 
-impl Address for MaybeOpenFsRepositoryImpl {
+impl<RS> Address for MaybeOpenFsRepositoryImpl<RS> {
     fn address(&self) -> Cow<'_, url::Url> {
         Cow::Owned(url::Url::from_directory_path(self.root()).unwrap())
     }
 }
 
-impl std::fmt::Debug for MaybeOpenFsRepositoryImpl {
+impl<RS> std::fmt::Debug for MaybeOpenFsRepositoryImpl<RS> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_fmt(format_args!("FsRepository @ {:?}", self.root()))
     }
 }
 
 /// A validated and opened fs repository.
-pub struct OpenFsRepositoryImpl {
+pub struct OpenFsRepositoryImpl<RenderStore> {
     root: PathBuf,
     /// the namespace to use for tag resolution. If set, then this is treated
     /// as "chroot" of the real tag root.
@@ -486,11 +720,14 @@ pub struct OpenFsRepositoryImpl {
     /// stores all digraph object data for this repo
     pub objects: FsHashStore,
     /// stores rendered file system layers for use in overlayfs
-    pub renders: Option<RenderStore>,
+    pub rs_impl: RenderStore,
 }
 
 #[async_trait::async_trait]
-impl FromConfig for OpenFsRepositoryImpl {
+impl<RS> FromConfig for OpenFsRepositoryImpl<RS>
+where
+    RS: DefaultRenderStoreCreationPolicy + RenderStoreForUser<RenderStore = RS> + Send + Sync,
+{
     type Config = Config;
 
     async fn from_config(config: Self::Config) -> crate::storage::OpenRepositoryResult<Self> {
@@ -506,34 +743,61 @@ impl FromConfig for OpenFsRepositoryImpl {
     }
 }
 
-impl Clone for OpenFsRepositoryImpl {
+impl<RS: Clone> Clone for OpenFsRepositoryImpl<RS> {
     fn clone(&self) -> Self {
         let root = self.root.clone();
         Self {
             objects: FsHashStore::open_unchecked(root.join("objects")),
             payloads: FsHashStore::open_unchecked(root.join("payloads")),
-            renders: self.renders.clone(),
+            rs_impl: self.rs_impl.clone(),
             root,
             tag_namespace: self.tag_namespace.clone(),
         }
     }
 }
 
-impl LocalRepository for OpenFsRepositoryImpl {
+impl<RS> LocalPayloads for OpenFsRepositoryImpl<RS> {
     #[inline]
     fn payloads(&self) -> &FsHashStore {
         &self.payloads
     }
+}
 
-    #[inline]
-    fn render_store(&self) -> Result<&RenderStore> {
-        self.renders
-            .as_ref()
-            .ok_or_else(|| Error::NoRenderStorage(self.address()))
+impl<RS> LocalRenderStore for OpenFsRepositoryImpl<RS>
+where
+    RS: LocalRenderStore<RenderStore = RS>,
+{
+    fn render_store(&self) -> &RenderStore {
+        self.rs_impl.render_store()
     }
 }
 
-impl OpenFsRepositoryImpl {
+impl<RS> RenderStoreForUser for OpenFsRepositoryImpl<RS>
+where
+    RS: RenderStoreForUser<RenderStore = RS>,
+{
+    type RenderStore = RS;
+
+    fn render_store_for_user(
+        creation_policy: RenderStoreCreationPolicy,
+        url: url::Url,
+        root: &Path,
+        username: &Path,
+    ) -> OpenRepositoryResult<Self::RenderStore> {
+        RS::render_store_for_user(creation_policy, url, root, username)
+    }
+}
+
+impl<RS> TryRenderStore for OpenFsRepositoryImpl<RS>
+where
+    RS: TryRenderStore,
+{
+    fn try_render_store(&self) -> Result<&RenderStore> {
+        self.rs_impl.try_render_store()
+    }
+}
+
+impl<RS> OpenFsRepositoryImpl<RS> {
     /// The address of this repository that can be used to re-open it
     pub fn address(&self) -> url::Url {
         Config {
@@ -548,8 +812,23 @@ impl OpenFsRepositoryImpl {
         .expect("repository address is valid")
     }
 
+    /// The latest repository version that this was migrated to.
+    pub async fn last_migration(&self) -> MigrationResult<semver::Version> {
+        Ok(read_last_migration_version(self.root())
+            .await?
+            .unwrap_or_else(|| {
+                semver::Version::parse(crate::VERSION)
+                    .expect("crate::VERSION is a valid semver value")
+            }))
+    }
+}
+
+impl<RS> OpenFsRepositoryImpl<RS>
+where
+    RS: DefaultRenderStoreCreationPolicy + RenderStoreForUser<RenderStore = RS>,
+{
     /// Establish a new filesystem repository
-    pub async fn create<P: AsRef<Path>>(root: P) -> OpenRepositoryResult<Self> {
+    pub async fn create(root: impl AsRef<Path>) -> OpenRepositoryResult<Self> {
         let root = root.as_ref();
         // avoid creating any blocking tasks so as to not spawn
         // threads for the case where this repo is being opened as
@@ -566,12 +845,12 @@ impl OpenFsRepositoryImpl {
                 source,
             }
         })?;
-        let username = whoami::username();
+        // let username = whoami::username();
         for path in [
             root.join("tags"),
             root.join("objects"),
             root.join("payloads"),
-            root.join("renders").join(username).join(PROXY_DIRNAME),
+            // root.join("renders").join(username).join(PROXY_DIRNAME),
             root.join(DURABLE_EDITS_DIR),
         ] {
             makedirs_with_perms(&path, 0o777)
@@ -586,32 +865,9 @@ impl OpenFsRepositoryImpl {
         unsafe { Self::open_unchecked(root) }
     }
 
-    pub(crate) fn get_render_storage(&self) -> Result<&crate::storage::fs::FsHashStore> {
-        match &self.renders {
-            Some(render_store) => Ok(&render_store.renders),
-            None => Err(Error::NoRenderStorage(self.address())),
-        }
-    }
-
-    /// Return the configured tag namespace, if any.
-    #[inline]
-    pub fn get_tag_namespace(&self) -> Option<Cow<'_, TagNamespace>> {
-        self.tag_namespace.as_deref().map(Cow::Borrowed)
-    }
-
-    /// The latest repository version that this was migrated to.
-    pub async fn last_migration(&self) -> MigrationResult<semver::Version> {
-        Ok(read_last_migration_version(self.root())
-            .await?
-            .unwrap_or_else(|| {
-                semver::Version::parse(crate::VERSION)
-                    .expect("crate::VERSION is a valid semver value")
-            }))
-    }
-
     // Open a repository over the given directory, which must already
     // exist and be a repository
-    pub async fn open<P: AsRef<Path>>(root: P) -> OpenRepositoryResult<Self> {
+    pub async fn open(root: impl AsRef<Path>) -> OpenRepositoryResult<Self> {
         // although this is an async function, we avoid spawning a blocking task
         // here for the cases where a local fs repo is opened to spawn a runtime
         // and the program cannot spawn another thread without angering the kernel
@@ -650,16 +906,30 @@ impl OpenFsRepositoryImpl {
     ///
     /// The caller must ensure that the repository version is compatible with
     /// this version of spfs before using the repository.
-    unsafe fn open_unchecked<P: AsRef<Path>>(root: P) -> OpenRepositoryResult<Self> {
+    unsafe fn open_unchecked(root: impl AsRef<Path>) -> OpenRepositoryResult<Self> {
         let root = root.as_ref();
-        let username = whoami::username();
-        Ok(Self {
+        let username = PathBuf::from(whoami::username());
+        let url = url::Url::from_directory_path(root).unwrap();
+        Ok(OpenFsRepositoryImpl::<RS> {
             objects: FsHashStore::open(root.join("objects"))?,
             payloads: FsHashStore::open(root.join("payloads"))?,
-            renders: RenderStore::for_user(root, username).ok(),
+            rs_impl: RS::render_store_for_user(
+                RS::default_creation_policy(),
+                url,
+                root,
+                &username,
+            )?,
             root: root.to_owned(),
             tag_namespace: None,
         })
+    }
+}
+
+impl<RS> OpenFsRepositoryImpl<RS> {
+    /// Return the configured tag namespace, if any.
+    #[inline]
+    pub fn get_tag_namespace(&self) -> Option<Cow<'_, TagNamespace>> {
+        self.tag_namespace.as_deref().map(Cow::Borrowed)
     }
 
     /// The filesystem root path of this repository
@@ -684,41 +954,47 @@ impl OpenFsRepositoryImpl {
     }
 }
 
+impl<RS> OpenFsRepositoryImpl<RS>
+where
+    RS: LocalRenderStore,
+{
+    pub(crate) fn get_render_storage(&self) -> &crate::storage::fs::FsHashStore {
+        &self.rs_impl.render_store().renders
+    }
+}
+
 #[async_trait::async_trait]
-impl FsRepositoryOps for OpenFsRepositoryImpl {
+impl<RS> FsRepositoryOps for OpenFsRepositoryImpl<RS>
+where
+    RS: LocalRenderStore<RenderStore = RS> + Send + Sync,
+{
     /// True if this repo is setup to generate local manifest renders.
     fn has_renders(&self) -> bool {
-        self.renders.is_some()
+        true
     }
 
     fn iter_rendered_manifests(
         &self,
     ) -> Pin<Box<dyn Stream<Item = Result<crate::encoding::Digest>> + Send + Sync + '_>> {
         Box::pin(try_stream! {
-            let renders = self.get_render_storage()?;
-            for await digest in renders.iter() {
+            for await digest in self.rs_impl.render_store().renders.iter() {
                 yield digest?;
             }
         })
     }
 
     fn proxy_path(&self) -> Option<&std::path::Path> {
-        self.renders
-            .as_ref()
-            .map(|render_store| render_store.proxy.root())
+        Some(self.rs_impl.render_store().proxy.root())
     }
 
     async fn remove_rendered_manifest(&self, digest: crate::encoding::Digest) -> Result<()> {
-        let renders = match &self.renders {
-            Some(render_store) => &render_store.renders,
-            None => return Ok(()),
-        };
+        let renders = &self.rs_impl.render_store().renders;
         let rendered_dirpath = renders.build_digest_path(&digest);
         let workdir = renders.workdir();
         makedirs_with_perms(&workdir, renders.directory_permissions).map_err(|source| {
             Error::StorageWriteError("remove render create workdir", workdir.clone(), source)
         })?;
-        OpenFsRepository::remove_dir_atomically(&rendered_dirpath, &workdir).await
+        OpenFsRepository::<RS>::remove_dir_atomically(&rendered_dirpath, &workdir).await
     }
 
     async fn remove_rendered_manifest_if_older_than(
@@ -726,10 +1002,7 @@ impl FsRepositoryOps for OpenFsRepositoryImpl {
         older_than: DateTime<Utc>,
         digest: crate::encoding::Digest,
     ) -> Result<bool> {
-        let renders = match &self.renders {
-            Some(render_store) => &render_store.renders,
-            None => return Ok(false),
-        };
+        let renders = &self.rs_impl.render_store().renders;
         let rendered_dirpath = renders.build_digest_path(&digest);
 
         let metadata = match tokio::fs::symlink_metadata(&rendered_dirpath).await {
@@ -765,10 +1038,6 @@ impl FsRepositoryOps for OpenFsRepositoryImpl {
     ///
     /// Returns tuples of (username, `ManifestViewer`).
     fn renders_for_all_users(&self) -> Result<Vec<(String, impl FsRepositoryOps)>> {
-        if !self.has_renders() {
-            return Ok(Vec::new());
-        }
-
         let mut render_dirs = Vec::new();
 
         let renders_dir = self.root.join("renders");
@@ -795,32 +1064,36 @@ impl FsRepositoryOps for OpenFsRepositoryImpl {
 
         Ok(render_dirs
             .into_iter()
-            .map(|(username, dir)| -> (String, Self) {
-                (
-                    username,
-                    Self {
-                        objects: FsHashStore::open_unchecked(self.root.join("objects")),
-                        payloads: FsHashStore::open_unchecked(self.root.join("payloads")),
-                        renders: self
-                            .renders
-                            .as_ref()
-                            .and_then(|_| RenderStore::for_user(self.root.as_ref(), dir).ok()),
-                        root: self.root.clone(),
-                        tag_namespace: self.tag_namespace.clone(),
-                    },
-                )
+            .map(|(username, dir)| {
+                let fs_impl = Self {
+                    objects: FsHashStore::open_unchecked(self.root.join("objects")),
+                    payloads: FsHashStore::open_unchecked(self.root.join("payloads")),
+                    rs_impl: RS::render_store_for_user(
+                        RenderStoreCreationPolicy::DoNotCreate,
+                        self.address(),
+                        &self.root,
+                        &dir,
+                    )
+                    .map_err(|source| Error::FailedToOpenRepository {
+                        repository: format!("<Render Storage for {username}>",),
+                        source,
+                    })?,
+                    root: self.root.clone(),
+                    tag_namespace: self.tag_namespace.clone(),
+                };
+                Ok((username, fs_impl))
             })
-            .collect())
+            .collect::<Result<Vec<_>>>()?)
     }
 }
 
-impl Address for OpenFsRepositoryImpl {
+impl<RS> Address for OpenFsRepositoryImpl<RS> {
     fn address(&self) -> Cow<'_, url::Url> {
         Cow::Owned(url::Url::from_directory_path(self.root()).unwrap())
     }
 }
 
-impl std::fmt::Debug for OpenFsRepositoryImpl {
+impl<RS> std::fmt::Debug for OpenFsRepositoryImpl<RS> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_fmt(format_args!("OpenFsRepositoryImpl @ {:?}", self.root()))
     }

--- a/crates/spfs/src/storage/fs/tag.rs
+++ b/crates/spfs/src/storage/fs/tag.rs
@@ -20,9 +20,10 @@ use futures::{Future, Stream, StreamExt, TryFutureExt};
 use relative_path::RelativePath;
 use tokio::io::{AsyncRead, AsyncSeek, AsyncWriteExt, ReadBuf};
 
-use super::{MaybeOpenFsRepository, OpenFsRepository};
+use super::{DefaultRenderStoreCreationPolicy, MaybeOpenFsRepository, OpenFsRepository};
 use crate::storage::tag::{EntryType, TagSpecAndTagStream, TagStream};
 use crate::storage::{
+    RenderStoreForUser,
     TagNamespace,
     TagNamespaceBuf,
     TagStorage,
@@ -34,7 +35,14 @@ use crate::{encoding, tracking, Error, OsError, OsErrorExt, Result};
 const TAG_EXT: &str = "tag";
 
 #[async_trait::async_trait]
-impl TagStorage for MaybeOpenFsRepository {
+impl<RS> TagStorage for MaybeOpenFsRepository<RS>
+where
+    RS: DefaultRenderStoreCreationPolicy
+        + RenderStoreForUser<RenderStore = RS>
+        + Send
+        + Sync
+        + 'static,
+{
     #[inline]
     fn get_tag_namespace(&self) -> Option<Cow<'_, TagNamespace>> {
         self.fs_impl.get_tag_namespace()
@@ -131,7 +139,14 @@ impl TagStorage for MaybeOpenFsRepository {
     }
 }
 
-impl MaybeOpenFsRepository {
+impl<RS> MaybeOpenFsRepository<RS>
+where
+    RS: DefaultRenderStoreCreationPolicy
+        + RenderStoreForUser<RenderStore = RS>
+        + Send
+        + Sync
+        + 'static,
+{
     /// Forcefully remove any lock file for the identified tag.
     ///
     /// # Safety
@@ -154,7 +169,7 @@ impl MaybeOpenFsRepository {
     }
 }
 
-impl OpenFsRepository {
+impl<RS> OpenFsRepository<RS> {
     fn tags_root_in_namespace(&self, namespace: Option<&TagNamespace>) -> PathBuf {
         let mut tags_root = self.fs_impl.root().join("tags");
         if let Some(tag_namespace) = namespace {
@@ -192,7 +207,10 @@ impl OpenFsRepository {
 }
 
 #[async_trait::async_trait]
-impl TagStorage for OpenFsRepository {
+impl<RS> TagStorage for OpenFsRepository<RS>
+where
+    RS: Send + Sync,
+{
     #[inline]
     fn get_tag_namespace(&self) -> Option<Cow<'_, TagNamespace>> {
         self.fs_impl.get_tag_namespace()
@@ -448,7 +466,10 @@ impl TagStorage for OpenFsRepository {
     }
 }
 
-impl TagStorageMut for MaybeOpenFsRepository {
+impl<RS> TagStorageMut for MaybeOpenFsRepository<RS>
+where
+    RS: Clone,
+{
     fn try_set_tag_namespace(
         &mut self,
         tag_namespace: Option<TagNamespaceBuf>,

--- a/crates/spfs/src/storage/handle.rs
+++ b/crates/spfs/src/storage/handle.rs
@@ -11,6 +11,7 @@ use futures::Stream;
 use relative_path::RelativePath;
 use spfs_encoding as encoding;
 
+use super::fs::{MaybeRenderStore, NoRenderStore, RenderStore};
 use super::prelude::*;
 use super::tag::TagSpecAndTagStream;
 use super::{TagNamespace, TagNamespaceBuf, TagStorageMut};
@@ -21,10 +22,12 @@ use crate::{graph, Error, Result};
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
 pub enum RepositoryHandle {
-    FS(super::fs::MaybeOpenFsRepository),
+    FSWithMaybeRenders(super::fs::MaybeOpenFsRepository<MaybeRenderStore>),
+    FSWithRenders(super::fs::MaybeOpenFsRepository<RenderStore>),
+    FSWithoutRenders(super::fs::MaybeOpenFsRepository<NoRenderStore>),
     Tar(super::tar::TarRepository),
     Rpc(super::rpc::RpcRepository),
-    FallbackProxy(Box<super::fallback::FallbackProxy>),
+    FallbackProxyWithRenders(Box<super::fallback::FallbackProxy<RenderStore>>),
     Proxy(Box<super::proxy::ProxyRepository>),
     Pinned(Box<super::pinned::PinnedRepository<RepositoryHandle>>),
 }
@@ -70,31 +73,69 @@ impl RepositoryHandle {
 
     pub fn try_as_tag_mut(&mut self) -> Result<&mut dyn TagStorageMut> {
         match self {
-            RepositoryHandle::FS(repo) => Ok(repo),
+            RepositoryHandle::FSWithMaybeRenders(repo) => Ok(repo),
+            RepositoryHandle::FSWithRenders(repo) => Ok(repo),
+            RepositoryHandle::FSWithoutRenders(repo) => Ok(repo),
             RepositoryHandle::Tar(repo) => Ok(repo),
             RepositoryHandle::Rpc(repo) => Ok(repo),
-            RepositoryHandle::FallbackProxy(repo) => Ok(&mut **repo),
+            RepositoryHandle::FallbackProxyWithRenders(repo) => Ok(&mut **repo),
             RepositoryHandle::Proxy(repo) => Ok(&mut **repo),
             RepositoryHandle::Pinned(_) => Err(Error::RepositoryIsPinned),
         }
     }
 }
 
-impl From<super::fs::MaybeOpenFsRepository> for RepositoryHandle {
-    fn from(repo: super::fs::MaybeOpenFsRepository) -> Self {
-        RepositoryHandle::FS(repo)
+impl From<super::fs::MaybeOpenFsRepository<RenderStore>> for RepositoryHandle {
+    fn from(repo: super::fs::MaybeOpenFsRepository<RenderStore>) -> Self {
+        RepositoryHandle::FSWithRenders(repo)
     }
 }
 
-impl From<super::fs::OpenFsRepository> for RepositoryHandle {
-    fn from(repo: super::fs::OpenFsRepository) -> Self {
-        RepositoryHandle::FS(repo.into())
+impl From<super::fs::OpenFsRepository<RenderStore>> for RepositoryHandle {
+    fn from(repo: super::fs::OpenFsRepository<RenderStore>) -> Self {
+        RepositoryHandle::FSWithRenders(repo.into())
     }
 }
 
-impl From<Arc<super::fs::OpenFsRepository>> for RepositoryHandle {
-    fn from(repo: Arc<super::fs::OpenFsRepository>) -> Self {
-        RepositoryHandle::FS(repo.into())
+impl From<Arc<super::fs::OpenFsRepository<RenderStore>>> for RepositoryHandle {
+    fn from(repo: Arc<super::fs::OpenFsRepository<RenderStore>>) -> Self {
+        RepositoryHandle::FSWithRenders(repo.into())
+    }
+}
+
+impl From<super::fs::MaybeOpenFsRepository<NoRenderStore>> for RepositoryHandle {
+    fn from(repo: super::fs::MaybeOpenFsRepository<NoRenderStore>) -> Self {
+        RepositoryHandle::FSWithoutRenders(repo)
+    }
+}
+
+impl From<super::fs::OpenFsRepository<NoRenderStore>> for RepositoryHandle {
+    fn from(repo: super::fs::OpenFsRepository<NoRenderStore>) -> Self {
+        RepositoryHandle::FSWithoutRenders(repo.into())
+    }
+}
+
+impl From<Arc<super::fs::OpenFsRepository<NoRenderStore>>> for RepositoryHandle {
+    fn from(repo: Arc<super::fs::OpenFsRepository<NoRenderStore>>) -> Self {
+        RepositoryHandle::FSWithoutRenders(repo.into())
+    }
+}
+
+impl From<super::fs::MaybeOpenFsRepository<MaybeRenderStore>> for RepositoryHandle {
+    fn from(repo: super::fs::MaybeOpenFsRepository<MaybeRenderStore>) -> Self {
+        RepositoryHandle::FSWithMaybeRenders(repo)
+    }
+}
+
+impl From<super::fs::OpenFsRepository<MaybeRenderStore>> for RepositoryHandle {
+    fn from(repo: super::fs::OpenFsRepository<MaybeRenderStore>) -> Self {
+        RepositoryHandle::FSWithMaybeRenders(repo.into())
+    }
+}
+
+impl From<Arc<super::fs::OpenFsRepository<MaybeRenderStore>>> for RepositoryHandle {
+    fn from(repo: Arc<super::fs::OpenFsRepository<MaybeRenderStore>>) -> Self {
+        RepositoryHandle::FSWithMaybeRenders(repo.into())
     }
 }
 
@@ -110,9 +151,9 @@ impl From<super::rpc::RpcRepository> for RepositoryHandle {
     }
 }
 
-impl From<super::fallback::FallbackProxy> for RepositoryHandle {
-    fn from(repo: super::fallback::FallbackProxy) -> Self {
-        RepositoryHandle::FallbackProxy(Box::new(repo))
+impl From<super::fallback::FallbackProxy<RenderStore>> for RepositoryHandle {
+    fn from(repo: super::fallback::FallbackProxy<RenderStore>) -> Self {
+        RepositoryHandle::FallbackProxyWithRenders(Box::new(repo))
     }
 }
 
@@ -134,10 +175,12 @@ impl From<Box<super::pinned::PinnedRepository<RepositoryHandle>>> for Repository
 macro_rules! each_variant {
     ($repo:expr, $inner:ident, $ops:tt) => {
         match $repo {
-            RepositoryHandle::FS($inner) => $ops,
+            RepositoryHandle::FSWithMaybeRenders($inner) => $ops,
+            RepositoryHandle::FSWithRenders($inner) => $ops,
+            RepositoryHandle::FSWithoutRenders($inner) => $ops,
             RepositoryHandle::Tar($inner) => $ops,
             RepositoryHandle::Rpc($inner) => $ops,
-            RepositoryHandle::FallbackProxy($inner) => $ops,
+            RepositoryHandle::FallbackProxyWithRenders($inner) => $ops,
             RepositoryHandle::Proxy($inner) => $ops,
             RepositoryHandle::Pinned($inner) => $ops,
         }
@@ -241,10 +284,14 @@ impl TagStorageMut for RepositoryHandle {
         tag_namespace: Option<TagNamespaceBuf>,
     ) -> Result<Option<TagNamespaceBuf>> {
         match self {
-            RepositoryHandle::FS(repo) => repo.try_set_tag_namespace(tag_namespace),
+            RepositoryHandle::FSWithMaybeRenders(repo) => repo.try_set_tag_namespace(tag_namespace),
+            RepositoryHandle::FSWithRenders(repo) => repo.try_set_tag_namespace(tag_namespace),
+            RepositoryHandle::FSWithoutRenders(repo) => repo.try_set_tag_namespace(tag_namespace),
             RepositoryHandle::Tar(repo) => repo.try_set_tag_namespace(tag_namespace),
             RepositoryHandle::Rpc(repo) => repo.try_set_tag_namespace(tag_namespace),
-            RepositoryHandle::FallbackProxy(repo) => repo.try_set_tag_namespace(tag_namespace),
+            RepositoryHandle::FallbackProxyWithRenders(repo) => {
+                repo.try_set_tag_namespace(tag_namespace)
+            }
             RepositoryHandle::Proxy(repo) => repo.try_set_tag_namespace(tag_namespace),
             RepositoryHandle::Pinned(_) => Err(Error::RepositoryIsPinned),
         }

--- a/crates/spfs/src/storage/mod.rs
+++ b/crates/spfs/src/storage/mod.rs
@@ -26,13 +26,21 @@ pub mod tar;
 pub use address::Address;
 pub use blob::{BlobStorage, BlobStorageExt};
 pub use error::OpenRepositoryError;
+pub use fs::DefaultRenderStoreCreationPolicy;
 pub use handle::RepositoryHandle;
 pub use layer::{LayerStorage, LayerStorageExt};
 pub use manifest::ManifestStorage;
 pub use payload::PayloadStorage;
 pub use platform::{PlatformStorage, PlatformStorageExt};
 pub use proxy::{Config, ProxyRepository};
-pub use repository::{LocalRepository, Repository, RepositoryExt};
+pub use repository::{
+    LocalPayloads,
+    LocalRenderStore,
+    RenderStoreForUser,
+    Repository,
+    RepositoryExt,
+    TryRenderStore,
+};
 pub use tag::{EntryType, TagStorage, TagStorageMut};
 pub use tag_namespace::{TagNamespace, TagNamespaceBuf, TAG_NAMESPACE_MARKER};
 

--- a/crates/spfs/src/storage/proxy/repository_test.rs
+++ b/crates/spfs/src/storage/proxy/repository_test.rs
@@ -6,19 +6,23 @@ use rstest::rstest;
 
 use crate::fixtures::*;
 use crate::prelude::*;
+use crate::storage::fs::RenderStore;
 
 #[rstest]
 #[tokio::test]
 async fn test_proxy_payload_read_through(tmpdir: tempfile::TempDir) {
     init_logging();
 
-    let primary = crate::storage::fs::MaybeOpenFsRepository::create(tmpdir.path().join("primary"))
-        .await
-        .unwrap();
-    let secondary =
-        crate::storage::fs::MaybeOpenFsRepository::create(tmpdir.path().join("secondary"))
-            .await
-            .unwrap();
+    let primary = crate::storage::fs::MaybeOpenFsRepository::<RenderStore>::create(
+        tmpdir.path().join("primary"),
+    )
+    .await
+    .unwrap();
+    let secondary = crate::storage::fs::MaybeOpenFsRepository::<RenderStore>::create(
+        tmpdir.path().join("secondary"),
+    )
+    .await
+    .unwrap();
 
     let digest = secondary
         .commit_blob(Box::pin(b"some data".as_slice()))
@@ -41,13 +45,16 @@ async fn test_proxy_payload_read_through(tmpdir: tempfile::TempDir) {
 async fn test_proxy_object_read_through(tmpdir: tempfile::TempDir) {
     init_logging();
 
-    let primary = crate::storage::fs::MaybeOpenFsRepository::create(tmpdir.path().join("primary"))
-        .await
-        .unwrap();
-    let secondary =
-        crate::storage::fs::MaybeOpenFsRepository::create(tmpdir.path().join("secondary"))
-            .await
-            .unwrap();
+    let primary = crate::storage::fs::MaybeOpenFsRepository::<RenderStore>::create(
+        tmpdir.path().join("primary"),
+    )
+    .await
+    .unwrap();
+    let secondary = crate::storage::fs::MaybeOpenFsRepository::<RenderStore>::create(
+        tmpdir.path().join("secondary"),
+    )
+    .await
+    .unwrap();
 
     let payload = secondary
         .commit_blob(Box::pin(b"some data".as_slice()))
@@ -70,13 +77,16 @@ async fn test_proxy_object_read_through(tmpdir: tempfile::TempDir) {
 async fn test_proxy_tag_read_through(tmpdir: tempfile::TempDir) {
     init_logging();
 
-    let primary = crate::storage::fs::MaybeOpenFsRepository::create(tmpdir.path().join("primary"))
-        .await
-        .unwrap();
-    let secondary =
-        crate::storage::fs::MaybeOpenFsRepository::create(tmpdir.path().join("secondary"))
-            .await
-            .unwrap();
+    let primary = crate::storage::fs::MaybeOpenFsRepository::<RenderStore>::create(
+        tmpdir.path().join("primary"),
+    )
+    .await
+    .unwrap();
+    let secondary = crate::storage::fs::MaybeOpenFsRepository::<RenderStore>::create(
+        tmpdir.path().join("secondary"),
+    )
+    .await
+    .unwrap();
 
     let payload = secondary
         .commit_blob(Box::pin(b"some data".as_slice()))

--- a/crates/spfs/src/storage/repository.rs
+++ b/crates/spfs/src/storage/repository.rs
@@ -3,13 +3,15 @@
 // https://github.com/spkenv/spk
 
 use std::collections::HashSet;
+use std::path::Path;
 use std::pin::Pin;
 
 use async_trait::async_trait;
 use encoding::prelude::*;
 use tokio_stream::StreamExt;
 
-use super::fs::{FsHashStore, RenderStore};
+use super::fs::{FsHashStore, RenderStore, RenderStoreCreationPolicy};
+use super::OpenRepositoryResult;
 use crate::tracking::{self, BlobRead};
 use crate::{encoding, graph, Error, Result};
 
@@ -135,14 +137,54 @@ pub trait RepositoryExt: super::PayloadStorage + graph::DatabaseExt {
 impl<T> RepositoryExt for T where T: super::PayloadStorage + graph::DatabaseExt {}
 
 /// Accessor methods for types only applicable to repositories that have
-/// payloads and renders, e.g., local repositories.
-pub trait LocalRepository {
+/// payloads, e.g., local repositories.
+pub trait LocalPayloads {
     /// Return the payload storage type
     fn payloads(&self) -> &FsHashStore;
+}
 
-    /// If supported, returns the type responsible for locally rendered manifests
+/// A trait for types that can support render stores, this provides a way to
+/// instantiate those types.
+pub trait RenderStoreForUser {
+    type RenderStore;
+
+    /// Create an instance of the render store for the given user.
     ///
-    /// # Errors:
-    /// - [`Error::NoRenderStorage`] - if this repository does not support manifest rendering
-    fn render_store(&self) -> Result<&RenderStore>;
+    /// This doesn't necessarily create the render store on disk; it depends on
+    /// the implementation.
+    ///
+    /// The `url` parameter is the URL of the repository the render store
+    /// belongs to.
+    fn render_store_for_user(
+        creation_policy: RenderStoreCreationPolicy,
+        url: url::Url,
+        root: &Path,
+        username: &Path,
+    ) -> OpenRepositoryResult<Self::RenderStore>;
+}
+
+/// A trait for types that might have render store, but no guarantees are made
+/// that it exists or is accessible.
+pub trait TryRenderStore {
+    /// Return the render store for repositories that support it.
+    ///
+    /// For some types this may create the render store for the user on demand
+    /// and may fail.
+    fn try_render_store(&self) -> Result<&RenderStore>;
+}
+
+//impl<T> TryRenderStore for T
+//where
+//    T: LocalRenderStore,
+//{
+//    fn try_render_store(&self) -> Result<&RenderStore> {
+//        Ok(self.render_store())
+//    }
+//}
+
+/// Accessor methods for types only applicable to repositories that have
+/// renders, e.g., local repositories.
+pub trait LocalRenderStore: RenderStoreForUser {
+    /// Returns the type responsible for locally rendered manifests
+    fn render_store(&self) -> &RenderStore;
 }

--- a/crates/spfs/src/storage/repository_test.rs
+++ b/crates/spfs/src/storage/repository_test.rs
@@ -65,10 +65,12 @@ async fn test_find_aliases(
 #[rstest]
 #[tokio::test]
 async fn test_commit_mode_fs(tmpdir: tempfile::TempDir) {
+    use crate::storage::fs::RenderStore;
+
     init_logging();
     let dir = tmpdir.path();
     let tmprepo = Arc::new(
-        fs::MaybeOpenFsRepository::create(dir.join("repo"))
+        fs::MaybeOpenFsRepository::<RenderStore>::create(dir.join("repo"))
             .await
             .unwrap()
             .into(),
@@ -90,7 +92,7 @@ async fn test_commit_mode_fs(tmpdir: tempfile::TempDir) {
 
     // Safety: tmprepo was created as an FsRepository
     let tmprepo = match &*tmprepo {
-        RepositoryHandle::FS(fs) => fs.opened().await.unwrap(),
+        RepositoryHandle::FSWithRenders(fs) => fs.opened().await.unwrap(),
         _ => panic!("Unexpected tmprepo type!"),
     };
 

--- a/crates/spfs/src/storage/tag_test.rs
+++ b/crates/spfs/src/storage/tag_test.rs
@@ -113,7 +113,9 @@ async fn test_tag_no_duplication(
 #[rstest]
 #[tokio::test]
 async fn test_tag_permissions(tmpdir: tempfile::TempDir) {
-    let storage = MaybeOpenFsRepository::create(tmpdir.path().join("repo"))
+    use crate::storage::fs::RenderStore;
+
+    let storage = MaybeOpenFsRepository::<RenderStore>::create(tmpdir.path().join("repo"))
         .await
         .unwrap();
     let spec = tracking::TagSpec::parse("hello").unwrap();

--- a/crates/spfs/src/storage/tar/repository.rs
+++ b/crates/spfs/src/storage/tar/repository.rs
@@ -16,7 +16,7 @@ use tar::{Archive, Builder};
 use crate::config::{pathbuf_deserialize_with_tilde_expansion, ToAddress};
 use crate::graph::ObjectProto;
 use crate::prelude::*;
-use crate::storage::fs::DURABLE_EDITS_DIR;
+use crate::storage::fs::{NoRenderStore, DURABLE_EDITS_DIR};
 use crate::storage::tag::TagSpecAndTagStream;
 use crate::storage::{
     EntryType,
@@ -68,7 +68,7 @@ pub struct TarRepository {
     up_to_date: AtomicBool,
     archive: std::path::PathBuf,
     repo_dir: tempfile::TempDir,
-    repo: crate::storage::fs::MaybeOpenFsRepository,
+    repo: crate::storage::fs::MaybeOpenFsRepository<NoRenderStore>,
 }
 
 #[async_trait::async_trait]
@@ -158,7 +158,8 @@ impl TarRepository {
             up_to_date: AtomicBool::new(false),
             archive: path,
             repo_dir: tmpdir,
-            repo: crate::storage::fs::MaybeOpenFsRepository::create(&repo_path).await?,
+            repo: crate::storage::fs::MaybeOpenFsRepository::<NoRenderStore>::create(&repo_path)
+                .await?,
         })
     }
 

--- a/crates/spfs/src/sync_test.rs
+++ b/crates/spfs/src/sync_test.rs
@@ -11,6 +11,7 @@ use super::Syncer;
 use crate::config::Config;
 use crate::fixtures::*;
 use crate::prelude::*;
+use crate::storage::fs::NoRenderStore;
 use crate::{encoding, storage, tracking, Error};
 
 #[rstest]
@@ -18,7 +19,11 @@ use crate::{encoding, storage, tracking, Error};
 async fn test_sync_ref_unknown(#[future] config: (tempfile::TempDir, Config)) {
     init_logging();
     let (_handle, config) = config.await;
-    let local = config.get_local_repository().await.unwrap().into();
+    let local = config
+        .get_local_repository::<NoRenderStore>()
+        .await
+        .unwrap()
+        .into();
     let origin = config.get_remote("origin").await.unwrap();
     let syncer = Syncer::new(&local, &origin);
     match syncer.sync_ref("--test-unknown--").await {
@@ -47,7 +52,13 @@ async fn test_push_ref(#[future] config: (tempfile::TempDir, Config)) {
     ensure(src_dir.join("dir2/otherfile.txt"), "hello2");
     ensure(src_dir.join("dir//dir/dir/file.txt"), "hello, world");
 
-    let local = Arc::new(config.get_local_repository().await.unwrap().into());
+    let local = Arc::new(
+        config
+            .get_local_repository::<NoRenderStore>()
+            .await
+            .unwrap()
+            .into(),
+    );
     let remote = config.get_remote("origin").await.unwrap();
     let manifest = crate::Committer::new(&local)
         .commit_dir(src_dir.as_path())
@@ -274,11 +285,11 @@ async fn test_sync_through_tar(
 #[fixture]
 async fn config(tmpdir: tempfile::TempDir) -> (tempfile::TempDir, Config) {
     let repo_path = tmpdir.path().join("repo");
-    crate::storage::fs::MaybeOpenFsRepository::create(&repo_path)
+    crate::storage::fs::MaybeOpenFsRepository::<NoRenderStore>::create(&repo_path)
         .await
         .expect("failed to make repo for test");
     let origin_path = tmpdir.path().join("origin");
-    crate::storage::fs::MaybeOpenFsRepository::create(&origin_path)
+    crate::storage::fs::MaybeOpenFsRepository::<NoRenderStore>::create(&origin_path)
         .await
         .expect("failed to make repo for test");
     let mut conf = Config::default();

--- a/crates/spk-build/src/build/binary_test.rs
+++ b/crates/spk-build/src/build/binary_test.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 use rstest::rstest;
 use spfs::encoding::EMPTY_DIGEST;
 use spfs::prelude::*;
+use spfs::storage::fs::RenderStore;
 use spk_schema::foundation::env::data_path;
 use spk_schema::foundation::fixtures::*;
 use spk_schema::foundation::ident_component::Component;
@@ -595,7 +596,7 @@ async fn test_build_package_source_cleanup() {
         .get(&Component::Run)
         .unwrap();
     let config = spfs::get_config().unwrap();
-    let repo = config.get_local_repository().await.unwrap();
+    let repo = config.get_local_repository::<RenderStore>().await.unwrap();
     let layer = repo.read_layer(digest).await.unwrap();
 
     let manifest_digest = match layer.manifest() {
@@ -691,7 +692,7 @@ async fn test_build_filters_reset_files() {
             .get(&Component::Run)
             .unwrap();
         let config = spfs::get_config().unwrap();
-        let repo = config.get_local_repository().await.unwrap();
+        let repo = config.get_local_repository::<RenderStore>().await.unwrap();
         let layer = repo.read_layer(digest).await.unwrap();
 
         let manifest_digest = match layer.manifest() {

--- a/crates/spk-cli/cmd-render/src/cmd_render.rs
+++ b/crates/spk-cli/cmd-render/src/cmd_render.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 use clap::Args;
 use miette::{bail, Context, IntoDiagnostic, Result};
 use spfs::storage::fallback::FallbackProxy;
+use spfs::storage::fs::NoRenderStore;
 use spk_cli_common::{build_required_packages, flags, CommandArgs, Run};
 use spk_exec::resolve_runtime_layers;
 
@@ -72,7 +73,7 @@ impl Run for Render {
         tracing::info!("Rendering into dir: {path:?}");
         let config = spfs::get_config().wrap_err("Failed to load spfs config")?;
         let local = config
-            .get_opened_local_repository()
+            .get_opened_local_repository::<NoRenderStore>()
             .await
             .wrap_err("Failed to open local spfs repo")?;
 

--- a/crates/spk-cli/group3/src/cmd_export_test.rs
+++ b/crates/spk-cli/group3/src/cmd_export_test.rs
@@ -90,7 +90,6 @@ async fn test_export_works_with_missing_builds() {
             "VERSION".to_string(),
             "objects".to_string(),
             "payloads".to_string(),
-            "renders".to_string(),
             "tags".to_string(),
             "tags/spk".to_string(),
             "tags/spk/pkg".to_string(),

--- a/crates/spk-cli/group3/src/cmd_import_test.rs
+++ b/crates/spk-cli/group3/src/cmd_import_test.rs
@@ -64,7 +64,6 @@ async fn test_archive_io() {
             "VERSION".to_string(),
             "objects".to_string(),
             "payloads".to_string(),
-            "renders".to_string(),
             "tags".to_string(),
             "tags/spk".to_string(),
             "tags/spk/pkg".to_string(),

--- a/crates/spk-launcher/src/main.rs
+++ b/crates/spk-launcher/src/main.rs
@@ -21,7 +21,7 @@ use nix::unistd::execv;
 use spfs::encoding::Digest;
 use spfs::prelude::*;
 use spfs::storage::fallback::FallbackProxy;
-use spfs::storage::fs::OpenFsRepository;
+use spfs::storage::fs::{NoRenderStore, OpenFsRepository};
 use spfs::storage::RepositoryHandle;
 use spfs::tracking::EnvSpec;
 use spfs::OsError;
@@ -108,7 +108,7 @@ impl<'a> Dynamic<'a> {
         &self,
         tag: &str,
         platform_digest: &Digest,
-        local: Arc<OpenFsRepository>,
+        local: Arc<OpenFsRepository<NoRenderStore>>,
         remote: RepositoryHandle,
     ) -> Result<OsString> {
         let digest_string = platform_digest.to_string();

--- a/crates/spk-storage/src/fixtures.rs
+++ b/crates/spk-storage/src/fixtures.rs
@@ -9,6 +9,7 @@ use once_cell::sync::Lazy;
 use rstest::fixture;
 use spfs::config::Remote;
 use spfs::prelude::*;
+use spfs::storage::fs::RenderStore;
 use spfs::Result;
 use spk_schema::foundation::fixtures::*;
 use spk_schema::ident_ops::{
@@ -120,9 +121,10 @@ where
     let repo = match kind {
         RepoKind::Spfs => {
             let storage_root = tmpdir.path().join("repo");
-            let spfs_repo = spfs::storage::fs::MaybeOpenFsRepository::create(&storage_root)
-                .await
-                .expect("failed to establish temporary local repo for test");
+            let spfs_repo =
+                spfs::storage::fs::MaybeOpenFsRepository::<RenderStore>::create(&storage_root)
+                    .await
+                    .expect("failed to establish temporary local repo for test");
             let written = spfs_repo
                 .commit_blob(Box::pin(std::io::Cursor::new(b"")))
                 .await

--- a/crates/spk-storage/src/storage/spfs.rs
+++ b/crates/spk-storage/src/storage/spfs.rs
@@ -16,6 +16,7 @@ use once_cell::sync::Lazy;
 use relative_path::RelativePathBuf;
 use serde::{Deserialize, Serialize};
 use spfs::prelude::{RepositoryExt as SpfsRepositoryExt, *};
+use spfs::storage::fs::MaybeRenderStore;
 use spfs::storage::EntryType;
 use spfs::tracking::{self, Tag, TagSpec};
 use spk_schema::foundation::ident_build::{parse_build, Build};
@@ -1311,7 +1312,7 @@ impl std::ops::Deref for SpfsRepositoryHandle<'_> {
 /// Return the local packages repository used for development.
 pub async fn local_repository() -> Result<SpfsRepository<NormalizedTagStrategy>> {
     let config = spfs::get_config()?;
-    let repo = config.get_local_repository().await?;
+    let repo = config.get_local_repository::<MaybeRenderStore>().await?;
     let inner: spfs::prelude::RepositoryHandle = repo.into();
     let address = inner.address().into_owned();
     Ok(SpfsRepository {

--- a/crates/spk-storage/src/storage/spfs_test.rs
+++ b/crates/spk-storage/src/storage/spfs_test.rs
@@ -7,6 +7,7 @@ use std::str::FromStr;
 
 use rstest::rstest;
 use spfs::prelude::*;
+use spfs::storage::fs::RenderStore;
 use spk_schema::foundation::fixtures::*;
 use spk_schema::foundation::version::Version;
 use spk_schema::ident_ops::NormalizedTagStrategy;
@@ -39,7 +40,7 @@ async fn test_metadata_io(tmpdir: tempfile::TempDir) {
         NormalizedTagStrategy,
     >::new(
         "test-repo",
-        spfs::storage::fs::MaybeOpenFsRepository::create(repo_root)
+        spfs::storage::fs::MaybeOpenFsRepository::<RenderStore>::create(repo_root)
             .await
             .unwrap(),
     ))
@@ -63,7 +64,7 @@ async fn test_upgrade_sets_version(tmpdir: tempfile::TempDir) {
         NormalizedTagStrategy,
     >::new(
         "test-repo",
-        spfs::storage::fs::MaybeOpenFsRepository::create(repo_root)
+        spfs::storage::fs::MaybeOpenFsRepository::<RenderStore>::create(repo_root)
             .await
             .unwrap(),
     ))
@@ -84,7 +85,7 @@ async fn test_upgrade_sets_version(tmpdir: tempfile::TempDir) {
 async fn test_upgrade_changes_tags(tmpdir: tempfile::TempDir) {
     init_logging();
     let repo_root = tmpdir.path();
-    let spfs_repo = spfs::storage::fs::MaybeOpenFsRepository::create(repo_root)
+    let spfs_repo = spfs::storage::fs::MaybeOpenFsRepository::<RenderStore>::create(repo_root)
         .await
         .unwrap();
     let repo = SpfsRepository::<NormalizedTagStrategy>::new(


### PR DESCRIPTION
The goal is to make it so it is possible to open repo without creating the renders directory for the current user, in situations where that renders directory will not be used. Examples include when using fuse or when running `spfs clean`.

This introduces different flavors of a "render store" besides `RenderStore` that either represent a render store that hasn't been created yet (but can be) or the lack of a render store. Operations that don't require a render store can access the local repository without the renders directory being created.

WIP: The test suite passes with this code but it is unfinished.