### PR TITLE
Update author with new email address

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ authors = [
     "Ryan Bottriell <ryan@bottriell.ca>",
     "J Robert Ray <jrray@imageworks.com>",
     "David Gilligan-Cook <dcook@imageworks.com>",
-    "Nichol Yip <nyip@imageworks.com>",
+    "Nichol Yip <nichyip14@gmail.com>",
 ]
 edition = "2021"
 version = "0.42.0"


### PR DESCRIPTION
`nyip@imageworks` will not be in use anymore so updated with personal email