### PR TITLE
env: fix handling of long lowerdir paths in newer kernel/mount versions

### DIFF
--- a/crates/spfs/Cargo.toml
+++ b/crates/spfs/Cargo.toml
@@ -18,6 +18,11 @@ default = []
 # If enabled, will create the "local" repository in a subdirectory
 # of the standard storage root, named "ci/pipeline_${CI_PIPELINE_ID}".
 gitlab-ci-local-repo-isolation = []
+# Use "mount" commands that are compatible with older centos7-era kernels that
+# do not support the "lowerdir+=" overlayfs options. "legacy-mount-options"
+# can run into path length limits when mounting many layers.
+# https://github.com/spkenv/spk/issues/968
+legacy-mount-options = []
 sentry = ["dep:sentry"]
 server = ["hyper/server", "tokio-util/codec", "tokio-util/io-util"]
 "protobuf-src" = ["dep:protobuf-src"]

--- a/crates/spfs/src/env.rs
+++ b/crates/spfs/src/env.rs
@@ -1126,10 +1126,19 @@ pub(crate) fn get_overlay_args<P: AsRef<Path>>(
     // the rightmost on the command line is the bottom layer, and the
     // leftmost is on the top). For more details see:
     // https://docs.kernel.org/filesystems/overlayfs.html#multiple-lower-layers
-    args.push_str("lowerdir=");
-    for path in layer_dirs.iter().rev() {
-        args.push_str(&path.as_ref().to_string_lossy());
-        args.push(':');
+    if cfg!(feature = "legacy-mount-options") {
+        args.push_str("lowerdir=");
+        for path in layer_dirs.iter().rev() {
+            args.push_str(&path.as_ref().to_string_lossy());
+            args.push(':');
+        }
+    } else {
+        for path in layer_dirs.iter().rev() {
+            args.push_str("lowerdir+=");
+            args.push_str(&path.as_ref().to_string_lossy());
+            args.push(',');
+        }
+        args.push_str("lowerdir+=");
     }
     args.push_str(&rt.config.lower_dir.to_string_lossy());
 


### PR DESCRIPTION
The new "lowerdir+" option can be used to specify multiple layers when mounting. This avoids a limitation with the "lowerdir" option which is limited to a max of 256 characters.

Use the older options when the "legacy-mount-options" feature is enabled.

Fixes: #968