### PR TITLE
Use better display output for flatbuffer objects

### DIFF
--- a/crates/spfs/src/graph/object.rs
+++ b/crates/spfs/src/graph/object.rs
@@ -37,10 +37,13 @@ where
 
 impl std::fmt::Display for Object {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("Object")
-            .field(&self.kind())
-            .field(&self.digest().unwrap())
-            .finish()
+        use std::fmt::Write;
+
+        f.write_fmt(format_args!("{:?}", self.kind()))?;
+        f.write_char('[')?;
+        f.write_fmt(format_args!("{}", self.digest().unwrap()))?;
+        f.write_char(']')?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Updates the `Display` impl for objects, eg:

## Previously
```txt
Object(Blob, Digest { bytes: [202, 141, 243, 191, 56, 20, 155, 154, 187, 135, 144, 151, 143, 37, 122, 171, 120, 127, 60, 144, 34, 81, 167, 166, 215, 191, 51, 95, 7, 86, 80, 82] })
```

## Now

```txt
Blob[ZKG7HPZYCSNZVO4HSCLY6JL2VN4H6PEQEJI2PJWXX4ZV6B2WKBJA====]
```
