### PR TITLE
Bugfix for newer python package conversions failing with no package names

### DIFF
--- a/packages/spk-convert-pip/requirements.txt
+++ b/packages/spk-convert-pip/requirements.txt
@@ -1,5 +1,7 @@
 # 1.10.0 is the last version that supports python 3.7
-pkginfo==1.10.0
+pkginfo==1.10.0 ; python_version <= "3.7"
+# 1.12.0 is required for newer python module package formats
+pkginfo==1.12.0 ; python_version >= "3.9"
 packaging==20.9
 # 0.40.0 latest at time of writing but no implied requirement for exactly this
 # version.


### PR DESCRIPTION
This fixes a bug preventing newer packages from being converted by `spk-convert-pip` built with python 3.9, by updating the `pkginfo` version to `1.12.0`. Older python 3.7 based builds are kept at `pkginfo` `1.10.0`.