### PR TITLE
Aligning spk-convert-pip with current SPI changes

### DIFF
--- a/packages/spk-convert-pip/spk-convert-pip
+++ b/packages/spk-convert-pip/spk-convert-pip
@@ -291,23 +291,11 @@ class PipImporter:
         assert not info.requires_external, "No support for external requirements"
         assert not info.supported_platforms, "No support for supported platforms field"
 
-        # The spk default is "Unlicensed", which seems odd
-        package_license = "Unknown"
-        if hasattr(info, "license"):
-            if info.license is not None:
-                package_license = str(info.license)
-                if len(package_license) > LICENSE_FIELD_TRUNCATION_POINT:
-                    package_license = (
-                        package_license[:LICENSE_FIELD_TRUNCATION_POINT]
-                        + TRUNCATED_VALUE_INDICATOR
-                    )
-
         spec = {
             "pkg": f"{_to_spk_name(info.name)}/{_to_spk_version(info.version)}",
             "api": "v0/package",
             "sources": [],
             "meta": {
-                "license": package_license,
                 "labels": {
                     SPK_GENERATED_BY_LABEL: SPK_GENERATED_BY_VALUE,
                     "spk-convert-pip:cli": self._cli_args,
@@ -326,6 +314,16 @@ class PipImporter:
                 "requirements": [],
             },
         }
+
+        # TODO: if info.license exists, add it into meta.licence but
+        # need a way to disable the SpdxLicense validation.
+        if hasattr(info, "license"):
+            package_license = str(info.license)
+            if len(package_license) > LICENSE_FIELD_TRUNCATION_POINT:
+                package_license = (
+                    package_license[:LICENSE_FIELD_TRUNCATION_POINT]
+                    + TRUNCATED_VALUE_INDICATOR
+                )
 
         if info.name == "pip":
             spec["build"]["validation"] = {"rules": [{"allow": "RecursiveBuild"}]}

--- a/packages/spk-convert-pip/spk-convert-pip.spk.yaml
+++ b/packages/spk-convert-pip/spk-convert-pip.spk.yaml
@@ -1,4 +1,4 @@
-pkg: spk-convert-pip/1.4.2
+pkg: spk-convert-pip/1.4.4
 api: v0/package
 build:
   script:


### PR DESCRIPTION
This modifies the license field processing in `spk-convert-pip` to align it with the current SPI license processing. The changes are from last September and move a code block around, as well as removing the "Unknown" default value.

This also versions up the `spk-convert-pip` spk package to `v1.4.4` to sync up the version numbers