### PR TITLE
Add `prune_tag_stream()` method to spfs Cleaner

### DIFF
--- a/crates/spfs/src/clean_test.rs
+++ b/crates/spfs/src/clean_test.rs
@@ -24,7 +24,7 @@ async fn test_attached_objects(#[future] tmprepo: TempRepo) {
 
     let cleaner = Cleaner::new(&tmprepo).with_reporter(TracingCleanReporter);
     cleaner
-        .discover_attached_objects(manifest.digest().unwrap())
+        .visit_attached_objects(manifest.digest().unwrap())
         .await
         .unwrap();
 


### PR DESCRIPTION
This adds a `prune_tag_stream()` method to spfs Cleaner's api, and refactors `prune_tag_stream_and_walk()` method into `prune_tag_stream()` and `walk_attached_objects()` (to reduce some repeated code).

`prune_tag_stream()` allows a Cleaner object to be used to only prune tags from a repo, e.g. remove all tags more than 2 weeks old from a local repo on a workstation or renderfarm machine.

