### PR TITLE
Bugfix: Solver building from source package with recursive dependencies

### DIFF
--- a/crates/spk-solve/src/solver.rs
+++ b/crates/spk-solve/src/solver.rs
@@ -20,7 +20,16 @@ use spk_schema::foundation::version::Compatibility;
 use spk_schema::ident::{PkgRequest, Request, RequestedBy, Satisfy, VarRequest};
 use spk_schema::ident_build::EmbeddedSource;
 use spk_schema::version::{ComponentsMissingProblem, IncompatibleReason, IsSameReasonAs};
-use spk_schema::{try_recipe, BuildIdent, Deprecate, Package, Recipe, Spec, SpecRecipe};
+use spk_schema::{
+    try_recipe,
+    BuildIdent,
+    Deprecate,
+    Package,
+    Recipe,
+    Spec,
+    SpecRecipe,
+    VersionIdent,
+};
 use spk_solve_graph::{
     Change,
     Decision,
@@ -123,6 +132,9 @@ pub struct Solver {
     // highlight problem areas in a solve and help user home in on
     // what might be causing issues.
     problem_packages: HashMap<String, u64>,
+    // Set of package/versions the solver has decided to try to build
+    // from source as part of a solve
+    new_builds_started: HashSet<VersionIdent>,
 }
 
 impl Default for Solver {
@@ -141,6 +153,7 @@ impl Default for Solver {
             number_of_steps_back: Arc::new(AtomicU64::new(0)),
             error_frequency: HashMap::new(),
             problem_packages: HashMap::new(),
+            new_builds_started: HashSet::new(),
         }
     }
 }
@@ -349,7 +362,17 @@ impl Solver {
     /// validate that a build is possible and to generate the resulting
     /// spec.
     #[async_recursion::async_recursion]
-    async fn resolve_new_build(&self, recipe: &SpecRecipe, state: &State) -> Result<Arc<Spec>> {
+    async fn resolve_new_build(&mut self, recipe: &SpecRecipe, state: &State) -> Result<Arc<Spec>> {
+        // Check if the package/version is one that the solver has
+        // already started to resolve a new build for, and error out
+        // if it is. The new_build_started set's insert will return
+        // true if the set did not contain the value before the insert.
+        if !self.new_builds_started.insert(recipe.ident().clone()) {
+            return Err(Error::String(
+                 format!("cannot build this package ({}) from source, during a solve, when it has a dependency on itself", recipe.ident()),
+             ));
+        }
+
         let mut opts = state.get_option_map().clone();
         for pkg_request in state.get_pkg_requests() {
             if !opts.contains_key(pkg_request.pkg.name.as_opt_name()) {
@@ -377,6 +400,11 @@ impl Solver {
             ..Default::default()
         };
         solver.update_options(opts.clone());
+        // Prime the new solver with the builds that have already been
+        // started so that it can detect long dependency loops in the
+        // things it might try to build from source in its solve.
+        solver.add_new_builds_started(&self.new_builds_started);
+
         let solution = solver.solve_build_environment(recipe).await?;
         recipe
             .generate_binary_build(&opts, &solution)
@@ -1064,6 +1092,7 @@ impl Solver {
         self.number_of_steps_back.store(0, Ordering::SeqCst);
         self.error_frequency.clear();
         self.problem_packages.clear();
+        self.new_builds_started.clear();
     }
 
     /// Run this solver
@@ -1104,6 +1133,12 @@ impl Solver {
                 .filter(|v| !matches!(v, Validators::BinaryOnly(_)))
                 .collect();
         }
+    }
+
+    /// Add the given set of package/versions to the solver's new
+    /// builds started records
+    pub fn add_new_builds_started(&mut self, new_builds: &HashSet<VersionIdent>) {
+        self.new_builds_started.extend(new_builds.clone());
     }
 
     /// Enable or disable running impossible checks on the initial requests


### PR DESCRIPTION
This fixes an issue in the Solver: when `--allow-builds` is enabled for the Solver (so, binary only is set to false and the `BinaryOnlyValidator` is not enabled), and it tries to build a package from source, and that package contains a recursive build dependency, which can generate a recurisve loop where the Solver tries to continually the same package build from source.

Adds a `new_builds_started` field to the Solver. When the Solver is allowed to build from source, it uses that new field to detect recursive loops in build environment dependencies.

Found this because we have a converted `python-pip` package with a build dependency on `python-pip` that's part of its manual bootstrapping.  When an `--allow-builds` solve contained a request for it, and the first version the solver found didn't have a build for the current OS, it triggered this issue.