### PR TITLE
Bugfix: Fixing internal name of imposible checks solver in info messages

### DIFF
--- a/crates/spk-solve/src/io.rs
+++ b/crates/spk-solve/src/io.rs
@@ -65,7 +65,7 @@ const STOP_ON_BLOCK_FLAG: &str = "--stop-on-block";
 const BY_USER: &str = "by user";
 
 const CLI_SOLVER: &str = "cli";
-const IMPOSSIBLE_CHECKS_SOLVER: &str = "check";
+const IMPOSSIBLE_CHECKS_SOLVER: &str = "checks";
 const ALL_SOLVERS: &str = "all";
 
 const UNABLE_TO_GET_OUTPUT_FILE_LOCK: &str = "Unable to get lock to write solver output to file";


### PR DESCRIPTION
This changes the internal name of the imposible checks solver to 'checks' from 'check'. This fixes a bug where some solver info messages contains the wrong name for that solver, e.g.:
```
INFO The All Impossible Checks solver found a solution, but its output was disabled. 
To see its output, rerun the spk command with '--solver-to-show check' or `--solver-to-run check`
```
will now say:
```
INFO The All Impossible Checks solver found a solution, but its output was disabled. 
To see its output, rerun the spk command with '--solver-to-show checks' or `--solver-to-run checks`
```
