### PR TITLE
Bugfix: host options were being left out of the solver's initial requests

### DIFF
--- a/crates/spk-cli/common/src/flags.rs
+++ b/crates/spk-cli/common/src/flags.rs
@@ -278,6 +278,10 @@ impl Solver {
             self.check_impossible_builds || self.check_impossible_all,
         );
 
+        for r in options.get_var_requests()? {
+            solver.add_request(r.into());
+        }
+
         Ok(solver)
     }
 }

--- a/crates/spk-cli/common/src/flags_test.rs
+++ b/crates/spk-cli/common/src/flags_test.rs
@@ -36,14 +36,17 @@ fn test_option_flags_parsing(#[case] args: &[&str], #[case] expected: &[(&str, &
     assert_eq!(actual, expected);
 }
 
+#[rstest]
+#[case::no_host_true(true)]
+#[case::no_host_false(false)]
 #[tokio::test]
-async fn test_get_solver_with_host_options() {
+async fn test_get_solver_with_host_options(#[case] no_host: bool) {
     // Test the get_solver() method adds the host options to the solver
     // correctly.
 
     let options_flags = crate::flags::Options {
         options: Vec::new(),
-        no_host: false,
+        no_host,
     };
 
     let solver_flags = crate::flags::Solver {
@@ -65,8 +68,17 @@ async fn test_get_solver_with_host_options() {
     let solver = solver_flags.get_solver(&options_flags).await.unwrap();
     let initial_state = solver.get_initial_state();
 
+    assert!(
+        !HOST_OPTIONS.get().unwrap().is_empty(),
+        "HOST_OPTIONS must not be empty for this test to be meaningful"
+    );
+
     for (name, value) in HOST_OPTIONS.get().unwrap() {
         let var_request = VarRequest::new_with_value(name, value);
-        assert!(initial_state.contains_var_request(&var_request));
+        if no_host {
+            assert!(!initial_state.contains_var_request(&var_request));
+        } else {
+            assert!(initial_state.contains_var_request(&var_request));
+        }
     }
 }

--- a/crates/spk-cli/common/src/flags_test.rs
+++ b/crates/spk-cli/common/src/flags_test.rs
@@ -5,6 +5,8 @@
 use rstest::rstest;
 use spk_schema::foundation::name::OptName;
 use spk_schema::foundation::option_map::OptionMap;
+use spk_schema::ident::VarRequest;
+use spk_schema::option_map::HOST_OPTIONS;
 
 #[rstest]
 #[case(&["hello:world"], &[("hello", "world")])]
@@ -32,4 +34,39 @@ fn test_option_flags_parsing(#[case] args: &[&str], #[case] expected: &[(&str, &
         .map(|(k, v)| (OptName::new(k).unwrap().to_owned(), v.to_string()))
         .collect();
     assert_eq!(actual, expected);
+}
+
+#[tokio::test]
+async fn test_get_solver_with_host_options() {
+    // Test the get_solver() method adds the host options to the solver
+    // correctly.
+
+    let options_flags = crate::flags::Options {
+        options: Vec::new(),
+        no_host: false,
+    };
+
+    let solver_flags = crate::flags::Solver {
+        repos: crate::flags::Repositories {
+            local_repo_only: false,
+            no_local_repo: false,
+            enable_repo: Default::default(),
+            disable_repo: Default::default(),
+            when: None,
+            legacy_spk_version_tags: false,
+        },
+        allow_builds: false,
+        check_impossible_initial: false,
+        check_impossible_validation: false,
+        check_impossible_builds: false,
+        check_impossible_all: false,
+    };
+
+    let solver = solver_flags.get_solver(&options_flags).await.unwrap();
+    let initial_state = solver.get_initial_state();
+
+    for (name, value) in HOST_OPTIONS.get().unwrap() {
+        let var_request = VarRequest::new_with_value(name, value);
+        assert!(initial_state.contains_var_request(&var_request));
+    }
 }


### PR DESCRIPTION
This fixes a bug where the host options were being left out of the solver's initial requests. A few lines of code hand been mistakenly removed in an earlier change. This restores them and adds a test for this situation.