### PR TITLE
env: make the new mount options opt-in

### DIFF
--- a/crates/spfs/Cargo.toml
+++ b/crates/spfs/Cargo.toml
@@ -18,11 +18,11 @@ default = []
 # If enabled, will create the "local" repository in a subdirectory
 # of the standard storage root, named "ci/pipeline_${CI_PIPELINE_ID}".
 gitlab-ci-local-repo-isolation = []
-# Use "mount" commands that are compatible with older centos7-era kernels that
-# do not support the "lowerdir+=" overlayfs options. "legacy-mount-options"
-# can run into path length limits when mounting many layers.
+# Use "mount" commands that leverage the "lowerdir+" overlayfs option supported
+# by newer kernels. Older systems that do not support the "lowerdir+" append
+# option may run into path length limits when mounting many layers.
 # https://github.com/spkenv/spk/issues/968
-legacy-mount-options = []
+mount-options-allow-append = []
 sentry = ["dep:sentry"]
 server = ["hyper/server", "tokio-util/codec", "tokio-util/io-util"]
 "protobuf-src" = ["dep:protobuf-src"]

--- a/crates/spfs/src/env.rs
+++ b/crates/spfs/src/env.rs
@@ -1126,19 +1126,19 @@ pub(crate) fn get_overlay_args<P: AsRef<Path>>(
     // the rightmost on the command line is the bottom layer, and the
     // leftmost is on the top). For more details see:
     // https://docs.kernel.org/filesystems/overlayfs.html#multiple-lower-layers
-    if cfg!(feature = "legacy-mount-options") {
-        args.push_str("lowerdir=");
-        for path in layer_dirs.iter().rev() {
-            args.push_str(&path.as_ref().to_string_lossy());
-            args.push(':');
-        }
-    } else {
+    if cfg!(feature = "mount-options-allow-append") {
         for path in layer_dirs.iter().rev() {
             args.push_str("lowerdir+=");
             args.push_str(&path.as_ref().to_string_lossy());
             args.push(',');
         }
         args.push_str("lowerdir+=");
+    } else {
+        args.push_str("lowerdir=");
+        for path in layer_dirs.iter().rev() {
+            args.push_str(&path.as_ref().to_string_lossy());
+            args.push(':');
+        }
     }
     args.push_str(&rt.config.lower_dir.to_string_lossy());
 


### PR DESCRIPTION
Rocky 9.4 does not support the `lowerdir+=` option.
Make the new mount options an opt-in feature.

Related-to: #968
Related-to: #1164