### PR TITLE
Fix runtime flattened_layers getting lost

### DIFF
--- a/crates/spfs/src/resolve.rs
+++ b/crates/spfs/src/resolve.rs
@@ -340,11 +340,11 @@ where
 
     // Note the layers we manufactured here via flattening so they will have a
     // strong reference in the runtime.
-    if !skip_runtime_save && runtime.status.flattened_layers != flattened_layers {
-        // If the additional layers has changed, then the runtime needs to be
-        // re-saved.
+    if runtime.status.flattened_layers != flattened_layers {
         runtime.status.flattened_layers = flattened_layers;
-        runtime.save_state_to_storage().await?;
+        if !skip_runtime_save {
+            runtime.save_state_to_storage().await?;
+        }
     }
 
     Ok(resolved_manifests)


### PR DESCRIPTION
When `skip_runtime_save` was added, when true it unintentionally did not update the `flattened_layers` field of the runtime. This then made flattened layers subject to premature deletion by spfs-clean. Deleting in-use renders can cause existing runtimes to be left with an empty /spfs directory.