### PR TITLE
Lazily load the default workspace as needed

### DIFF
--- a/crates/spk-schema/src/spec.rs
+++ b/crates/spk-schema/src/spec.rs
@@ -220,6 +220,7 @@ impl TemplateExt for SpecTemplate {
 
         if api.is_none() {
             tracing::warn!(
+                spec_file = %file_path.to_string_lossy(),
                 "Spec file is missing the 'api' field, this may be an error in the future"
             );
             tracing::warn!(


### PR DESCRIPTION
Not all spk [env] command lines contain a request that requires the use of a workspace, but previously the workspace was loaded unconditionally, meaning that any/all *.spk.yaml files in the working directory would be read in and possibly warned about if they do not contain the "api" entry.

Avoid this unnecessary file IO overhead when workspaces are not needed.

Also reuse the already loaded workspace instead of creating another new one per file in `parse_idents`.

Finally, if loading a workspace and warning about possibly more than one file if missing the "api" entry, include the filename of the offending file in the warning message.