### PR TITLE
Updated ring dependency to 0.7.14 to avoid a bug in 0.7.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ prost = "0.12.1"
 rand = "0.8.5"
 regex = "1.6"
 relative-path = "1.3"
-ring = "0.17.13"
+ring = "0.17.14"
 rstest = "0.18.2"
 sentry = { version = "0.34.0", default-features = false, features = [
     # all the default features except `debug-images` which causes a deadlock on


### PR DESCRIPTION
This updates the `ring` dependency to `0.7.14` to avoid a bug in `0.7.13` that impacts centos 7 compiles.