### PR TITLE
Solve `spk info filename.spk.yaml` failing with file not found

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4083,6 +4083,7 @@ dependencies = [
  "futures",
  "itertools 0.12.1",
  "miette",
+ "rstest 0.25.0",
  "serde",
  "serde_json",
  "serde_yaml 0.9.27",
@@ -4093,8 +4094,10 @@ dependencies = [
  "spk-storage",
  "spk-workspace",
  "strum",
+ "tempfile",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -4660,6 +4663,7 @@ name = "spk-workspace"
 version = "0.42.0"
 dependencies = [
  "bracoxide",
+ "dunce",
  "format_serde_error",
  "glob",
  "itertools 0.12.1",

--- a/crates/spk-cli/common/src/flags.rs
+++ b/crates/spk-cli/common/src/flags.rs
@@ -705,8 +705,19 @@ impl Workspace {
             | Err(spk_workspace::error::FromPathError::LoadWorkspaceFileError(
                 spk_workspace::error::LoadWorkspaceFileError::WorkspaceNotFound(_),
             )) => {
-                tracing::debug!("Using virtual workspace in current dir");
-                spk_workspace::Workspace::builder()
+                let mut builder = spk_workspace::Workspace::builder();
+
+                if self.workspace.is_dir() {
+                    tracing::debug!(
+                        "Using virtual workspace in {d}",
+                        d = self.workspace.to_string_lossy()
+                    );
+                    builder = builder.with_root(&self.workspace);
+                } else {
+                    tracing::debug!("Using virtual workspace in current dir");
+                }
+
+                builder
                     .with_glob_pattern("*.spk.yaml")?
                     .build()
                     .into_diagnostic()

--- a/crates/spk-cli/group4/Cargo.toml
+++ b/crates/spk-cli/group4/Cargo.toml
@@ -32,3 +32,8 @@ spk-workspace = { workspace = true }
 strum = { workspace = true }
 tokio = { workspace = true, features = ["rt"] }
 tracing = { workspace = true }
+
+[dev-dependencies]
+rstest = { workspace = true }
+tempfile = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/crates/spk-cli/group4/src/cmd_view.rs
+++ b/crates/spk-cli/group4/src/cmd_view.rs
@@ -38,6 +38,10 @@ use spk_solve::solution::{LayerPackageAndComponents, get_spfs_layers_to_packages
 use spk_storage;
 use strum::{Display, EnumString, IntoEnumIterator, VariantNames};
 
+#[cfg(test)]
+#[path = "./cmd_view_test.rs"]
+mod cmd_view_test;
+
 /// Constants for the valid output formats
 #[derive(Default, Display, EnumString, VariantNames, Clone)]
 #[strum(serialize_all = "lowercase")]

--- a/crates/spk-cli/group4/src/cmd_view_test.rs
+++ b/crates/spk-cli/group4/src/cmd_view_test.rs
@@ -1,0 +1,67 @@
+// Copyright (c) Contributors to the SPK project.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/spkenv/spk
+
+use std::fs::File;
+use std::io::Write;
+
+use clap::Parser;
+use rstest::{fixture, rstest};
+use spk_cli_common::Run;
+
+use super::View;
+
+#[derive(Parser)]
+struct Opt {
+    #[clap(flatten)]
+    view: View,
+}
+
+#[fixture]
+pub fn tmpdir() -> tempfile::TempDir {
+    tempfile::Builder::new()
+        .prefix("spk-test-")
+        .tempdir()
+        .expect("create a temp directory for test files")
+}
+
+pub fn init_logging() {
+    let sub = tracing_subscriber::FmtSubscriber::builder()
+        .with_env_filter("spk_workspace=trace,debug")
+        .without_time()
+        .with_test_writer()
+        .finish();
+    let _ = tracing::subscriber::set_global_default(sub);
+}
+
+#[rstest]
+#[tokio::test]
+async fn view_on_filename_and_default_workspace(tmpdir: tempfile::TempDir) {
+    init_logging();
+
+    let full_name = tmpdir.path().join("package.spk.yaml");
+
+    let mut file = File::create(&full_name).unwrap();
+    file.write_all(
+        r#"
+pkg: test/1.0.0
+api: v0/package
+"#
+        .as_bytes(),
+    )
+    .unwrap();
+
+    let mut opt = Opt::try_parse_from([
+        "view",
+        "-vvv",
+        "--workspace",
+        &tmpdir.path().to_string_lossy(),
+        // A straight `spk info package.spk.yaml` fails with "Failed to parse
+        // request" and/or "yaml was expected to contain a list of requests"
+        // but using the `--variants` flag still does something expected.
+        "--variants",
+        &full_name.to_string_lossy(),
+    ])
+    .unwrap();
+    opt.view.run().await.unwrap();
+}

--- a/crates/spk-workspace/Cargo.toml
+++ b/crates/spk-workspace/Cargo.toml
@@ -17,6 +17,7 @@ sentry = ["spk-solve/sentry"]
 
 [dependencies]
 bracoxide = { workspace = true }
+dunce = { workspace = true }
 format_serde_error = { workspace = true }
 glob = { workspace = true }
 itertools = { workspace = true }

--- a/crates/spk-workspace/src/workspace.rs
+++ b/crates/spk-workspace/src/workspace.rs
@@ -23,7 +23,7 @@ mod workspace_test;
 /// can be used to determine the number and order of
 /// packages to be built in order to efficiently satisfy
 /// and entire set of requirements for an environment.
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct Workspace {
     /// Spec templates available in this workspace.
     ///
@@ -142,10 +142,15 @@ impl Workspace {
         &self,
         file: &std::path::Path,
     ) -> Vec<&ConfiguredTemplate> {
+        // Attempt to canonicalize `file` using the same function that the
+        // workspace uses as it locates files, to have a chance of matching
+        // one of the entries in the workspace by comparing to its
+        // `file_path()`.
+        let file_path = dunce::canonicalize(file).unwrap_or_else(|_| file.to_owned());
         self.templates
             .values()
             .flat_map(|templates| templates.iter())
-            .filter(|t| t.template.file_path() == file)
+            .filter(|t| t.template.file_path() == file_path)
             .collect()
     }
 


### PR DESCRIPTION
At least for the simple case where no workspace file is present, fix `find_package_template_by_file` so it compares with canonicalized path names.

Change `Workspace::load_or_default` so that if the `--workspace` argument is a directory (that doesn't contain a workspace.spk.yaml file) it still roots the virtual workspace to the given directory. This allows for workspace tests to load a virtual workspace in a temporary directory.

Add a very basic cmd_view test that verifies it is possible to use `spk view --variants filename.spk.yaml`, something which is required by the CI automation at SPI.