### PR TITLE
Fix workspace issues stemming from new virtual workspace no accounting for path arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4083,7 +4083,7 @@ dependencies = [
  "futures",
  "itertools 0.12.1",
  "miette",
- "rstest 0.25.0",
+ "rstest 0.18.2",
  "serde",
  "serde_json",
  "serde_yaml 0.9.27",

--- a/crates/spk-cli/cmd-make-recipe/src/cmd_make_recipe.rs
+++ b/crates/spk-cli/cmd-make-recipe/src/cmd_make_recipe.rs
@@ -51,7 +51,7 @@ impl Run for MakeRecipe {
             None => workspace.default_package_template(),
             Some(p) => workspace.find_package_template(p),
         }
-        .must_be_found();
+        .wrap_err("did not find recipe template")?;
 
         if let Some(name) = configured.template.name() {
             tracing::info!("rendering template for {name}");

--- a/crates/spk-cli/cmd-make-recipe/src/cmd_make_recipe.rs
+++ b/crates/spk-cli/cmd-make-recipe/src/cmd_make_recipe.rs
@@ -45,11 +45,11 @@ impl Run for MakeRecipe {
 
     async fn run(&mut self) -> Result<Self::Output> {
         let options = self.options.get_options()?;
-        let workspace = self.workspace.load_or_default()?;
+        let mut workspace = self.workspace.load_or_default()?;
 
         let configured = match self.package.as_ref() {
-            None => workspace.default_package_template(),
-            Some(p) => workspace.find_package_template(p),
+            Some(p) => workspace.find_or_load_package_template(p),
+            None => workspace.default_package_template().map_err(From::from),
         }
         .wrap_err("did not find recipe template")?;
 

--- a/crates/spk-cli/group4/src/cmd_view.rs
+++ b/crates/spk-cli/group4/src/cmd_view.rs
@@ -236,7 +236,7 @@ impl View {
             None => workspace.default_package_template(),
             Some(name) => workspace.find_package_template(name),
         }
-        .must_be_found();
+        .wrap_err("did not find recipe template")?;
         let rendered_data = configured.template.render(options)?;
         let recipe = rendered_data.into_recipe().wrap_err_with(|| {
             format!(

--- a/crates/spk-cli/group4/src/cmd_view_test.rs
+++ b/crates/spk-cli/group4/src/cmd_view_test.rs
@@ -7,6 +7,7 @@ use std::io::Write;
 
 use clap::Parser;
 use rstest::{fixture, rstest};
+use spfs::runtime::makedirs_with_perms;
 use spk_cli_common::Run;
 
 use super::View;
@@ -33,6 +34,12 @@ pub fn init_logging() {
         .finish();
     let _ = tracing::subscriber::set_global_default(sub);
 }
+
+// The use of the --workspace flag in these tests is meant to simulate the
+// default behavior without the flag, which defaults to using ".", but these
+// tests want to avoid changing the current working directory during test
+// execution, so the tests don't need to be serialized or have to worry about
+// changing the current working directory back to the original value.
 
 #[rstest]
 #[tokio::test]
@@ -64,4 +71,162 @@ api: v0/package
     ])
     .unwrap();
     opt.view.run().await.unwrap();
+}
+
+#[rstest]
+#[tokio::test]
+async fn view_on_filename_in_sibling_dir_and_default_workspace(
+    #[from(tmpdir)] tmpdir1: tempfile::TempDir,
+    #[from(tmpdir)] tmpdir2: tempfile::TempDir,
+) {
+    init_logging();
+
+    let full_name = tmpdir1.path().join("package.spk.yaml");
+
+    let mut file = File::create(&full_name).unwrap();
+    file.write_all(
+        r#"
+pkg: test/1.0.0
+api: v0/package
+"#
+        .as_bytes(),
+    )
+    .unwrap();
+
+    let mut opt = Opt::try_parse_from([
+        "view",
+        "-vvv",
+        "--workspace",
+        &tmpdir2.path().to_string_lossy(),
+        // A straight `spk info package.spk.yaml` fails with "Failed to parse
+        // request" and/or "yaml was expected to contain a list of requests"
+        // but using the `--variants` flag still does something expected.
+        "--variants",
+        &full_name.to_string_lossy(),
+    ])
+    .unwrap();
+    opt.view.run().await.unwrap();
+}
+
+#[rstest]
+#[tokio::test]
+async fn view_on_filename_in_subdir_and_default_workspace(tmpdir: tempfile::TempDir) {
+    init_logging();
+
+    makedirs_with_perms(tmpdir.path().join("subdir"), 0o777).unwrap();
+
+    let full_name = tmpdir.path().join("subdir").join("package.spk.yaml");
+
+    let mut file = File::create(&full_name).unwrap();
+    file.write_all(
+        r#"
+pkg: test/1.0.0
+api: v0/package
+"#
+        .as_bytes(),
+    )
+    .unwrap();
+
+    let mut opt = Opt::try_parse_from([
+        "view",
+        "-vvv",
+        "--workspace",
+        &tmpdir.path().to_string_lossy(),
+        // A straight `spk info package.spk.yaml` fails with "Failed to parse
+        // request" and/or "yaml was expected to contain a list of requests"
+        // but using the `--variants` flag still does something expected.
+        "--variants",
+        &full_name.to_string_lossy(),
+    ])
+    .unwrap();
+    opt.view.run().await.unwrap();
+}
+
+#[rstest]
+#[tokio::test]
+async fn view_on_filename_and_unrelated_workspace(tmpdir: tempfile::TempDir) {
+    init_logging();
+
+    let full_name = tmpdir.path().join("package.spk.yaml");
+
+    let mut file = File::create(&full_name).unwrap();
+    file.write_all(
+        r#"
+pkg: test/1.0.0
+api: v0/package
+"#
+        .as_bytes(),
+    )
+    .unwrap();
+
+    // This workspace intentionally does not reference package.spk.yaml.
+    let mut file = File::create(tmpdir.path().join("workspace.spk.yaml")).unwrap();
+    file.write_all(
+        r#"
+api: v0/workspace
+recipes: []
+"#
+        .as_bytes(),
+    )
+    .unwrap();
+
+    let mut opt = Opt::try_parse_from([
+        "view",
+        "-vvv",
+        "--workspace",
+        &tmpdir.path().to_string_lossy(),
+        // A straight `spk info package.spk.yaml` fails with "Failed to parse
+        // request" and/or "yaml was expected to contain a list of requests"
+        // but using the `--variants` flag still does something expected.
+        "--variants",
+        &full_name.to_string_lossy(),
+    ])
+    .unwrap();
+    opt.view.run().await.unwrap();
+}
+
+#[rstest]
+#[tokio::test]
+async fn view_on_workspace_filename_and_existing_workspace(tmpdir: tempfile::TempDir) {
+    init_logging();
+
+    let full_name = tmpdir.path().join("workspace.spk.yaml");
+
+    let mut file = File::create(&full_name).unwrap();
+    file.write_all(
+        r#"
+api: v0/workspace
+recipes: []
+"#
+        .as_bytes(),
+    )
+    .unwrap();
+
+    let mut opt = Opt::try_parse_from([
+        "view",
+        "-vvv",
+        "--workspace",
+        &tmpdir.path().to_string_lossy(),
+        // A straight `spk info package.spk.yaml` fails with "Failed to parse
+        // request" and/or "yaml was expected to contain a list of requests"
+        // but using the `--variants` flag still does something expected.
+        //
+        // Doing `--variants` on a workspace file is meaningless but this test
+        // demonstrates how this fails with a "file does not exist" error when
+        // the file does exist.
+        "--variants",
+        &full_name.to_string_lossy(),
+    ])
+    .unwrap();
+    let err = opt
+        .view
+        .run()
+        .await
+        .expect_err("--variants should fail on a workspace file");
+
+    assert!(
+        !err.to_string().contains("did not find package template"),
+        "Expected error to not contain 'did not find package template', got: {}",
+        err,
+    );
 }

--- a/crates/spk-schema/src/spec.rs
+++ b/crates/spk-schema/src/spec.rs
@@ -137,7 +137,7 @@ macro_rules! spec {
 
 /// A generic, structured data object that can be turned into a recipe
 /// when provided with the necessary option values
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SpecTemplate {
     name: Option<PkgNameBuf>,
     versions: HashSet<Version>,

--- a/crates/spk-workspace/src/lib.rs
+++ b/crates/spk-workspace/src/lib.rs
@@ -15,4 +15,9 @@ mod file;
 mod workspace;
 
 pub use file::WorkspaceFile;
-pub use workspace::{FindPackageTemplateError, FindPackageTemplateResult, Workspace};
+pub use workspace::{
+    FindOrLoadPackageTemplateError,
+    FindPackageTemplateError,
+    FindPackageTemplateResult,
+    Workspace,
+};

--- a/crates/spk-workspace/src/lib.rs
+++ b/crates/spk-workspace/src/lib.rs
@@ -15,4 +15,4 @@ mod file;
 mod workspace;
 
 pub use file::WorkspaceFile;
-pub use workspace::{FindPackageTemplateResult, Workspace};
+pub use workspace::{FindPackageTemplateError, FindPackageTemplateResult, Workspace};

--- a/crates/spk-workspace/src/workspace.rs
+++ b/crates/spk-workspace/src/workspace.rs
@@ -32,7 +32,7 @@ pub struct Workspace {
     pub(crate) templates: HashMap<PkgNameBuf, Vec<ConfiguredTemplate>>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ConfiguredTemplate {
     pub template: SpecTemplate,
     pub config: crate::file::TemplateConfig,
@@ -62,21 +62,21 @@ impl Workspace {
         // that find_package_recipe_from_template_or_repo() can operate
         // correctly.
         let Some((_name, template)) = iter.next() else {
-            return FindPackageTemplateResult::NoTemplateFiles;
+            return Err(FindPackageTemplateError::NoTemplateFiles);
         };
 
         if iter.next().is_some() {
-            let all = self.templates.values().flatten().collect();
-            return FindPackageTemplateResult::MultipleTemplateFiles(all);
+            let all = self.templates.values().flatten().cloned().collect();
+            return Err(FindPackageTemplateError::MultipleTemplates(all));
         };
 
-        FindPackageTemplateResult::Found(template)
+        Ok(template)
     }
 
     /// Find a package template file for the requested package, if any.
     ///
     /// A package name, name with version, or filename can be provided.
-    pub fn find_package_template<S>(&self, package: S) -> FindPackageTemplateResult
+    pub fn find_package_template<S>(&self, package: S) -> FindPackageTemplateResult<'_>
     where
         S: AsRef<str>,
     {
@@ -100,12 +100,14 @@ impl Workspace {
         };
 
         if found.is_empty() {
-            return FindPackageTemplateResult::NotFound(package.to_owned());
+            return Err(FindPackageTemplateError::NotFound(package.to_owned()));
         }
         if found.len() > 1 {
-            return FindPackageTemplateResult::MultipleTemplateFiles(found);
+            return Err(FindPackageTemplateError::MultipleTemplates(
+                found.into_iter().cloned().collect(),
+            ));
         }
-        FindPackageTemplateResult::Found(found[0])
+        Ok(found[0])
     }
 
     /// Like [`Self::find_package_template`], but further filters by package version.
@@ -206,62 +208,61 @@ impl Workspace {
 }
 
 /// The result of the [`Workspace::find_package_template`] function.
-#[derive(Debug)]
-pub enum FindPackageTemplateResult<'a> {
-    /// A non-ambiguous package template file was found
-    Found(&'a ConfiguredTemplate),
+pub type FindPackageTemplateResult<'workspace> =
+    Result<&'workspace ConfiguredTemplate, FindPackageTemplateError>;
+
+/// Possible errors for [`Workspace::find_package_template`] and related functions.
+#[derive(Debug, thiserror::Error, miette::Diagnostic)]
+#[diagnostic(
+    url(
+        "https://spkenv.dev/error_codes#{}",
+        self.code().unwrap_or_else(|| Box::new("spk::generic"))
+    )
+)]
+pub enum FindPackageTemplateError {
     /// No package was specifically requested, and there are multiple
     /// files in the current repository.
-    MultipleTemplateFiles(Vec<&'a ConfiguredTemplate>),
+    #[error("Multiple package specs in current workspace:\n{}", self.formatted_packages_list())]
+    #[diagnostic(help = "ensure that you specify a package name, file path or version")]
+    MultipleTemplates(Vec<ConfiguredTemplate>),
     /// No package was specifically requested, and there no template
     /// files in the current repository.
+    #[error("No package specs found in current workspace")]
+    #[diagnostic(help = "please specify a spec file path")]
     NoTemplateFiles,
     /// The template file was not found
+    #[error("Spec file not found for '{0}', or the file does not exist")]
     NotFound(String),
 }
 
-impl<'a> FindPackageTemplateResult<'a> {
-    ///True if a template file was found
-    pub fn is_found(&self) -> bool {
-        matches!(self, Self::Found { .. })
-    }
-
-    /// Prints error messages and exits if no template file was found
-    pub fn must_be_found(self) -> &'a ConfiguredTemplate {
-        match self {
-            Self::Found(template) => return template,
-            Self::MultipleTemplateFiles(templates) => {
-                let mut here = std::env::current_dir().unwrap_or_default();
-                here = here.canonicalize().unwrap_or(here);
-                tracing::error!("Multiple package specs in current workspace:");
-                for configured in templates {
-                    // attempt to strip the current working directory from each path
-                    // because in most cases it was loaded from the active workspace
-                    // and the additional path prefix is just noise
-                    let path = configured.template.file_path();
-                    let path = path.strip_prefix(&here).unwrap_or(path).to_string_lossy();
-                    let mut versions = configured
-                        .config
-                        .versions
-                        .iter()
-                        .map(ToString::to_string)
-                        .collect::<Vec<_>>()
-                        .join(", ");
-                    if versions.is_empty() {
-                        versions.push_str("<any>");
-                    }
-                    tracing::error!(" - {path} versions=[{versions}]",);
-                }
-                tracing::error!(" > ensure that you specify a package name, file path or version");
+impl FindPackageTemplateError {
+    /// Generates a list-formatted, one-per-line string of the available templates
+    /// when the error contains such information. Eg for [`FindPackageTemplateError::MultipleTemplates`].
+    fn formatted_packages_list(&self) -> String {
+        let Self::MultipleTemplates(templates) = self else {
+            return String::new();
+        };
+        let mut lines = Vec::with_capacity(templates.len());
+        let mut here = std::env::current_dir().unwrap_or_default();
+        here = here.canonicalize().unwrap_or(here);
+        for configured in templates {
+            // attempt to strip the current working directory from each path
+            // because in most cases it was loaded from the active workspace
+            // and the additional path prefix is just noise
+            let path = configured.template.file_path();
+            let path = path.strip_prefix(&here).unwrap_or(path).to_string_lossy();
+            let mut versions = configured
+                .config
+                .versions
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(", ");
+            if versions.is_empty() {
+                versions.push_str("<any>");
             }
-            Self::NoTemplateFiles => {
-                tracing::error!("No package specs found in current workspace");
-                tracing::error!(" > please specify a filepath");
-            }
-            Self::NotFound(request) => {
-                tracing::error!("Spec file not found for '{request}', or the file does not exist");
-            }
+            lines.push(format!(" - {path} versions=[{versions}]"));
         }
-        std::process::exit(1);
+        lines.join("\n")
     }
 }

--- a/docs/ref/spec.md
+++ b/docs/ref/spec.md
@@ -27,7 +27,7 @@ The root package spec defines which fields can and should exist at the top level
 | ----------- | -------------- | ---------------------------------------------------------------------- |
 | description | _str_          | (Optional) A concise, one sentence description of the package          |
 | homepage    | _str_          | (Optional) URL where the package lives                                 |
-| license     | _str_          | (Optional) Package license. If not specified, defaults to _Unlicensed_ |
+| license     | _str_          | (Optional) Package license. If not specified, defaults to _Unlicensed_ |
 | labels      | _Map[str,str]_ | (Optional) A storage for arbitrary key-value data                      |
 
 ## SourceSpec


### PR DESCRIPTION
The new workspace feature has introduced a variety of regressions for
using `spk info --variants <filename>` and will error with a file not
found error for files that do actually exist.

One problem is that when a workspace spec doesn't exist, then the only
possible files that can be inspected have to exist in the root of the
virtual workspace generated, ignoring that the command line contains the
name of a valid file.

Another problem is when the workspace does exist, then the only possible
files that can be inspected have to be defined in the workspace, even
when the command line contains the name of a valid file.

Perhaps the design can be reconsidered to not use a "virtual workspace"
in these cases or at least have a fallback that tries to open the file
directly.