### PR TITLE
Make git source tests not require a git clone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2959,9 +2959,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.13"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",

--- a/crates/spk-build/src/build/sources_test.rs
+++ b/crates/spk-build/src/build/sources_test.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/spkenv/spk
 
+use std::io::Write;
+
 use rstest::rstest;
 use spk_schema::foundation::fixtures::*;
 use spk_schema::ident::build_ident;
@@ -47,8 +49,44 @@ fn test_validate_sources_changeset_ok() {
 
 #[rstest]
 #[tokio::test]
-async fn test_sources_subdir(_tmpdir: tempfile::TempDir) {
+async fn test_sources_subdir(tmpdir: tempfile::TempDir) {
     let rt = spfs_runtime().await;
+
+    // Create a small git working copy at tmpdir so this test does not depend on
+    // this working copy using git.
+    {
+        std::process::Command::new("git")
+            .args(["init", "--quiet"])
+            .current_dir(&tmpdir)
+            .output()
+            .unwrap();
+        tmpdir.path().join("file_a.txt").ensure();
+        tmpdir.path().join("file_b.txt").ensure();
+        let output = std::process::Command::new("git")
+            .args(["add", "file_a.txt", "file_b.txt"])
+            .current_dir(&tmpdir)
+            .output()
+            .unwrap();
+        std::io::stderr().write_all(&output.stderr).unwrap();
+        assert!(output.status.success());
+        let output = std::process::Command::new("git")
+            .args([
+                "-c",
+                "user.name=Test User",
+                "-c",
+                "user.email=<testuser@invalid.invalid>",
+                "commit",
+                "--author",
+                "Test User <testuser@invalid.invalid>",
+                "-m",
+                "test commit",
+            ])
+            .current_dir(&tmpdir)
+            .output()
+            .unwrap();
+        std::io::stderr().write_all(&output.stderr).unwrap();
+        assert!(output.status.success());
+    }
 
     let tar_file = rt.tmpdir.path().join("archive.tar.gz");
     let writer = std::fs::OpenOptions::new()
@@ -67,16 +105,7 @@ async fn test_sources_subdir(_tmpdir: tempfile::TempDir) {
         subdir: Some("/archive/src".to_string()),
     };
     let git_source = GitSource {
-        git: std::env::current_dir()
-            .unwrap()
-            // Now that we're in a sub-crate, to find the root of the git
-            // project we need to pop two directories.
-            .parent()
-            .unwrap()
-            .parent()
-            .unwrap()
-            .to_string_lossy()
-            .to_string(),
+        git: tmpdir.path().to_string_lossy().to_string(),
         subdir: Some("git_repo".to_string()),
         depth: 1,
         reference: String::new(),
@@ -102,7 +131,8 @@ async fn test_sources_subdir(_tmpdir: tempfile::TempDir) {
     assert!(dest_dir.join("git_repo").is_dir());
     assert!(dest_dir.join("archive/src").is_dir());
     assert!(dest_dir.join("archive/src/src/lib.rs").is_file());
-    assert!(dest_dir.join("git_repo/crates/spk/src/cli.rs").is_file());
+    assert!(dest_dir.join("git_repo/file_a.txt").is_file());
+    assert!(dest_dir.join("git_repo/file_b.txt").is_file());
     assert!(
         !dest_dir.join("local/.git").exists(),
         "should exclude git repo"

--- a/crates/spk-schema/src/source_spec_test.rs
+++ b/crates/spk-schema/src/source_spec_test.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/spkenv/spk
 
+use std::io::Write;
+
 use rstest::rstest;
 
 use super::{GitSource, LocalSource, ScriptSource, TarSource};
@@ -44,22 +46,52 @@ fn test_local_source_file(tmpdir: tempfile::TempDir) {
 #[rstest]
 fn test_git_sources(tmpdir: tempfile::TempDir) {
     init_logging();
+
     let source_dir = tmpdir.path().join("source");
+    std::fs::create_dir_all(&source_dir).unwrap();
+
+    // Create a small git working copy at tmpdir so this test does not depend on
+    // this working copy using git.
+    {
+        std::process::Command::new("git")
+            .args(["init", "--quiet"])
+            .current_dir(&source_dir)
+            .output()
+            .unwrap();
+        std::fs::write(source_dir.join("file_a.txt"), b"").unwrap();
+        std::fs::write(source_dir.join("file_b.txt"), b"").unwrap();
+        let output = std::process::Command::new("git")
+            .args(["add", "file_a.txt", "file_b.txt"])
+            .current_dir(&source_dir)
+            .output()
+            .unwrap();
+        std::io::stderr().write_all(&output.stderr).unwrap();
+        assert!(output.status.success());
+        let output = std::process::Command::new("git")
+            .args([
+                "-c",
+                "user.name=Test User",
+                "-c",
+                "user.email=<testuser@invalid.invalid>",
+                "commit",
+                "--author",
+                "Test User <testuser@invalid.invalid>",
+                "-m",
+                "test commit",
+            ])
+            .current_dir(&source_dir)
+            .output()
+            .unwrap();
+        std::io::stderr().write_all(&output.stderr).unwrap();
+        assert!(output.status.success());
+    }
+
     let dest_dir = tmpdir.path().join("dest");
     {
-        std::fs::create_dir_all(&source_dir).unwrap();
         std::fs::create_dir_all(&dest_dir).unwrap();
         std::fs::File::create(source_dir.join("file.txt")).unwrap();
     }
-    let spec = format!(
-        "{{git: {:?}}}",
-        std::env::current_dir()
-            .unwrap()
-            .parent()
-            .unwrap()
-            .parent()
-            .unwrap()
-    );
+    let spec = format!("{{git: {:?}}}", source_dir.to_string_lossy().to_string());
     let source: GitSource = serde_yaml::from_str(&spec).unwrap();
     source.collect(&dest_dir).unwrap();
 


### PR DESCRIPTION
If using a different vcs tool besides git to check out the spk project, these tests would fail, as they assume the working copy is a git clone.

Modify the tests to create a new git clone in a temporary directory so they don't depend on the working copy being a git clone.