### PR TITLE
Skip invalid template files when loading workspace

### DIFF
--- a/crates/spk-cli/common/src/flags.rs
+++ b/crates/spk-cli/common/src/flags.rs
@@ -723,6 +723,7 @@ impl Workspace {
                     .with_glob_pattern("*.spk.yaml")?
                     .build()
                     .into_diagnostic()
+                    .wrap_err("loading *.spk.yaml")
             }
             Err(err) => Err(err.into()),
         }

--- a/crates/spk-cli/group4/src/cmd_view.rs
+++ b/crates/spk-cli/group4/src/cmd_view.rs
@@ -127,7 +127,11 @@ impl Run for View {
     async fn run(&mut self) -> Result<Self::Output> {
         if self.variants || self.variants_with_tests {
             let options = self.options.get_options()?;
-            let mut workspace = self.requests.workspace.load_or_default()?;
+            let mut workspace = self
+                .requests
+                .workspace
+                .load_or_default()
+                .wrap_err("loading workspace")?;
             return self.print_variants_info(&options, &mut workspace, self.variants_with_tests);
         }
 

--- a/crates/spk-workspace/src/builder.rs
+++ b/crates/spk-workspace/src/builder.rs
@@ -97,7 +97,15 @@ impl WorkspaceBuilder {
     pub fn build(self) -> Result<super::Workspace, error::BuildError> {
         let mut workspace = super::Workspace::default();
         for (file, config) in self.spec_files {
-            workspace.load_template_file_with_config(file, config)?;
+            match workspace.load_template_file_with_config(&file, config) {
+                Ok(_) => {}
+                Err(e) => {
+                    tracing::warn!(
+                        file = file.to_string_lossy().to_string(),
+                        "ignoring template file: {e}"
+                    );
+                }
+            }
         }
         Ok(workspace)
     }


### PR DESCRIPTION
For the use case of `spk info --variants <valid spec file>`, this command would fail with an error about a different file if another file exists with a name matching `*.spk.yaml` but loading this other file fails for any reason.

Like #1190 and #1191, this command is expected to succeed and is not intended to interact with any other files other than the one named on the command line.