### PR TITLE
Wrapping unsafe sections of two build.rs files to stop compiler erroring out

### DIFF
--- a/crates/spfs-vfs/build.rs
+++ b/crates/spfs-vfs/build.rs
@@ -4,7 +4,9 @@
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(feature = "protobuf-src")]
-    std::env::set_var("PROTOC", protobuf_src::protoc());
+    unsafe {
+        std::env::set_var("PROTOC", protobuf_src::protoc());
+    }
     tonic_build::configure().compile(&["src/proto/defs/vfs.proto"], &["src/proto/defs"])?;
     Ok(())
 }

--- a/crates/spfs/build.rs
+++ b/crates/spfs/build.rs
@@ -4,7 +4,9 @@
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(feature = "protobuf-src")]
-    std::env::set_var("PROTOC", protobuf_src::protoc());
+    unsafe {
+        std::env::set_var("PROTOC", protobuf_src::protoc());
+    }
     tonic_build::configure().bytes(["buffer"]).compile(
         &[
             "src/proto/defs/database.proto",


### PR DESCRIPTION
This wraps some unsafe sections of two build.rs files to stop the compiler erroring out when trying to build spk.
Apparently, the github CI doesn't use these files, or try to check or compile these bits. But locally for me they cause errors and the compiling fails.
