### PR TITLE
Add `-R` for `--recursive` in `spk ls`

### DIFF
--- a/crates/spk-cli/group2/src/cmd_ls.rs
+++ b/crates/spk-cli/group2/src/cmd_ls.rs
@@ -60,7 +60,7 @@ pub struct Ls<Output: Default = Console> {
     components: bool,
 
     /// Recursively list all package versions and builds
-    #[clap(long)]
+    #[clap(long, short = 'R')]
     recursive: bool,
 
     /// Show the deprecated packages


### PR DESCRIPTION
This just adds `-R` as the short form of `--recursive` for `spk ls` to save on the typing.