### PR TITLE
Fix `spfs clean` failing if a tag namespace exists

### DIFF
--- a/crates/spfs-cli/cmd-clean/src/cmd_clean.rs
+++ b/crates/spfs-cli/cmd-clean/src/cmd_clean.rs
@@ -50,6 +50,11 @@ pub struct CmdClean {
     #[clap(long)]
     dry_run: bool,
 
+    /// Prune all tag namespaces. The default is to only prune tags in the
+    /// active tag namespace.
+    #[clap(long)]
+    prune_all_tag_namespaces: bool,
+
     /// Prune old tags that have the same target as a more recent version
     #[clap(long = "prune-repeated", group = "repo_data")]
     prune_repeated: bool,
@@ -165,6 +170,7 @@ impl CmdClean {
             .with_reporter(spfs::clean::ConsoleCleanReporter::default())
             .with_dry_run(self.dry_run)
             .with_required_age(chrono::Duration::minutes(15))
+            .with_prune_all_tag_namespaces(self.prune_all_tag_namespaces)
             .with_prune_repeated_tags(prune_repeated_tags)
             .with_prune_tags_older_than(self.prune_if_older_than)
             .with_keep_tags_newer_than(self.keep_if_newer_than)

--- a/crates/spfs-cli/cmd-clean/src/cmd_clean.rs
+++ b/crates/spfs-cli/cmd-clean/src/cmd_clean.rs
@@ -217,7 +217,11 @@ impl CmdClean {
         };
         println!(
             "{visited_tags:>12} tags visited     [{:>6} {removed}]",
-            pruned_tags.values().map(Vec::len).sum::<usize>()
+            pruned_tags
+                .values()
+                .flat_map(|m| m.values())
+                .map(|v| v.len())
+                .sum::<usize>()
         );
         println!(
             "{visited_objects:>12} objects visited  [{:>6} {removed}]",

--- a/crates/spfs/src/clean_test.rs
+++ b/crates/spfs/src/clean_test.rs
@@ -301,6 +301,120 @@ async fn test_clean_on_repo_with_tag_namespace(
 
 #[rstest]
 #[tokio::test]
+async fn test_clean_on_repo_with_tag_namespace_set(
+    #[future] tmprepo: TempRepo,
+    tmpdir: tempfile::TempDir,
+) {
+    init_logging();
+
+    // The point of this test is to run a cleaner when a tag in a tag namespace
+    // exists and a tag namespace is set on the repo passed into the Cleaner. It
+    // is a dupe of `test_clean_on_repo_with_tag_namespace` but the repo passed
+    // into the Cleaner has a tag namespace set.
+
+    let non_namespaced_tmprepo = tmprepo.await;
+    let namespaced_tmprepo = non_namespaced_tmprepo.with_tag_namespace("test").await;
+
+    // Group 1: untagged objects
+    let data_dir_1 = tmpdir.path().join("data");
+    ensure(data_dir_1.join("dir/dir/test.file"), "1 hello");
+    ensure(data_dir_1.join("dir/dir/test.file2"), "1 hello, world");
+    ensure(data_dir_1.join("dir/dir/test.file4"), "1 hello, world");
+
+    let manifest1 = crate::Committer::new(&namespaced_tmprepo)
+        .commit_dir(data_dir_1.as_path())
+        .await
+        .unwrap();
+
+    // Group 2: tagged objects
+    let data_dir_2 = tmpdir.path().join("data2");
+    ensure(data_dir_2.join("dir/dir/test.file"), "2 hello");
+    ensure(data_dir_2.join("dir/dir/test.file2"), "2 hello, world");
+
+    let manifest2 = crate::Committer::new(&namespaced_tmprepo)
+        .commit_dir(data_dir_2.as_path())
+        .await
+        .unwrap();
+    let layer = namespaced_tmprepo
+        .create_layer(&manifest2.to_graph_manifest())
+        .await
+        .unwrap();
+    let tag = tracking::TagSpec::parse("tagged_manifest").unwrap();
+    namespaced_tmprepo
+        .push_tag(&tag, &layer.digest().unwrap())
+        .await
+        .unwrap();
+
+    // Note current time now.
+    let time_before_group_three = Utc::now();
+
+    // Ensure these new files are created a measurable amount of time after
+    // the noted time.
+    sleep(Duration::from_millis(250)).await;
+
+    // Group 3: untagged objects created after grabbing time.
+    let data_dir_3 = tmpdir.path().join("data");
+    ensure(data_dir_3.join("dir/dir/test.file"), "3 hello");
+    ensure(data_dir_3.join("dir/dir/test.file2"), "3 hello, world");
+    ensure(data_dir_3.join("dir/dir/test.file4"), "3 hello, world");
+
+    let manifest3 = crate::Committer::new(&namespaced_tmprepo)
+        .commit_dir(data_dir_3.as_path())
+        .await
+        .unwrap();
+
+    // Clean objects older than group 3.
+    let cleaner = Cleaner::new(&namespaced_tmprepo)
+        .with_reporter(TracingCleanReporter)
+        .with_required_age_cutoff(time_before_group_three);
+    let result = cleaner
+        .prune_all_tags_and_clean()
+        .await
+        .expect("failed to clean objects");
+    println!("{result:#?}");
+
+    for node in manifest1.walk() {
+        if !node.entry.kind.is_blob() {
+            continue;
+        }
+        let res = namespaced_tmprepo.open_payload(node.entry.object).await;
+        if let Err(Error::UnknownObject(_)) = res {
+            continue;
+        }
+        if let Err(err) = res {
+            println!("{err:?}");
+        }
+        panic!(
+            "expected object to be cleaned but it was not: {:?}",
+            node.entry.object
+        );
+    }
+
+    for node in manifest2.walk() {
+        if !node.entry.kind.is_blob() {
+            continue;
+        }
+        namespaced_tmprepo
+            .open_payload(node.entry.object)
+            .await
+            .expect("expected payload not to be cleaned");
+    }
+
+    // Group 3 should not have been cleaned...
+
+    for node in manifest3.walk() {
+        if !node.entry.kind.is_blob() {
+            continue;
+        }
+        namespaced_tmprepo
+            .open_payload(node.entry.object)
+            .await
+            .expect("expected payload not to be cleaned");
+    }
+}
+
+#[rstest]
+#[tokio::test]
 async fn test_clean_untagged_objects_layers_platforms(#[future] tmprepo: TempRepo) {
     init_logging();
     let tmprepo = tmprepo.await;

--- a/crates/spfs/src/clean_test.rs
+++ b/crates/spfs/src/clean_test.rs
@@ -187,6 +187,120 @@ async fn test_clean_untagged_objects(#[future] tmprepo: TempRepo, tmpdir: tempfi
 
 #[rstest]
 #[tokio::test]
+async fn test_clean_on_repo_with_tag_namespace(
+    #[future] tmprepo: TempRepo,
+    tmpdir: tempfile::TempDir,
+) {
+    init_logging();
+
+    // The point of this test is to run a cleaner when a tag in a tag namespace
+    // exists. It is a dupe of `test_clean_untagged_objects` but the content is
+    // created in a tag namespace while the cleaner is run on the non-namespaced
+    // repo.
+
+    let non_namespaced_tmprepo = tmprepo.await;
+    let namespaced_tmprepo = non_namespaced_tmprepo.with_tag_namespace("test").await;
+
+    // Group 1: untagged objects
+    let data_dir_1 = tmpdir.path().join("data");
+    ensure(data_dir_1.join("dir/dir/test.file"), "1 hello");
+    ensure(data_dir_1.join("dir/dir/test.file2"), "1 hello, world");
+    ensure(data_dir_1.join("dir/dir/test.file4"), "1 hello, world");
+
+    let manifest1 = crate::Committer::new(&namespaced_tmprepo)
+        .commit_dir(data_dir_1.as_path())
+        .await
+        .unwrap();
+
+    // Group 2: tagged objects
+    let data_dir_2 = tmpdir.path().join("data2");
+    ensure(data_dir_2.join("dir/dir/test.file"), "2 hello");
+    ensure(data_dir_2.join("dir/dir/test.file2"), "2 hello, world");
+
+    let manifest2 = crate::Committer::new(&namespaced_tmprepo)
+        .commit_dir(data_dir_2.as_path())
+        .await
+        .unwrap();
+    let layer = namespaced_tmprepo
+        .create_layer(&manifest2.to_graph_manifest())
+        .await
+        .unwrap();
+    let tag = tracking::TagSpec::parse("tagged_manifest").unwrap();
+    namespaced_tmprepo
+        .push_tag(&tag, &layer.digest().unwrap())
+        .await
+        .unwrap();
+
+    // Note current time now.
+    let time_before_group_three = Utc::now();
+
+    // Ensure these new files are created a measurable amount of time after
+    // the noted time.
+    sleep(Duration::from_millis(250)).await;
+
+    // Group 3: untagged objects created after grabbing time.
+    let data_dir_3 = tmpdir.path().join("data");
+    ensure(data_dir_3.join("dir/dir/test.file"), "3 hello");
+    ensure(data_dir_3.join("dir/dir/test.file2"), "3 hello, world");
+    ensure(data_dir_3.join("dir/dir/test.file4"), "3 hello, world");
+
+    let manifest3 = crate::Committer::new(&namespaced_tmprepo)
+        .commit_dir(data_dir_3.as_path())
+        .await
+        .unwrap();
+
+    // Clean objects older than group 3.
+    let cleaner = Cleaner::new(&non_namespaced_tmprepo)
+        .with_reporter(TracingCleanReporter)
+        .with_required_age_cutoff(time_before_group_three);
+    let result = cleaner
+        .prune_all_tags_and_clean()
+        .await
+        .expect("failed to clean objects");
+    println!("{result:#?}");
+
+    for node in manifest1.walk() {
+        if !node.entry.kind.is_blob() {
+            continue;
+        }
+        let res = namespaced_tmprepo.open_payload(node.entry.object).await;
+        if let Err(Error::UnknownObject(_)) = res {
+            continue;
+        }
+        if let Err(err) = res {
+            println!("{err:?}");
+        }
+        panic!(
+            "expected object to be cleaned but it was not: {:?}",
+            node.entry.object
+        );
+    }
+
+    for node in manifest2.walk() {
+        if !node.entry.kind.is_blob() {
+            continue;
+        }
+        namespaced_tmprepo
+            .open_payload(node.entry.object)
+            .await
+            .expect("expected payload not to be cleaned");
+    }
+
+    // Group 3 should not have been cleaned...
+
+    for node in manifest3.walk() {
+        if !node.entry.kind.is_blob() {
+            continue;
+        }
+        namespaced_tmprepo
+            .open_payload(node.entry.object)
+            .await
+            .expect("expected payload not to be cleaned");
+    }
+}
+
+#[rstest]
+#[tokio::test]
 async fn test_clean_untagged_objects_layers_platforms(#[future] tmprepo: TempRepo) {
     init_logging();
     let tmprepo = tmprepo.await;

--- a/crates/spfs/src/config.rs
+++ b/crates/spfs/src/config.rs
@@ -266,7 +266,7 @@ impl RemoteConfig {
                     builder.when(tracking::TimeSpec::parse(v)?);
                 }
                 "tag_namespace" => {
-                    builder.tag_namespace(TagNamespaceBuf::new(RelativePath::new(&v)));
+                    builder.tag_namespace(TagNamespaceBuf::new(RelativePath::new(&v))?);
                 }
                 _ => (),
             }

--- a/crates/spfs/src/fixtures.rs
+++ b/crates/spfs/src/fixtures.rs
@@ -42,9 +42,10 @@ impl TempRepo {
                 let mut repo = spfs::storage::fs::FsRepository::open(tempdir.path().join("repo"))
                     .await
                     .unwrap();
-                repo.set_tag_namespace(Some(spfs::storage::TagNamespaceBuf::new(
-                    namespace.as_ref(),
-                )));
+                repo.set_tag_namespace(Some(
+                    spfs::storage::TagNamespaceBuf::new(namespace.as_ref())
+                        .expect("tag namespaces used in tests must be valid"),
+                ));
                 TempRepo::FS(Arc::new(repo.into()), Arc::clone(tempdir))
             }
             _ => panic!("only TempRepo::FS type supports setting tag namespaces"),

--- a/crates/spfs/src/proto/conversions.rs
+++ b/crates/spfs/src/proto/conversions.rs
@@ -434,7 +434,7 @@ impl From<&storage::EntryType> for super::ls_tags_response::Entry {
                     super::ls_tags_response::entry::Kind::Folder(e.to_owned())
                 }
                 storage::EntryType::Namespace(e) => {
-                    super::ls_tags_response::entry::Kind::Namespace(e.to_owned())
+                    super::ls_tags_response::entry::Kind::Namespace(e.to_string())
                 }
                 storage::EntryType::Tag(e) => {
                     super::ls_tags_response::entry::Kind::Tag(e.to_owned())
@@ -453,7 +453,7 @@ impl TryFrom<super::ls_tags_response::Entry> for storage::EntryType {
                     Ok(storage::EntryType::Folder(e))
                 }
                 super::ls_tags_response::entry::Kind::Namespace(e) => {
-                    Ok(storage::EntryType::Namespace(e))
+                    Ok(storage::EntryType::Namespace(e.into()))
                 }
                 super::ls_tags_response::entry::Kind::Tag(e) => Ok(storage::EntryType::Tag(e)),
             },

--- a/crates/spfs/src/server/tag.rs
+++ b/crates/spfs/src/server/tag.rs
@@ -19,7 +19,10 @@ fn string_to_namespace(namespace: &String) -> Option<&TagNamespace> {
     if namespace.is_empty() {
         None
     } else {
-        Some(TagNamespace::new(RelativePath::new(namespace)))
+        Some(
+            TagNamespace::new(RelativePath::new(namespace))
+                .expect("namespace was valid before being passed over rpc as a string"),
+        )
     }
 }
 

--- a/crates/spfs/src/storage/fs/tag.rs
+++ b/crates/spfs/src/storage/fs/tag.rs
@@ -238,7 +238,7 @@ impl TagStorage for OpenFsRepository {
                 path.file_name().map(|s| {
                     let s = s.to_string_lossy();
                     match s.split_once(TAG_NAMESPACE_MARKER) {
-                        Some((name, _)) => Ok(EntryType::Namespace(name.to_owned())),
+                        Some((name, _)) => Ok(EntryType::Namespace(name.into())),
                         None => Ok(EntryType::Folder(s.to_string())),
                     }
                 })

--- a/crates/spfs/src/storage/tag.rs
+++ b/crates/spfs/src/storage/tag.rs
@@ -25,7 +25,7 @@ mod tag_test;
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum EntryType {
     Folder(String),
-    Namespace(String),
+    Namespace(TagNamespaceBuf),
     Tag(String),
 }
 
@@ -33,7 +33,7 @@ impl AsRef<str> for EntryType {
     fn as_ref(&self) -> &str {
         match self {
             Self::Folder(s) => s,
-            Self::Namespace(s) => s,
+            Self::Namespace(s) => s.as_str(),
             Self::Tag(s) => s,
         }
     }
@@ -43,7 +43,7 @@ impl From<EntryType> for String {
     fn from(entry: EntryType) -> String {
         match entry {
             EntryType::Folder(s) => s,
-            EntryType::Namespace(s) => s,
+            EntryType::Namespace(s) => s.to_string(),
             EntryType::Tag(s) => s,
         }
     }

--- a/crates/spfs/src/storage/tag_namespace.rs
+++ b/crates/spfs/src/storage/tag_namespace.rs
@@ -12,7 +12,7 @@ pub const TAG_NAMESPACE_MARKER: &str = "#ns";
 
 /// A borrowed tag namespace name
 #[repr(transparent)]
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct TagNamespace(RelativePath);
 
 impl TagNamespace {

--- a/crates/spfs/src/storage/tag_namespace.rs
+++ b/crates/spfs/src/storage/tag_namespace.rs
@@ -7,6 +7,8 @@ use std::ops::Deref;
 use relative_path::{RelativePath, RelativePathBuf};
 use serde::{Deserialize, Serialize};
 
+use crate::{Error, Result};
+
 /// A suffix on directory names that indicates that the directory is a tag namespace.
 pub const TAG_NAMESPACE_MARKER: &str = "#ns";
 
@@ -16,7 +18,22 @@ pub const TAG_NAMESPACE_MARKER: &str = "#ns";
 pub struct TagNamespace(RelativePath);
 
 impl TagNamespace {
-    pub fn new(path: &RelativePath) -> &Self {
+    /// Create a new TagNamespace instance.
+    ///
+    /// The path provided must only contain a single path component.
+    pub fn new(path: &RelativePath) -> Result<&Self> {
+        TagNamespaceBuf::validate_path(path)?;
+
+        // Safety: TagNamespace is repr(transparent) over RelativePath
+        Ok(unsafe { &*(path as *const RelativePath as *const TagNamespace) })
+    }
+
+    /// Create a new TagNamespace instance without validation.
+    ///
+    /// # Safety
+    ///
+    /// The path provided must only contain a single path component.
+    unsafe fn new_unchecked(path: &RelativePath) -> &Self {
         // Safety: TagNamespace is repr(transparent) over RelativePath
         unsafe { &*(path as *const RelativePath as *const TagNamespace) }
     }
@@ -52,8 +69,34 @@ impl TagNamespaceBuf {
     }
 
     /// Create a new tag namespace from the given path.
-    pub fn new<P: AsRef<RelativePath>>(path: P) -> Self {
-        Self(path.as_ref().to_owned())
+    pub fn new<P: AsRef<RelativePath>>(path: P) -> Result<Self> {
+        let path = path.as_ref();
+        TagNamespaceBuf::validate_path(path)?;
+        Ok(Self(path.to_owned()))
+    }
+
+    /// Validate that a RelativePath is a valid tag namespace name.
+    ///
+    /// Tag namespaces may not have any directory structure meaning the
+    /// directory created for the tag namespace will be created in the top level
+    /// of the tags directory in the spfs repository.
+    ///
+    /// When `spfs clean` walks tags to avoid data loss it must walk all tags is
+    /// all namespaces and with the current implementation only tag namespaces
+    /// defined in the top level of the tags directory will be discovered.
+    #[inline]
+    fn validate_path(path: &RelativePath) -> Result<()> {
+        let mut it = path.components();
+        if it.next().is_none() {
+            return Err(Error::String("tag namespace must not be empty".to_string()));
+        }
+        if it.next().is_some() {
+            return Err(Error::String(
+                "tag namespace must not contain any directory structure".to_string(),
+            ));
+        }
+
+        Ok(())
     }
 }
 
@@ -73,7 +116,8 @@ impl std::ops::Deref for TagNamespaceBuf {
     type Target = TagNamespace;
 
     fn deref(&self) -> &Self::Target {
-        TagNamespace::new(self.0.deref())
+        // Safety: A TagNamespaceBuf has already been checked for validity.
+        unsafe { TagNamespace::new_unchecked(self.0.deref()) }
     }
 }
 

--- a/crates/spfs/src/storage/tag_namespace.rs
+++ b/crates/spfs/src/storage/tag_namespace.rs
@@ -42,10 +42,15 @@ impl std::fmt::Display for TagNamespace {
 }
 
 /// An owned tag namespace name
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct TagNamespaceBuf(RelativePathBuf);
 
 impl TagNamespaceBuf {
+    #[inline]
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
     /// Create a new tag namespace from the given path.
     pub fn new<P: AsRef<RelativePath>>(path: P) -> Self {
         Self(path.as_ref().to_owned())
@@ -69,5 +74,17 @@ impl std::ops::Deref for TagNamespaceBuf {
 
     fn deref(&self) -> &Self::Target {
         TagNamespace::new(self.0.deref())
+    }
+}
+
+impl From<&str> for TagNamespaceBuf {
+    fn from(path: &str) -> Self {
+        Self(RelativePathBuf::from(path))
+    }
+}
+
+impl From<String> for TagNamespaceBuf {
+    fn from(path: String) -> Self {
+        Self(RelativePathBuf::from(path))
     }
 }

--- a/crates/spfs/src/storage/tag_test.rs
+++ b/crates/spfs/src/storage/tag_test.rs
@@ -362,7 +362,7 @@ async fn test_tag_in_namespace(
         .collect::<Result<Vec<_>>>()
         .await
         .unwrap();
-    assert_eq!(tags, vec![EntryType::Namespace(namespace_name.to_string())]);
+    assert_eq!(tags, vec![EntryType::Namespace(namespace_name.into())]);
 }
 
 #[rstest]

--- a/crates/spfs/src/storage/tag_test.rs
+++ b/crates/spfs/src/storage/tag_test.rs
@@ -383,13 +383,15 @@ async fn test_tag_in_namespace_name_collision(
     // | none      | foo/bar/baz |
     // | foo       | bar/baz     |
     // | foo/bar   | baz         |
+    //
+    // However the last one is not currently checked because "foo/bar" has
+    // become an invalid tag namespace name. Should that change in the future,
+    // the code to check it was removed in the commit that added this message.
 
     let repo_in_foo = tmprepo.with_tag_namespace("foo").await;
-    let repo_in_foo_bar = tmprepo.with_tag_namespace("foo/bar").await;
 
     let foo_bar_baz = random_digest();
     let bar_baz = random_digest();
-    let baz = random_digest();
 
     let spec_foo_bar_baz = tracking::TagSpec::parse("foo/bar/baz").unwrap();
     tmprepo
@@ -400,13 +402,7 @@ async fn test_tag_in_namespace_name_collision(
     let spec_bar_baz = tracking::TagSpec::parse("bar/baz").unwrap();
     repo_in_foo.push_tag(&spec_bar_baz, &bar_baz).await.unwrap();
 
-    let spec_baz = tracking::TagSpec::parse("baz").unwrap();
-    repo_in_foo_bar.push_tag(&spec_baz, &baz).await.unwrap();
-
     // Now confirm these can be read back.
-
-    let tag = repo_in_foo_bar.resolve_tag(&spec_baz).await.unwrap();
-    assert_eq!(tag.target, baz);
 
     let tag = repo_in_foo.resolve_tag(&spec_bar_baz).await.unwrap();
     assert_eq!(tag.target, bar_baz);

--- a/crates/spfs/src/tracking/tag.rs
+++ b/crates/spfs/src/tracking/tag.rs
@@ -353,6 +353,7 @@ fn _find_org_error(org: &str) -> Option<usize> {
     for (i, ch) in org.chars().enumerate() {
         match ch {
             '-' | '_' | '.' | '/' => (),
+            '#' if &org[i..] == "#ns" => return None,
             _ => {
                 if !ch.is_ascii_alphanumeric() {
                     return Some(i);

--- a/crates/spfs/src/tracking/tag.rs
+++ b/crates/spfs/src/tracking/tag.rs
@@ -353,7 +353,6 @@ fn _find_org_error(org: &str) -> Option<usize> {
     for (i, ch) in org.chars().enumerate() {
         match ch {
             '-' | '_' | '.' | '/' => (),
-            '#' if &org[i..] == "#ns" => return None,
             _ => {
                 if !ch.is_ascii_alphanumeric() {
                     return Some(i);


### PR DESCRIPTION
This slipped through testing, the clean would immediately fail when it encounters a directory named like "test#ns" as it fails to parse the tag spec, reporting that the "org" is invalid.

This error is avoided by allowing "#ns" to be the suffix of an org and then `spfs clean` seems to work as expected, but ignores all the cases where it _shouldn't_ accept an "org" that contains a namespace.

The current tag stream code doesn't really understand tag namespaces or offer a way to choose to walk into them or skip them. It was intended that `spfs clean` would visit all tags in all namespaces, but otherwise other tag operations would only see tags in the configured namespace.