### PR TITLE
Clarify spfs shell usage across codebase

### DIFF
--- a/crates/spfs-cli/cmd-fuse/src/cmd_fuse.rs
+++ b/crates/spfs-cli/cmd-fuse/src/cmd_fuse.rs
@@ -106,7 +106,7 @@ pub struct CmdFuse {
 
     /// The tag or id of the files to mount
     ///
-    /// Use '-' or nothing to request an empty environment
+    /// Use '-' or an empty string to request an empty environment
     #[clap(name = "REF")]
     reference: EnvSpec,
 

--- a/crates/spfs-cli/cmd-winfsp/src/cmd_winfsp.rs
+++ b/crates/spfs-cli/cmd-winfsp/src/cmd_winfsp.rs
@@ -246,7 +246,7 @@ struct CmdMount {
 
     /// The tag or id of the files to mount
     ///
-    /// Use '-' or '' to request an empty environment
+    /// Use '-' or an empty string to request an empty environment
     #[clap(name = "REF")]
     reference: EnvSpec,
 }

--- a/crates/spfs-cli/main/src/cmd_run.rs
+++ b/crates/spfs-cli/main/src/cmd_run.rs
@@ -151,7 +151,7 @@ pub struct CmdRun {
 
     /// The tag or id of the desired runtime
     ///
-    /// Use '-' to request an empty environment
+    /// Use '-' to or an empty string to request an empty environment
     pub reference: Option<spfs::tracking::EnvSpec>,
 
     /// The command to run in the environment and its arguments

--- a/crates/spfs-cli/main/src/cmd_shell.rs
+++ b/crates/spfs-cli/main/src/cmd_shell.rs
@@ -54,7 +54,7 @@ pub struct CmdShell {
 
     /// The tag or id of the desired runtime
     ///
-    /// Use '-' or nothing to request an empty environment
+    /// Use '-' or an empty string to request an empty environment
     #[clap(name = "REF")]
     reference: Option<spfs::tracking::EnvSpec>,
 }

--- a/docs/spfs/_index.md
+++ b/docs/spfs/_index.md
@@ -23,7 +23,7 @@ The contents of `/spfs` are managed _per-process-tree_. This means that one prog
 
 ```bash
 # enter an empty spfs environment
-spfs shell
+spfs shell -
 
 # put some files into the spfs area
 echo "hello, world" > /spfs/message.txt
@@ -59,7 +59,7 @@ The spfs _commit_ process is used to capture any active file changes and save th
 
 ```bash
 # enter an empty spfs environment
-spfs shell
+spfs shell -
 
 # put some files into the spfs area
 echo "hello, world" > /spfs/message.txt

--- a/docs/spfs/usage.md
+++ b/docs/spfs/usage.md
@@ -11,7 +11,7 @@ Additional command line workflows for more advanced users.
 When tags are created in spfs, they are added to what is known as a _tag stream_. Tag streams are simply a historical record of that tag over time, keeping track of each change, when it was made, and by whom. Previous versions of a tag can be referenced using a tilde, where the most recent version of a tag is version `~0`; the previous version is version `~1`; the version before that is version `~2` etc... This notation can be used everywhere a tag can be used. This means that `spfs run my-tag` is the same as `spfs run my-tag~0`. All the available versions of a tag can be viewed using the `spfs log <tag>` command, where you will see this notation used.
 
 ```bash
-spfs shell
+spfs shell -
 
 echo 1 > /spfs/message.txt
 spfs commit layer --tag my-layer
@@ -60,7 +60,7 @@ It's easy enough to pull and mount an spfs file tree, but sometimes it's not ide
 - `spfs cat` can be used to output the contents of a file stored in spfs
 
 ```bash
-spfs shell
+spfs shell -
 mkdir -p /spfs/bin
 echo "I am root" > /spfs/root.txt
 touch /spfs/bin/command


### PR DESCRIPTION
Providing "nothing" as the docs say after `spfs` doesn't work. This clarifies the commands usage across the repo.

Slack conversation:

https://spk-dev.slack.com/archives/C01UU20QHE0/p1747145971551979

