### PR TITLE
Add spfs cli documentation

### DIFF
--- a/crates/spfs-cli/cmd-clean/Cargo.toml
+++ b/crates/spfs-cli/cmd-clean/Cargo.toml
@@ -22,6 +22,7 @@ sentry = ["spfs-cli-common/sentry"]
 [dependencies]
 chrono = { workspace = true }
 clap = { workspace = true }
+clap-markdown = "0.1.5"
 colored = { workspace = true }
 miette = { workspace = true, features = ["fancy"] }
 question = "0.2.2"

--- a/crates/spfs-cli/cmd-clean/src/cmd_clean.rs
+++ b/crates/spfs-cli/cmd-clean/src/cmd_clean.rs
@@ -113,6 +113,8 @@ pub struct CmdClean {
         default_value_t = spfs::Cleaner::DEFAULT_DISCOVER_CONCURRENCY
     )]
     max_discover_concurrency: usize,
+    #[clap(long, hide = true)]
+    markdown_help: bool
 }
 
 impl CommandName for CmdClean {
@@ -123,6 +125,11 @@ impl CommandName for CmdClean {
 
 impl CmdClean {
     pub async fn run(&mut self, config: &spfs::Config) -> Result<i32> {
+        if self.markdown_help {
+            clap_markdown::print_help_markdown::<CmdClean>();
+            return Ok(0);
+        }
+        
         let mut repo =
             spfs::config::open_repository_from_string(config, self.remote.as_ref()).await?;
         tracing::debug!("spfs clean command called");

--- a/docs/spfs/cli/_index.md
+++ b/docs/spfs/cli/_index.md
@@ -1,0 +1,13 @@
+---
+title: CLI
+chapter: true
+---
+
+# CLI
+
+CLI usage documentation for `spfs`
+
+Somehow list the subcommands here:
+
+- subcommand1 with hyperlink
+- subcommand2 with hyperlink

--- a/docs/spfs/cli/clean.md
+++ b/docs/spfs/cli/clean.md
@@ -1,0 +1,61 @@
+---
+title: Clean
+chapter: true
+---
+
+# Command-Line Help for `spfs-clean`
+
+This document contains the help content for the `spfs-clean` command-line program.
+
+**Command Overview:**
+
+* [`spfs-clean`Γå┤](#spfs-clean)
+
+## `spfs-clean`
+
+Clean the repository storage of any untracked data
+
+Untracked data is any data that is not tagged or is not attached to/used by a tagged object. This command also provides semantics for pruning a repository from older tag data to help detach additional data and reduce repository size.
+
+**Usage:** `spfs-clean [OPTIONS]`
+
+###### **Options:**
+
+* `-v`, `--verbose` ΓÇö Make output more verbose, can be specified more than once
+* `--log-file <LOG_FILE>` ΓÇö Additionally log output to the provided file
+* `--timestamp` ΓÇö Enables timestamp in logging (always enabled in file log)
+* `-r`, `--remote <REMOTE>` ΓÇö Trigger the clean operation on a remote repository
+* `--remove-durable <RUNTIME>` ΓÇö Remove the durable upper path component of the named runtime. If given, this will be the only thing removed
+* `--runtime-storage <RUNTIME_STORAGE>` ΓÇö The address of the storage being used for runtimes
+
+   Defaults to the current configured local repository.
+* `-y`, `--yes` ΓÇö Don't prompt/ask before cleaning the data
+* `--dry-run` ΓÇö Don't delete anything, just print what would be deleted (assumes --yes)
+* `--prune-repeated` ΓÇö Prune old tags that have the same target as a more recent version
+* `--prune-repeated-keep <PRUNE_REPEATED_KEEP>` ΓÇö When pruning old tag that have the same target as a more recent version, keep this many of the repeated tags
+* `--prune-if-older-than <PRUNE_IF_OLDER_THAN>` ΓÇö Prune tags older that the given age (eg: 1y, 8w, 10d, 3h, 4m, 8s)
+* `--keep-if-newer-than <KEEP_IF_NEWER_THAN>` ΓÇö Always keep data newer than the given age (eg: 1y, 8w, 10d, 3h, 4m, 8s)
+* `--prune-if-more-than <PRUNE_IF_MORE_THAN>` ΓÇö Prune tags if there are more than this number in a stream
+* `--keep-if-less-than <KEEP_IF_LESS_THAN>` ΓÇö Always keep at least this number of tags in a stream
+* `--keep-proxies-with-no-links` ΓÇö Do not remove proxies for users that have no additional hard links.
+
+   Proxies will still be removed if the object is unattached. This is enabled by default because it is generally considered safe and can be effective at reducing disk usage.
+* `--max-tag-stream-concurrency <MAX_TAG_STREAM_CONCURRENCY>`
+
+  Default value: `500`
+* `--max-removal-concurrency <MAX_REMOVAL_CONCURRENCY>`
+
+  Default value: `500`
+* `--max-discover-concurrency <MAX_DISCOVER_CONCURRENCY>`
+
+  Default value: `50`
+
+
+
+<hr/>
+
+<small><i>
+    This document was generated automatically by
+    <a href="https://crates.io/crates/clap-markdown"><code>clap-markdown</code></a>.
+</i></small>
+


### PR DESCRIPTION
I need some help plugging this in more broadly across the codebase. 

I was able to get this working specifically for `spfs clean` for now, and I had to run
```
.\spfs clean --markdown-help > ../../docs/spfs/cli/clean.md
```
manually from my build folder to generate the docs for now. It would be great if we could hide all of this way somehow, I'm just not familiar enough with the codebase yet to know how to do it all.

Closes #1207 