### PR TITLE
Restructure spk-solve for multiple solvers

### DIFF
--- a/crates/spk-build/src/build/binary.rs
+++ b/crates/spk-build/src/build/binary.rs
@@ -37,7 +37,7 @@ use spk_schema::{
 };
 use spk_solve::graph::Graph;
 use spk_solve::solution::Solution;
-use spk_solve::{BoxedResolverCallback, Named, ResolverCallback, Solver};
+use spk_solve::{BoxedResolverCallback, Named, ResolverCallback, StepSolver};
 use spk_storage as storage;
 
 use crate::report::{BuildOutputReport, BuildReport, BuildSetupReport};
@@ -131,7 +131,7 @@ pub struct BinaryPackageBuilder<'a, Recipe> {
     prefix: PathBuf,
     recipe: Recipe,
     source: BuildSource,
-    solver: Solver,
+    solver: StepSolver,
     environment: HashMap<String, String>,
     source_resolver: BoxedResolverCallback<'a>,
     build_resolver: BoxedResolverCallback<'a>,
@@ -155,7 +155,7 @@ where
             recipe,
             source,
             prefix: PathBuf::from("/spfs"),
-            solver: Solver::default(),
+            solver: StepSolver::default(),
             environment: Default::default(),
             #[cfg(test)]
             source_resolver: Box::new(spk_solve::DecisionFormatter::new_testing()),

--- a/crates/spk-cli/cmd-test/src/test/build.rs
+++ b/crates/spk-cli/cmd-test/src/test/build.rs
@@ -15,7 +15,7 @@ use spk_schema::foundation::option_map::OptionMap;
 use spk_schema::ident::{PkgRequest, PreReleasePolicy, RangeIdent, Request, RequestedBy};
 use spk_schema::{AnyIdent, Recipe, SpecRecipe};
 use spk_solve::solution::Solution;
-use spk_solve::{BoxedResolverCallback, DefaultResolver, ResolverCallback, Solver};
+use spk_solve::{BoxedResolverCallback, DefaultResolver, ResolverCallback, StepSolver};
 use spk_storage as storage;
 
 use super::Tester;
@@ -117,7 +117,7 @@ impl<'a> PackageBuildTester<'a> {
             }
         }
 
-        let mut solver = Solver::default();
+        let mut solver = StepSolver::default();
         solver.set_binary_only(true);
         solver.update_options(self.options.clone());
         for repo in self.repos.iter().cloned() {
@@ -154,7 +154,7 @@ impl<'a> PackageBuildTester<'a> {
     }
 
     async fn resolve_source_package(&mut self, package: &AnyIdent) -> Result<Solution> {
-        let mut solver = Solver::default();
+        let mut solver = StepSolver::default();
         solver.update_options(self.options.clone());
         let local_repo: Arc<storage::RepositoryHandle> =
             Arc::new(storage::local_repository().await?.into());

--- a/crates/spk-cli/cmd-test/src/test/install.rs
+++ b/crates/spk-cli/cmd-test/src/test/install.rs
@@ -12,7 +12,7 @@ use spk_schema::foundation::option_map::OptionMap;
 use spk_schema::ident::{PkgRequest, PreReleasePolicy, RangeIdent, Request, RequestedBy};
 use spk_schema::ident_build::Build;
 use spk_schema::{Recipe, SpecRecipe, Variant, VariantExt};
-use spk_solve::{BoxedResolverCallback, DefaultResolver, ResolverCallback, Solver};
+use spk_solve::{BoxedResolverCallback, DefaultResolver, ResolverCallback, StepSolver};
 use spk_storage as storage;
 
 use super::Tester;
@@ -94,7 +94,7 @@ where
 
         let requires_localization = rt.config.mount_backend.requires_localization();
 
-        let mut solver = Solver::default();
+        let mut solver = StepSolver::default();
         solver.set_binary_only(true);
         solver.update_options(self.options.clone());
         for repo in self.repos.iter().cloned() {

--- a/crates/spk-cli/cmd-test/src/test/sources.rs
+++ b/crates/spk-cli/cmd-test/src/test/sources.rs
@@ -13,7 +13,7 @@ use spk_schema::foundation::ident_component::Component;
 use spk_schema::foundation::option_map::OptionMap;
 use spk_schema::ident::{PkgRequest, PreReleasePolicy, RangeIdent, Request, RequestedBy};
 use spk_schema::{Recipe, SpecRecipe};
-use spk_solve::{BoxedResolverCallback, DefaultResolver, ResolverCallback, Solver};
+use spk_solve::{BoxedResolverCallback, DefaultResolver, ResolverCallback, StepSolver};
 use spk_storage as storage;
 
 use super::Tester;
@@ -92,7 +92,7 @@ impl<'a> PackageSourceTester<'a> {
 
         let requires_localization = rt.config.mount_backend.requires_localization();
 
-        let mut solver = Solver::default();
+        let mut solver = StepSolver::default();
         solver.set_binary_only(true);
         solver.update_options(self.options.clone());
         for repo in self.repos.iter().cloned() {

--- a/crates/spk-cli/common/src/flags.rs
+++ b/crates/spk-cli/common/src/flags.rs
@@ -257,10 +257,10 @@ pub struct Solver {
 }
 
 impl Solver {
-    pub async fn get_solver(&self, options: &Options) -> Result<solve::Solver> {
+    pub async fn get_solver(&self, options: &Options) -> Result<solve::StepSolver> {
         let option_map = options.get_options()?;
 
-        let mut solver = solve::Solver::default();
+        let mut solver = solve::StepSolver::default();
         solver.update_options(option_map);
 
         for (name, repo) in self.repos.get_repos_for_non_destructive_operation().await? {

--- a/crates/spk-exec/src/exec_test.rs
+++ b/crates/spk-exec/src/exec_test.rs
@@ -9,15 +9,15 @@ use rstest::{fixture, rstest};
 use spk_cmd_build::build_package;
 use spk_schema::foundation::fixtures::*;
 use spk_schema::ident::build_ident;
-use spk_solve::{DecisionFormatterBuilder, Solver};
+use spk_solve::{DecisionFormatterBuilder, StepSolver};
 use spk_solve_macros::request;
 use spk_storage::fixtures::*;
 
 use crate::solution_to_resolved_runtime_layers;
 
 #[fixture]
-fn solver() -> Solver {
-    Solver::default()
+fn solver() -> StepSolver {
+    StepSolver::default()
 }
 
 /// If two layers contribute files to the same subdirectory, the Manifest is
@@ -26,7 +26,7 @@ fn solver() -> Solver {
 #[tokio::test]
 async fn get_environment_filesystem_merges_directories(
     tmpdir: tempfile::TempDir,
-    mut solver: Solver,
+    mut solver: StepSolver,
 ) {
     let rt = spfs_runtime().await;
 

--- a/crates/spk-solve/src/lib.rs
+++ b/crates/spk-solve/src/lib.rs
@@ -7,7 +7,7 @@ mod io;
 #[cfg(feature = "statsd")]
 mod metrics;
 mod search_space;
-mod solver;
+mod solvers;
 mod status_line;
 
 use std::sync::Arc;
@@ -34,7 +34,7 @@ pub use metrics::{
     get_metrics_client,
 };
 pub(crate) use search_space::show_search_space_stats;
-pub use solver::{Solver, SolverRuntime};
+pub use solvers::{StepSolver, StepSolverRuntime};
 pub use spk_schema::foundation::ident_build::Build;
 pub use spk_schema::foundation::ident_component::Component;
 pub use spk_schema::foundation::option_map;
@@ -62,11 +62,11 @@ pub use {
 
 #[async_trait::async_trait]
 pub trait ResolverCallback: Send + Sync {
-    /// Run a solve using the given [`crate::Solver`],
+    /// Run a solve using the given [`crate::StepSolver`],
     /// producing a [`crate::Solution`].
     async fn solve<'s, 'a: 's>(
         &'s self,
-        r: &'a Solver,
+        r: &'a StepSolver,
     ) -> Result<(Solution, Arc<tokio::sync::RwLock<Graph>>)>;
 }
 
@@ -77,7 +77,7 @@ pub struct DefaultResolver {}
 impl ResolverCallback for DefaultResolver {
     async fn solve<'s, 'a: 's>(
         &'s self,
-        r: &'a Solver,
+        r: &'a StepSolver,
     ) -> Result<(Solution, Arc<tokio::sync::RwLock<Graph>>)> {
         let mut runtime = r.run();
         let solution = runtime.solution().await;

--- a/crates/spk-solve/src/solvers/mod.rs
+++ b/crates/spk-solve/src/solvers/mod.rs
@@ -1,0 +1,14 @@
+// Copyright (c) Contributors to the SPK project.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/spkenv/spk
+
+//! Spk package solver implementations.
+
+pub(crate) mod step;
+
+pub use step::{ErrorFreq, Solver as StepSolver, SolverRuntime as StepSolverRuntime};
+
+// Public to allow other tests to use its macros
+#[cfg(test)]
+#[path = "./solver_test.rs"]
+mod solver_test;

--- a/crates/spk-solve/src/solvers/step/mod.rs
+++ b/crates/spk-solve/src/solvers/step/mod.rs
@@ -1,0 +1,16 @@
+// Copyright (c) Contributors to the SPK project.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/spkenv/spk
+
+//! Spk's original solver.
+//!
+//! This solver works by using a depth-first search to find a solution to the
+//! list of requests. It is fastest when few or no conflicting requests are
+//! encountered when picking candidates, but as the number of candidates grows
+//! then its mostly brute force approach gets overwhelmed.
+
+mod solver;
+
+#[cfg(test)]
+pub(crate) use solver::ErrorDetails;
+pub use solver::{ErrorFreq, Solver, SolverRuntime};

--- a/crates/spk-solve/src/solvers/step/solver.rs
+++ b/crates/spk-solve/src/solvers/step/solver.rs
@@ -53,15 +53,9 @@ use spk_solve_validation::{
 };
 use spk_storage::RepositoryHandle;
 
-use super::error;
 use crate::error::OutOfOptions;
 use crate::option_map::OptionMap;
-use crate::{Error, Result};
-
-// Public to allow other tests to use its macros
-#[cfg(test)]
-#[path = "./solver_test.rs"]
-mod solver_test;
+use crate::{Error, Result, error};
 
 /// Structure to hold whether the three kinds of impossible checks are
 /// enabled or disabled in a solver.


### PR DESCRIPTION
Move `Solver` into a nested module and rename it publicly as `StepSolver` in order to make way for other solver implementations and for the name `Solver` to become available for repurposing it later.

The name `StepSolver` was inspired by how the solver makes progress by calling the `step_state` function.

The `solver_test` module has been separated from the `solver` module since this is destined to become a module of tests that are generic over the solver implementation.