### PR TITLE
Add Resolvo examples to the Solver Usage documentation

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -235,6 +235,7 @@
     "flifetime",
     "FMQA",
     "FNGMD",
+    "FOANXT",
     "FOPEN",
     "fowner",
     "freetype",
@@ -813,6 +814,7 @@
     "YYYNNNNNNN",
     "YYYNNNYYYY",
     "ZLMZGDCVUOL",
+    "ZOWQVE",
     "ZPGKGOTY",
     "ZWOIF"
   ],

--- a/docs-packages/README.md
+++ b/docs-packages/README.md
@@ -1,0 +1,1 @@
+These recipes were used to produce the solver output shown in the documentation.

--- a/docs-packages/gcc-4.spk.yaml
+++ b/docs-packages/gcc-4.spk.yaml
@@ -1,0 +1,5 @@
+pkg: gcc/4.8.5
+api: v0/package
+build:
+  script:
+    - true

--- a/docs-packages/gcc-6.spk.yaml
+++ b/docs-packages/gcc-6.spk.yaml
@@ -1,0 +1,5 @@
+pkg: gcc/6.3.1
+api: v0/package
+build:
+  script:
+    - true

--- a/docs-packages/maya2019.spk.yaml
+++ b/docs-packages/maya2019.spk.yaml
@@ -1,0 +1,9 @@
+pkg: maya/2019.0.0
+api: v0/package
+build:
+  script:
+    - true
+install:
+  embedded:
+    - pkg: qt/5.12.6
+      api: v0/package

--- a/docs-packages/maya2020.spk.yaml
+++ b/docs-packages/maya2020.spk.yaml
@@ -1,0 +1,9 @@
+pkg: maya/2020.0.0
+api: v0/package
+build:
+  script:
+    - true
+install:
+  embedded:
+    - pkg: qt/5.12.6
+      api: v0/package

--- a/docs-packages/my-plugin.spk.yaml
+++ b/docs-packages/my-plugin.spk.yaml
@@ -1,0 +1,11 @@
+pkg: my-plugin/1.0.0
+api: v0/package
+build:
+  options:
+    - pkg: maya/2019
+  script:
+    - true
+install:
+  requirements:
+    - pkg: maya
+      fromBuildEnv: true

--- a/docs-packages/my-tool.spk.yaml
+++ b/docs-packages/my-tool.spk.yaml
@@ -1,0 +1,5 @@
+pkg: my-tool/1.2.0
+api: v0/package
+build:
+  script:
+    - true

--- a/docs-packages/qt.spk.yaml
+++ b/docs-packages/qt.spk.yaml
@@ -1,0 +1,5 @@
+pkg: qt/5.13.0
+api: v0/package
+build:
+  script:
+    - true

--- a/docs/use/solver.md
+++ b/docs/use/solver.md
@@ -31,7 +31,7 @@ ERROR (link)
 
 This error is one of the most obvious - but knowing when and why it can appear helps with understanding other issues. This error happens when the package that was requested simple doesn't exist in and of the enabled repositories.
 
-#### Possible Solutions
+#### Possible Solutions {#possible-solutions-1}
 
 - check that the package name was spelled correctly
 - if you just created the package but haven't published it, make sure the the `--enable-repo=local` flag is used
@@ -62,7 +62,7 @@ In this case, the package exists but still failed to resolve. We can see that th
 
 In these cases, the additional use of the `--verbose (-v)` flag is extremely helpful, as it shows us that the solver tried to find an appropriate version and, most importantly, it shows us why none of those versions could be used.
 
-#### Possible Solutions
+#### Possible Solutions {#possible-solutions-2}
 
 - if you just created a new version but haven't published it, make sure the the `--enable-repo=local` flag is used
 - if the package is in a testing or other alternative repository, make sure to enable the repository with `--enable-repo=<name>`
@@ -90,7 +90,7 @@ ERROR (link)
 
 In this example, we've specifically requested an environment where the `os` option is `darwin`. We can see by the different error message that although there is a `gcc/6.3.1` package available that it was build for `os: linux`, which is not what we requested.
 
-#### Possible Solutions
+#### Possible Solutions {#possible-solutions-3}
 
 - Ensure that all your options are appropriate for the package that you are requesting
 - Consider whether the build options that you are using are required or unnecessarily specific
@@ -189,7 +189,7 @@ ERROR (link)
 
 Packages can be deprecated by package owners when an issue is found or an older version is no longer fit for use. Deprecated packages should not be used under normal circumstances, but there are ways to use the packages if absolutely required.
 
-##### Possible Solutions
+##### Possible Solutions {#possible-solutions-4}
 
 - Generally, you want to update to a newer version of the package that has not been deprecated. Package maintainers should not deprecate packages without providing a reasonable alternative.
 - If you are really stuck, note that the error message says _was not specifically requested_. This means that if you request the deprecated build exactly, then it will still resolve the environment for you, eg `spk env my-tool/1.2.0/STLY6HNC`.

--- a/website/layouts/shortcodes/tab.html
+++ b/website/layouts/shortcodes/tab.html
@@ -1,10 +1,11 @@
 {{ if .Parent }}
 	{{ $name := trim (.Get "name") " " }}
+	{{ $lang := trim (default "console" (.Get "lang")) " " }}
 	{{ if not (.Parent.Scratch.Get "tabs") }}
 	    {{ .Parent.Scratch.Set "tabs" slice }}
 	{{ end }}
 	{{ with .Inner }}
-        {{ $.Parent.Scratch.Add "tabs" (dict "name" $name "content" . ) }}
+        {{ $.Parent.Scratch.Add "tabs" (dict "name" $name "lang" $lang "content" . ) }}
 	{{ end }}
 {{ else }}
 	{{- errorf "[%s] %q: tab shortcode missing its parent" site.Language.Lang .Page.Path -}}

--- a/website/layouts/shortcodes/tabs.html
+++ b/website/layouts/shortcodes/tabs.html
@@ -14,7 +14,7 @@
     <div class="tab-content">
         {{ range $idx, $tab := .Scratch.Get "tabs" }}
         <div data-tab-item="{{ .name }}" data-tab-group="{{ $groupId }}" class="tab-item {{ cond (eq $idx 0) "active" ""}}">
-            {{ .content }}
+            <pre><code class="language-{{ .lang }}">{{ .content | safeHTML }}</code></pre>
         </div>
         {{ end }}
     </div>


### PR DESCRIPTION
A number of the examples are not really applicable to Resolvo.

Some recipes were added to be able to recreate the output from the existing examples (though the existing output is a little out of date).

The tabs and tab shortcodes were not rendering code blocks as theme documentation suggests it will, so it has been modified to wrap the "content" in a code block. That required removing the triple backticks from the markdown file. Perhaps this can be improved?