### PR TITLE
Fix spk passing wrong arg to spfs for runtime name

### DIFF
--- a/crates/spk-cli/common/src/flags.rs
+++ b/crates/spk-cli/common/src/flags.rs
@@ -192,7 +192,7 @@ impl Runtime {
             );
             args.insert(
                 0,
-                std::ffi::CString::new("--name").expect("should never fail"),
+                std::ffi::CString::new("--runtime-name").expect("should never fail"),
             );
         }
 


### PR DESCRIPTION
RE:

https://github.com/spkenv/spk/blob/main/crates/spfs-cli/main/src/cmd_run.rs#L143

And

https://github.com/spkenv/spk/edit/main/crates/spfs-cli/main/src/cmd_shell.rs#L44