### PR TITLE
Fix spurious encode test failure

### DIFF
--- a/crates/spfs/src/config_test.rs
+++ b/crates/spfs/src/config_test.rs
@@ -119,6 +119,7 @@ fn test_config_expands_tilde_in_paths() {
 }
 
 #[rstest]
+#[serial_test::serial(config)]
 fn test_make_current_updates_config() {
     let config1 = Config::default();
     config1.make_current().unwrap();


### PR DESCRIPTION
    thread 'graph::layer::layer_test::test_layer_encoding_annotation_only::write_encoding_format_1_EncodingFormat__Legacy::write_digest_strategy_1_DigestStrategy__Legacy' panicked at crates/spfs/src/graph/./layer_test.rs:44:13:
    Encode should fail if encoding format is legacy

Add `serial_test` to another test that modifies the spfs config so it doesn't run concurrently.

This test failure is only reproducible by chance, so it isn't certain that this change (alone) fixes it, but I wasn't able to get the failure to happen again after making this change.