### PR TITLE
Change `spk ls` to use  repo walkers

### DIFF
--- a/crates/spk-cli/group2/src/cmd_ls.rs
+++ b/crates/spk-cli/group2/src/cmd_ls.rs
@@ -205,10 +205,9 @@ impl<T: Output> Ls<T> {
         while let Some(item) = traversal.try_next().await? {
             if let RepoWalkerItem::Build(build) = item {
                 let package = build.spec.ident().name().to_string();
-                if set.contains(&package) {
+                if !set.insert(package.clone()) {
                     continue;
                 }
-                set.insert(package.clone());
 
                 if self.verbose > 0 {
                     self.output


### PR DESCRIPTION
This changes and refactors `spk ls` to use RepoWalkers. It reduced the number of cases inside `ls` while providing the same functionality. 

This is built on top of https://github.com/spkenv/spk/pull/1225