### PR TITLE
Fix resolvo not allowing prereleases

### DIFF
--- a/crates/spk-schema/crates/ident/src/request.rs
+++ b/crates/spk-schema/crates/ident/src/request.rs
@@ -49,7 +49,18 @@ use crate::{BuildIdent, Error, RangeIdent, Result, Satisfy, VersionIdent};
 mod request_test;
 
 #[derive(
-    Debug, Clone, Copy, Hash, PartialEq, Eq, Serialize, Deserialize, PartialOrd, Ord, Default,
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    Deserialize,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    Serialize,
+    Variantly,
 )]
 pub enum PreReleasePolicy {
     #[default]


### PR DESCRIPTION
The original solver allows that if a prerelease version of a package is requested then any other install.requirement for that package implicitly allows prereleases too.

There wasn't an existing test to verify this behavior, and resolvo wasn't allowing this.