### PR TITLE
Add redirect_dir properties for overlayfs

### DIFF
--- a/crates/spfs-cli/cmd-enter/src/cmd_enter.rs
+++ b/crates/spfs-cli/cmd-enter/src/cmd_enter.rs
@@ -193,7 +193,10 @@ impl CmdEnter {
             }
             let start_time = Instant::now();
             // Safety: the responsibility of the caller.
-            let render_summary = unsafe { spfs::change_to_durable_runtime(&mut runtime).await? };
+            let render_summary = unsafe {
+                spfs::change_to_durable_runtime(&config.filesystem.overlayfs_options, &mut runtime)
+                    .await?
+            };
             // Safety: the responsibility of the caller.
             unsafe {
                 self.report_render_summary(render_summary, start_time.elapsed().as_secs_f64())
@@ -213,7 +216,10 @@ impl CmdEnter {
         } else if self.remount.enabled {
             let start_time = Instant::now();
             // Safety: the responsibility of the caller.
-            let render_summary = unsafe { spfs::reinitialize_runtime(&mut runtime).await? };
+            let render_summary = unsafe {
+                spfs::reinitialize_runtime(&config.filesystem.overlayfs_options, &mut runtime)
+                    .await?
+            };
             // Safety: the responsibility of the caller.
             unsafe {
                 self.report_render_summary(render_summary, start_time.elapsed().as_secs_f64())
@@ -229,7 +235,8 @@ impl CmdEnter {
             tracing::debug!("initializing runtime {owned:#?}");
 
             let start_time = Instant::now();
-            let render_summary = spfs::initialize_runtime(&mut owned).await?;
+            let render_summary =
+                spfs::initialize_runtime(&config.filesystem.overlayfs_options, &mut owned).await?;
             // Safety: the responsibility of the caller.
             unsafe {
                 self.report_render_summary(render_summary, start_time.elapsed().as_secs_f64())

--- a/crates/spfs/src/env.rs
+++ b/crates/spfs/src/env.rs
@@ -1043,12 +1043,19 @@ impl OverlayMountOptions {
         if self.read_only {
             opts.push(OVERLAY_ARGS_RO_PREFIX);
         }
-        if !self.global_options.break_hardlinks && params.contains(OVERLAY_ARGS_INDEX) {
+        if !self.global_options.break_hardlinks
+            && params.contains(OVERLAY_ARGS_INDEX)
+            && self.global_options.redirect_dir.allow_break_hardlinks()
+        {
             opts.push(OVERLAY_ARGS_INDEX_ON);
         }
-        if self.global_options.metadata_copy_up && params.contains(OVERLAY_ARGS_METACOPY) {
+        if self.global_options.metadata_copy_up
+            && params.contains(OVERLAY_ARGS_METACOPY)
+            && self.global_options.redirect_dir.allow_metadata_copy_up()
+        {
             opts.push(OVERLAY_ARGS_METACOPY_ON);
         }
+        opts.push(self.global_options.redirect_dir.into());
         opts
     }
 }
@@ -1287,7 +1294,13 @@ fn mount_overlayfs_syscalls<P: AsRef<Path>>(
         }
     }
 
-    if !mount_options.global_options.break_hardlinks && params.contains(OVERLAY_ARGS_INDEX) {
+    if !mount_options.global_options.break_hardlinks
+        && params.contains(OVERLAY_ARGS_INDEX)
+        && mount_options
+            .global_options
+            .redirect_dir
+            .allow_break_hardlinks()
+    {
         // Safety: fd is valid and arguments are null-terminated.
         let rc = unsafe {
             syscall!(
@@ -1309,7 +1322,13 @@ fn mount_overlayfs_syscalls<P: AsRef<Path>>(
         }
     }
 
-    if mount_options.global_options.metadata_copy_up && params.contains(OVERLAY_ARGS_METACOPY) {
+    if mount_options.global_options.metadata_copy_up
+        && params.contains(OVERLAY_ARGS_METACOPY)
+        && mount_options
+            .global_options
+            .redirect_dir
+            .allow_metadata_copy_up()
+    {
         // Safety: fd is valid and arguments are null-terminated.
         let rc = unsafe {
             syscall!(

--- a/crates/spfs/src/resolve_test.rs
+++ b/crates/spfs/src/resolve_test.rs
@@ -64,9 +64,14 @@ async fn test_auto_merge_layers(tmpdir: tempfile::TempDir) {
         runtime.push_digest(layer.digest().unwrap());
     }
 
-    let dirs = crate::resolve::resolve_overlay_dirs(&mut runtime, &fs_repo, true)
-        .await
-        .expect("resolve overlay dirs successfully");
+    let dirs = crate::resolve::resolve_overlay_dirs(
+        &config.filesystem.overlayfs_options,
+        &mut runtime,
+        &fs_repo,
+        true,
+    )
+    .await
+    .expect("resolve overlay dirs successfully");
 
     assert!(
         dirs.len() < layers.len(),
@@ -137,9 +142,14 @@ async fn test_auto_merge_layers_with_edit(tmpdir: tempfile::TempDir) {
     }
 
     // Test - merging layers doesn't lose the edit
-    let dirs = crate::resolve::resolve_overlay_dirs(&mut runtime, &fs_repo, true)
-        .await
-        .expect("resolve overlay dirs successfully");
+    let dirs = crate::resolve::resolve_overlay_dirs(
+        &config.filesystem.overlayfs_options,
+        &mut runtime,
+        &fs_repo,
+        true,
+    )
+    .await
+    .expect("resolve overlay dirs successfully");
 
     // Check the results
     let d = dirs.last().unwrap();

--- a/cspell.json
+++ b/cspell.json
@@ -225,6 +225,7 @@
     "FDCWD",
     "FETCHCONTENT",
     "fexceptions",
+    "filehandle",
     "filesequence",
     "filesystems",
     "filesytem",

--- a/docs/admin/config.md
+++ b/docs/admin/config.md
@@ -165,6 +165,17 @@ break_hardlinks = true
 # Control if the "metadata" feature is used, if the kernel supports it.
 # Defaults to true.
 metadata_copy_up = true
+# Set the redirect_dir mode to use. If not using spk, setting this to "on" may
+# improve performance.
+#
+# Valid values are:
+# - on
+# - off
+# - follow
+# - nofollow
+#
+# Defaults to "follow".
+redirect_dir = "follow"
 
 [fuse]
 # the number of threads that the fuse filesystem process will create

--- a/docs/admin/config.md
+++ b/docs/admin/config.md
@@ -152,6 +152,20 @@ use_mount_syscalls = false
 # systems that can perform read-through lookups, such as FUSE.
 secondary_repositories = ["origin"]
 
+# OverlayFs related settings.
+#
+# See kernel.org/doc/html/latest/filesystems/overlayfs.html for details.
+#
+# It is not recommended to change the default setting, doing so may lead to
+# incorrect behavior when using spk.
+[filesystem.overlayfs_options]
+# Control if the "index" feature is used, if the kernel supports it.
+# Defaults to true.
+break_hardlinks = true
+# Control if the "metadata" feature is used, if the kernel supports it.
+# Defaults to true.
+metadata_copy_up = true
+
 [fuse]
 # the number of threads that the fuse filesystem process will create
 # in order to operate. More threads may improve performance of the


### PR DESCRIPTION
To address #1233 start setting the redirect_dir setting when mounting an
overlayfs filesystem. Default to "follow" meaning the redirects won't be
created (but if any were to exist already for some reason they will be
honored). Redirects need to not be created to avoid the situation in the
issue where files are not collected because they are invisible in the
upperdir.

Through experimentation and noticing fine print in the documentation, it
is necessary to disable the other overlayfs options when using "follow"
mode.