### PR TITLE
Add rust-toolchain

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,11 +17,8 @@ jobs:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.11.0
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.87.0
-          target: x86_64-pc-windows-gnu
-          override: true
+      - name: Setup rust toolchain
+        run: rustup show
       - name: Prepare VM
         uses: crazy-max/ghaction-chocolatey@v3
         with:
@@ -53,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     container:
-      image: rust:1.87.0
+      image: rust:slim-bookworm
       options: --security-opt seccomp=unconfined --privileged
     env:
       # Disable cnproc because we're in a container
@@ -71,7 +68,7 @@ jobs:
       - name: Prepare Container
         run: |
           apt-get update
-          apt-get install -y libcap2-bin sudo cmake tcsh rsync protobuf-compiler fuse libfuse-dev
+          apt-get install -y libcap2-bin sudo cmake tcsh rsync protobuf-compiler fuse libfuse-dev curl unzip pkg-config libssl-dev git
           # spfs-fuse requires this option enabled
           echo user_allow_other >> /etc/fuse.conf
           FB_REL=https://github.com/google/flatbuffers/releases/

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.87.0"


### PR DESCRIPTION
This will stop cargo from using whatever the latest installed version is present and causing lint failures at inopportune times.

Remove the rust version from the github actions workflow file since these should honor the rust-toolchain.toml file.

Work is needed internally at SPI before we can remove the rust version in our internal CI configuration.