### PR TITLE
Linting fixes for features not enabled by default

### DIFF
--- a/crates/spfs-cli/common/src/args.rs
+++ b/crates/spfs-cli/common/src/args.rs
@@ -252,15 +252,16 @@ pub fn configure_sentry(
                 // Proxy values may have been read from env.
                 // If they do not contain a scheme prefix, sentry-transport
                 // produces a panic log output
-                if let Some(url) = opts.http_proxy.as_ref().map(ToString::to_string) {
-                    if !url.contains("://") {
-                        opts.http_proxy = Some(format!("http://{url}")).map(Cow::Owned);
-                    }
+                if let Some(url) = opts.http_proxy.as_ref().map(ToString::to_string)
+                    && !url.contains("://")
+                {
+                    opts.http_proxy = Some(format!("http://{url}")).map(Cow::Owned);
                 }
-                if let Some(url) = opts.https_proxy.as_ref().map(ToString::to_string) {
-                    if !url.contains("://") {
-                        opts.https_proxy = Some(format!("https://{url}")).map(Cow::Owned);
-                    }
+
+                if let Some(url) = opts.https_proxy.as_ref().map(ToString::to_string)
+                    && !url.contains("://")
+                {
+                    opts.https_proxy = Some(format!("https://{url}")).map(Cow::Owned);
                 }
 
                 sentry::init(opts)

--- a/crates/spk-cli/common/src/env.rs
+++ b/crates/spk-cli/common/src/env.rs
@@ -282,11 +282,12 @@ fn get_spk_context() -> (
 
 #[cfg(feature = "sentry")]
 fn remove_ansi_escapes(message: String) -> String {
-    if let Ok(b) = strip_ansi_escapes::strip(message.clone()) {
-        if let Ok(s) = std::str::from_utf8(&b) {
-            return s.to_string();
-        }
+    if let Ok(b) = strip_ansi_escapes::strip(message.clone())
+        && let Ok(s) = std::str::from_utf8(&b)
+    {
+        return s.to_string();
     }
+
     message
 }
 

--- a/crates/spk/src/cli.rs
+++ b/crates/spk/src/cli.rs
@@ -133,10 +133,10 @@ impl Opt {
         }
 
         #[cfg(feature = "statsd")]
-        if result.is_err() {
-            if let Some(client) = statsd_client {
-                client.incr(&SPK_ERROR_COUNT_METRIC)
-            }
+        if result.is_err()
+            && let Some(client) = statsd_client
+        {
+            client.incr(&SPK_ERROR_COUNT_METRIC)
         }
 
         result


### PR DESCRIPTION
This contains a set of rust 1.89.0 related linting fixes for features that are not enabled by default.