### PR TITLE
Fix resolvo treating options as var requirements

### DIFF
--- a/crates/spk-solve/src/solvers/resolvo/mod.rs
+++ b/crates/spk-solve/src/solvers/resolvo/mod.rs
@@ -145,7 +145,6 @@ impl Solver {
     pub async fn solve(&self) -> Result<Solution> {
         let repos = self.repos.clone();
         let requests = self.requests.clone();
-        let options = self.options.clone();
         let binary_only = self.binary_only;
         let build_from_source_trail = self.build_from_source_trail.clone();
         // Use a blocking thread so resolvo can call `block_on` on the runtime.
@@ -160,11 +159,7 @@ impl Solver {
                 loop_counter += 1;
                 let mut this_iter_provider = provider.take().expect("provider is always Some");
                 let pkg_requirements = this_iter_provider.root_pkg_requirements(&requests);
-                let mut var_requirements = this_iter_provider.var_requirements(&requests);
-                // XXX: Not sure if this will result in the desired precedence
-                // when options and var requests for the same thing exist.
-                var_requirements
-                    .extend(this_iter_provider.var_requirements_from_options(options.clone()));
+                let var_requirements = this_iter_provider.var_requirements(&requests);
                 let mut solver = resolvo::Solver::new(this_iter_provider)
                     .with_runtime(tokio::runtime::Handle::current());
                 let problem = resolvo::Problem::new()


### PR DESCRIPTION
This test is a minimal reproduction of a problem we found when using the resolvo solver. Please read the test code first to understand the package relationships involved. The step solver passes the test because it solves successfully; the resolvo solver fails to solve with the following error:

```
The following packages are incompatible
└─ my-app:run my-app:run cannot be installed because there are no viable options:
   └─ my-app:run mem-01k4x9e8jtsez9ebc3qs1qtcg4/my-app/4.5.6/TSZZLWXD:run would require
      └─ openimageio:run openimageio:run/Binary:1.2.3, which cannot be
  installed because there are no viable options:
         └─ openimageio:run mem-01k4x9e8jtsez9ebc3qs1qtcg4/openimageio/1.2.3/XFWQWLQ2:run is
            excluded because build option spi-platform does not satisfy global var request:
            ~2025.1.1.1 does not intersect with ~2024.1.1.1
```

In the test the solver is invoked in a way to mimic solving for a build environment (it is in an `spk build` where we have the problem in the real world), or similar to `spk env -o spi-platform=~2025.1.1.1 my-app`.

The step solver doesn't think this is a problem but I'm struggling to understand why. If I say `-o distro=rocky` then I definitely expect that the solver won't pick any builds that have `- var distro/centos`, so what is different about the `spi-platform` var here? Why is the step solver willing to pick a build that has a different major version?

I'm not convinced the step solver is right here, but assuming it is, I need to understand what is wrong about how resolvo is operating. For example, if I comment out the part of the resolvo code that causes it to exclude the mismatched option, then 10 of the preexisting solver tests start to fail. If it is supposed to ignore mismatched options under a specific set of circumstances, what are those?

Edit: the mystery around host options being enforced was answered (see comments) and the step solver is working as intended (modulo options not really doing anything) so this PR changes resolvo to match the behavior of the step solver to the extent of our test coverage.