### PR TITLE
Bugfix: spfs push stopped defaulting to origin for remote repo

### DIFF
--- a/crates/spfs-cli/main/src/cmd_push.rs
+++ b/crates/spfs-cli/main/src/cmd_push.rs
@@ -28,6 +28,12 @@ pub struct CmdPush {
 
 impl CmdPush {
     pub async fn run(&mut self, config: &spfs::Config) -> Result<i32> {
+        // Default to the remote to "origin" to match spfs push's
+        // behaviour before the "repos" argument added above.
+        if self.repos.remote.is_none() {
+            self.repos.remote = Some("origin".to_string());
+        }
+
         let (repo, remote) = tokio::try_join!(
             config.get_local_repository_handle(),
             spfs::config::open_repository_from_string(config, self.repos.remote.as_ref()),


### PR DESCRIPTION
This fixes a bug that stopped spfs push from defaulting to the origin repo for the destintion. It restores the default `remote` repo argument value to `origin`. This bug came in when spfs commands had their repos arguments updated to allow wrapping repos with proxy repos.