### PR TITLE
Bump fuser to 0.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1387,16 +1387,15 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "fuser"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53274f494609e77794b627b1a3cddfe45d675a6b2e9ba9c0fdc8d8eee2184369"
+checksum = "0bb29a3ae32279fe3e79a958fe01899f5fb23eadccee919cf88e145b54ed9367"
 dependencies = [
  "libc",
  "log",
  "memchr",
  "nix 0.29.0",
  "page_size",
- "pkg-config",
  "smallvec",
  "zerocopy",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ enum_dispatch = "0.3.13"
 featurecomb = "0.1.3"
 flatbuffers = "25.2"
 format_serde_error = { version = "0.3", default-features = false }
-fuser = "0.15.1"
+fuser = "0.16.0"
 futures = "0.3.28"
 futures-core = "0.3.28"
 glob = "0.3"

--- a/crates/spfs-vfs/src/fuse.rs
+++ b/crates/spfs-vfs/src/fuse.rs
@@ -775,7 +775,7 @@ impl fuser::Filesystem for Session {
         _req: &Request<'_>,
         config: &mut fuser::KernelConfig,
     ) -> std::result::Result<(), libc::c_int> {
-        const DESIRED: &[(&str, u32)] = &[
+        const DESIRED: &[(&str, u64)] = &[
             ("FUSE_ASYNC_READ", FUSE_ASYNC_READ),
             ("FUSE_BIG_WRITES", FUSE_BIG_WRITES),
             ("FUSE_DO_READDIRPLUS", FUSE_DO_READDIRPLUS),


### PR DESCRIPTION
In response to https://github.com/spkenv/spk/security/dependabot/17