### PR TITLE
Add missing support for "fallback" repository schema

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -76,6 +76,8 @@ jobs:
           make coverage FEATURES=server,spfs/server,spfs/protobuf-src,spk/migration-to-components,sentry,statsd,fuse-backend,spfs-vfs/protobuf-src
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - name: Code coverage summary report in logs
         uses: irongut/CodeCoverageSummary@v1.3.0
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -75,7 +75,7 @@ jobs:
           # Originally used tarpaulin but it used too much space to generate
           make coverage FEATURES=server,spfs/server,spfs/protobuf-src,spk/migration-to-components,sentry,statsd,fuse-backend,spfs-vfs/protobuf-src
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - name: Code coverage summary report in logs

--- a/crates/spfs-cli/cmd-render/src/cmd_render.rs
+++ b/crates/spfs-cli/cmd-render/src/cmd_render.rs
@@ -71,7 +71,12 @@ impl CmdRender {
 
         // Use PayloadFallback to repair any missing payloads found in the
         // local repository by copying from any of the configure remotes.
-        let fallback = FallbackProxy::new(repo, remotes);
+        let fallback = FallbackProxy::new(
+            repo, remotes,
+            // preserve original behavior of not looking for tags in the secondary
+            // repos
+            false,
+        );
 
         let rendered = match &self.target {
             Some(target) => self.render_to_dir(fallback, env_spec, target).await?,

--- a/crates/spfs/src/config.rs
+++ b/crates/spfs/src/config.rs
@@ -75,6 +75,10 @@ pub fn default_proxy_repo_include_secondary_tags() -> bool {
     true
 }
 
+pub fn default_fallback_repo_include_secondary_tags() -> bool {
+    true
+}
+
 static CONFIG: OnceCell<RwLock<Arc<Config>>> = OnceCell::new();
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/spfs/src/resolve.rs
+++ b/crates/spfs/src/resolve.rs
@@ -365,7 +365,12 @@ pub(crate) async fn resolve_and_render_overlay_dirs(
     let config = get_config()?;
     let (repo, remotes) =
         tokio::try_join!(config.get_opened_local_repository(), config.list_remotes())?;
-    let fallback_repo = FallbackProxy::new(repo, remotes);
+    let fallback_repo = FallbackProxy::new(
+        repo, remotes,
+        // preserve original behavior of not looking for tags in the secondary
+        // repos
+        false,
+    );
 
     let manifests = resolve_overlay_dirs(
         &config.filesystem.overlayfs_options,

--- a/crates/spfs/src/storage/error.rs
+++ b/crates/spfs/src/storage/error.rs
@@ -98,6 +98,9 @@ pub enum OpenRepositoryError {
         tag_namespace: TagNamespaceBuf,
         source: Box<dyn miette::Diagnostic + Send + Sync>,
     },
+
+    #[error("Unsupported repository type: {0}")]
+    UnsupportedRepositoryType(String),
 }
 
 impl OpenRepositoryError {

--- a/crates/spfs/src/storage/fallback/repository_test.rs
+++ b/crates/spfs/src/storage/fallback/repository_test.rs
@@ -44,7 +44,7 @@ async fn test_proxy_payload_repair(tmpdir: tempfile::TempDir) {
     assert!(err.is_err());
 
     // Loading the payload through the fallback should succeed.
-    let proxy = super::FallbackProxy::new(primary, vec![secondary.into()]);
+    let proxy = super::FallbackProxy::new(primary, vec![secondary.into()], false);
     proxy
         .open_payload(digest)
         .await

--- a/crates/spfs/src/storage/proxy/mod.rs
+++ b/crates/spfs/src/storage/proxy/mod.rs
@@ -8,3 +8,38 @@
 
 mod repository;
 pub use repository::{Config, ProxyRepository};
+pub(crate) use repository::{
+    find_tags_in_namespace,
+    iter_tag_streams_in_namespace,
+    ls_tags_in_namespace,
+    read_tag_in_namespace,
+};
+
+use crate::storage::Repository;
+
+/// An abstraction for reusing logic across "proxy-like" repositories.
+pub(crate) trait ProxyRepositoryExt {
+    fn include_secondary_tags(&self) -> bool;
+    fn primary(&self) -> impl Repository;
+    fn secondary(&self) -> &[crate::storage::RepositoryHandle];
+}
+
+impl<T> ProxyRepositoryExt for &T
+where
+    T: ProxyRepositoryExt + ?Sized,
+{
+    #[inline]
+    fn include_secondary_tags(&self) -> bool {
+        (**self).include_secondary_tags()
+    }
+
+    #[inline]
+    fn primary(&self) -> impl Repository {
+        (**self).primary()
+    }
+
+    #[inline]
+    fn secondary(&self) -> &[crate::storage::RepositoryHandle] {
+        (**self).secondary()
+    }
+}

--- a/crates/spk-cli/cmd-render/src/cmd_render.rs
+++ b/crates/spk-cli/cmd-render/src/cmd_render.rs
@@ -98,7 +98,13 @@ impl Run for Render {
                 .render_into_directory(stack, &path, spfs::storage::fs::RenderType::Copy)
                 .await?;
         } else {
-            let fallback = FallbackProxy::new(local, fallback_repository_handles);
+            let fallback = FallbackProxy::new(
+                local,
+                fallback_repository_handles,
+                // preserve original behavior of not looking for tags in the secondary
+                // repos
+                false,
+            );
             spfs::storage::fs::Renderer::new(&fallback)
                 .with_reporter(spfs::storage::fs::ConsoleRenderReporter::default())
                 .render_into_directory(stack, &path, spfs::storage::fs::RenderType::Copy)

--- a/crates/spk-launcher/src/main.rs
+++ b/crates/spk-launcher/src/main.rs
@@ -137,7 +137,13 @@ impl<'a> Dynamic<'a> {
             let r = syncer.sync_env(env_spec).await.wrap_err("sync reference")?;
             let env_spec = r.env;
 
-            let fallback = FallbackProxy::new(local, vec![remote]);
+            let fallback = FallbackProxy::new(
+                local,
+                vec![remote],
+                // preserve original behavior of not looking for tags in the secondary
+                // repos
+                false,
+            );
 
             spfs::storage::fs::Renderer::new(&fallback)
                 .with_reporter(spfs::storage::fs::ConsoleRenderReporter::default())


### PR DESCRIPTION
Missed adding this back when FallbackProxy was implemented.

Also update the FallbackProxy type to have the same tag reading features that the Proxy type has. They now behave nearly the same but the FallbackProxy still propagates payloads into the primary repo.