### PR TITLE
Fix `spfs check` crashing if an annotation blob is missing

### DIFF
--- a/crates/spfs/src/check.rs
+++ b/crates/spfs/src/check.rs
@@ -247,7 +247,11 @@ where
         tracing::trace!(%digest, "Checking digest");
         self.reporter.visit_digest(&digest);
         match self.read_object_with_fallback(digest).await {
-            Err(Error::UnknownObject(_)) => Ok(CheckObjectResult::Missing(digest)),
+            Err(Error::UnknownObject(_)) => {
+                let result = CheckObjectResult::Missing(digest);
+                self.reporter.checked_object(&result);
+                Ok(result)
+            }
             Err(err) => Err(err),
             Ok((obj, fallback)) => {
                 let mut res = unsafe {
@@ -836,7 +840,7 @@ impl CheckTagResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum CheckObjectResult {
     /// The object was already checked in this session
     Duplicate,
@@ -886,7 +890,7 @@ impl CheckObjectResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct CheckPlatformResult {
     pub repaired: bool,
     pub platform: graph::Platform,
@@ -909,7 +913,7 @@ impl CheckPlatformResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct CheckLayerResult {
     pub repaired: bool,
     pub layer: graph::Layer,
@@ -932,7 +936,7 @@ impl CheckLayerResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct CheckManifestResult {
     pub repaired: bool,
     pub manifest: graph::Manifest,
@@ -955,7 +959,7 @@ impl CheckManifestResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum CheckAnnotationResult {
     /// The annotation was stored directly in the layer and did not
     /// need checking
@@ -1000,7 +1004,7 @@ impl CheckEntryResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum CheckBlobResult {
     /// The blob was already checked in this session
     Duplicate,


### PR DESCRIPTION
This changes how annotation blobs are checked to stop the check from failing entirely if a blob is missing.

After making this change I noticed that the `spfs check` command was not reporting that the blob was missing with a "Missing: <digest>" line. I added a debug reporter to the test to look at what is reported, and `checked_object` is called _once_ with the following object:

```
[crates/spfs/src/./check_test.rs:306:5] &checked_objects = [
    Layer(
        CheckLayerResult {
            repaired: false,
            layer: Layer {
                manifest: "None",
                annotations: [
                    Annotation {
                        key: "test_annotation",
                        data_type: AnnotationDigest,
                        data: AnnotationDigest {
                            digest: Some(
                                Digest(
                                    "374QBB7CVFPRYCJ46QHHXZXPJ2MY4INU5I4NBNEU5IX5WJLW7T7A====",
                                ),
                            ),
                        },
                    },
                ],
            },
            results: [
                Ignorable,
                Annotation(
                    Checked {
                        digest: Digest(
                            "374QBB7CVFPRYCJ46QHHXZXPJ2MY4INU5I4NBNEU5IX5WJLW7T7A====",
                        ),
                        result: Missing(
                            Digest(
                                "374QBB7CVFPRYCJ46QHHXZXPJ2MY4INU5I4NBNEU5IX5WJLW7T7A====",
                            ),
                        ),
                        repaired: false,
                    },
                ),
            ],
        },
    ),
]
```

The `ConsoleCheckReporter` only reacts to `CheckObjectResult::Missing` so it ignores this result and doesn't print anything. This leads me to some questions.

The test repo is populated with a single blob and a layer with an annotation that links to that blob. Then, the blob is deleted.

Should the checker report that it checked 1 object or 2, i.e., is it expected to count known missing objects?

Should the checker call `CheckReporter::checked_object` on the inner blob, thereby reporting the missing object both as an entry in the results list seen above _and_ as a "top-level" `CheckObjectResult::Missing` item? If not, `ConsoleCheckReporter::checked_object` needs to walk this inner list of results and report them.

As an aside, I think it would be more useful for the checker to say something like:

    Layer XYZ==='s "foo" annotation blob ABC=== is missing

Instead of what it would end up doing if the missing blob is reported in isolation like:

    Missing: ABC===

Just getting a list of missing digests doesn't help very much when trying to understand what is wrong with a repo.