### PR TITLE
Bugfix: annotation blob value syncing

### DIFF
--- a/crates/spfs/src/sync.rs
+++ b/crates/spfs/src/sync.rs
@@ -398,9 +398,6 @@ impl<'src, 'dst> Syncer<'src, 'dst> {
         match annotation.value() {
             AnnotationValue::String(_) => Ok(SyncAnnotationResult::InternalValue),
             AnnotationValue::Blob(digest) => {
-                if !self.processed_digests.insert(*digest) {
-                    return Ok(SyncAnnotationResult::Duplicate);
-                }
                 self.reporter.visit_annotation(&annotation);
                 let sync_result = self.sync_digest(*digest).await?;
                 let res = SyncAnnotationResult::Synced {

--- a/crates/spfs/src/sync.rs
+++ b/crates/spfs/src/sync.rs
@@ -398,6 +398,12 @@ impl<'src, 'dst> Syncer<'src, 'dst> {
         match annotation.value() {
             AnnotationValue::String(_) => Ok(SyncAnnotationResult::InternalValue),
             AnnotationValue::Blob(digest) => {
+                if self.processed_digests.contains(&digest) {
+                    // do not insert here because annotation blobs
+                    // share a digest with payloads which must be
+                    // visited at least once to sync
+                    return Ok(SyncAnnotationResult::Duplicate);
+                }
                 self.reporter.visit_annotation(&annotation);
                 let sync_result = self.sync_digest(*digest).await?;
                 let res = SyncAnnotationResult::Synced {

--- a/crates/spfs/src/sync_test.rs
+++ b/crates/spfs/src/sync_test.rs
@@ -178,7 +178,7 @@ async fn test_sync_ref_including_annotation_blob(
     let annotation_value = AnnotationValue::Blob(Cow::Owned(annotation_digest));
     let layer_with_annotation = graph::Layer::new_with_manifest_and_annotation(
         manifest.to_graph_manifest().digest().unwrap(),
-        "testkey",
+        "test key",
         annotation_value,
     );
     repo_a.write_object(&layer_with_annotation).await.unwrap();


### PR DESCRIPTION
This fixes a bug that was preventing annotation blob value's from syncing. The issue was the processing insert checks were happening at all the levels,  including the top level of annotation syncing method. And that made the lower levels (sync_object, sync_blob) think the annotation's blob digest has been already sync'd.

This also adds a sync test for an annotation blob in a layer.