### PR TITLE
Fuse missing payload handling

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    patch:
+      default:
+        # we have not decided to enforce coverage yet
+        # but still want to see the patch coverage
+        target: 0%  # no amount of coverage is required
+        threshold: 100%  # the amount the coverage is allowed to drop

--- a/crates/spfs-vfs/src/fuse.rs
+++ b/crates/spfs-vfs/src/fuse.rs
@@ -335,7 +335,7 @@ impl Filesystem {
                     data = Some(bytes);
                     break;
                 }
-                Err(spfs::Error::UnknownObject(_)) => continue,
+                Err(err) if err.try_next_repo() => continue,
                 Err(err) => {
                     err!(reply, err);
                 }
@@ -408,7 +408,7 @@ impl Filesystem {
                         flags |= FOPEN_NONSEEKABLE | FOPEN_STREAM;
                         break;
                     }
-                    Err(spfs::Error::UnknownObject(_)) => continue,
+                    Err(err) if err.try_next_repo() => continue,
                     Err(err) => err!(reply, err),
                 },
                 #[cfg(not(feature = "fuse-backend-abi-7-31"))]

--- a/crates/spfs/src/error.rs
+++ b/crates/spfs/src/error.rs
@@ -194,6 +194,16 @@ impl Error {
         Error::Errno(msg, errno)
     }
 
+    /// Return true if this error suggests the call might succeed if retried on
+    /// a secondary repository.
+    #[inline]
+    pub fn try_next_repo(&self) -> bool {
+        matches!(
+            self,
+            Error::UnknownObject(_) | Error::ObjectMissingPayload(_, _)
+        )
+    }
+
     #[cfg(unix)]
     pub fn wrap_nix<E: Into<String>>(err: nix::Error, prefix: E) -> Error {
         let err = Self::from(err);


### PR DESCRIPTION
When opening a payload, also continue checking the next repositories if the error was ObjectMissingPayload. Otherwise some file I/O that could succeed will fail if the local repository is missing payloads.