### PR TITLE
Remove legacy-spk-version-tags feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -157,7 +157,7 @@ jobs:
       matrix:
         features:
           # SPI's standand features
-          - migration-to-components,sentry,spfs/protobuf-src,spfs-vfs/protobuf-src,statsd,fuse-backend-rhel-7-6,legacy-spk-version-tags
+          - migration-to-components,sentry,spfs/protobuf-src,spfs-vfs/protobuf-src,statsd,fuse-backend-rhel-7-6
         no-default-features:
           - ""
           - --no-default-features

--- a/.site/spi/.spdev.yaml
+++ b/.site/spi/.spdev.yaml
@@ -24,7 +24,7 @@ components:
       tags:
         - proxy
       variables:
-        FEATURES: migration-to-components,sentry,spfs/protobuf-src,legacy-spk-version-tags
+        FEATURES: migration-to-components,sentry,spfs/protobuf-src
 
   - kind: RustCrate
     name: spk-no-sentry
@@ -33,7 +33,7 @@ components:
       tags:
         - proxy
       variables:
-        FEATURES: migration-to-components,spfs/protobuf-src,legacy-spk-version-tags
+        FEATURES: migration-to-components,spfs/protobuf-src
 
   - kind: HugoDocs
     name: docs

--- a/.site/spi/spk.spec
+++ b/.site/spi/spk.spec
@@ -41,7 +41,7 @@ echo -e '#! /bin/bash\n\nexec cc -D_BSD_SOURCE "$@"' > cc_wrapper
 chmod +x cc_wrapper
 scl enable devtoolset-9 -- env CC=`pwd`/cc_wrapper cargo install --locked ast-grep
 # Include `--all` to also build spk-launcher
-dev env -- cargo build --release --features "migration-to-components,sentry,spfs/protobuf-src,statsd,fuse-backend-rhel-7-6,legacy-spk-version-tags" --all
+dev env -- cargo build --release --features "migration-to-components,sentry,spfs/protobuf-src,statsd,fuse-backend-rhel-7-6" --all
 
 %install
 mkdir -p %{buildroot}/usr/local/bin

--- a/crates/spk-cli/common/Cargo.toml
+++ b/crates/spk-cli/common/Cargo.toml
@@ -13,7 +13,6 @@ description = { workspace = true }
 workspace = true
 
 [features]
-legacy-spk-version-tags = ["spk-storage/legacy-spk-version-tags"]
 migration-to-components = [
     "spk-build/migration-to-components",
     "spk-config/migration-to-components",
@@ -29,10 +28,7 @@ sentry = [
     "spk-build/sentry",
     "spfs/sentry",
 ]
-statsd = [
-    "dep:statsd",
-    "spk-solve/statsd",
-]
+statsd = ["dep:statsd", "spk-solve/statsd"]
 
 [dependencies]
 miette = { workspace = true, features = ["fancy"] }

--- a/crates/spk-cli/common/src/flags.rs
+++ b/crates/spk-cli/common/src/flags.rs
@@ -1035,16 +1035,6 @@ pub struct Repositories {
     #[clap(long)]
     pub when: Option<spfs::tracking::TimeSpec>,
 
-    /// Enable support for legacy spk version tags in the repository.
-    ///
-    /// This causes extra file I/O but is required if the repository contains
-    /// any packages that were published with non-normalized version tags.
-    ///
-    /// This is enabled by default if spk is built with the legacy-spk-version-tags
-    /// feature flag enabled.
-    #[clap(long, hide = true)]
-    pub legacy_spk_version_tags: bool,
-
     /// Add the path as a spfs filesystem repo ahead of the existing
     /// 'origin' remote repo.
     ///
@@ -1093,9 +1083,6 @@ impl Repositories {
             if let Some(ts) = self.when.as_ref() {
                 repo.pin_at_time(ts);
             }
-            if self.legacy_spk_version_tags {
-                repo.set_legacy_spk_version_tags(true);
-            }
             repos.push(("local".into(), repo.into()));
         }
         for (name, ts) in enabled.iter() {
@@ -1116,9 +1103,6 @@ impl Repositories {
             }?;
             if let Some(ts) = ts.as_ref().or(self.when.as_ref()) {
                 repo.pin_at_time(ts);
-            }
-            if self.legacy_spk_version_tags {
-                repo.set_legacy_spk_version_tags(true);
             }
             repos.push((name.to_string(), repo.into()));
         }
@@ -1161,9 +1145,6 @@ impl Repositories {
             if let Some(ts) = self.when.as_ref() {
                 repo.pin_at_time(ts);
             }
-            if self.legacy_spk_version_tags {
-                repo.set_legacy_spk_version_tags(true);
-            }
             repos.push(("local".into(), repo.into()));
         }
         if self.local_repo_only {
@@ -1204,9 +1185,6 @@ impl Repositories {
             }?;
             if let Some(ts) = ts.as_ref().or(self.when.as_ref()) {
                 repo.pin_at_time(ts);
-            }
-            if self.legacy_spk_version_tags {
-                repo.set_legacy_spk_version_tags(true);
             }
             repos.push((name.into(), repo.into()));
         }

--- a/crates/spk-cli/common/src/flags_test.rs
+++ b/crates/spk-cli/common/src/flags_test.rs
@@ -66,7 +66,6 @@ async fn test_get_solver_with_host_options(
             enable_repo: Default::default(),
             disable_repo: Default::default(),
             when: None,
-            legacy_spk_version_tags: false,
             wrap_origin: None,
         },
         decision_formatter_settings: DecisionFormatterSettings {

--- a/crates/spk-cli/group2/Cargo.toml
+++ b/crates/spk-cli/group2/Cargo.toml
@@ -13,7 +13,6 @@ description = { workspace = true }
 workspace = true
 
 [features]
-legacy-spk-version-tags = ["spk-cli-common/legacy-spk-version-tags"]
 
 [dependencies]
 miette = { workspace = true, features = ["fancy"] }

--- a/crates/spk-launcher/bin/create-spk-platform
+++ b/crates/spk-launcher/bin/create-spk-platform
@@ -21,7 +21,7 @@ mkdir -p build
 export SPDEV_CONFIG_FILE=.site/spi/.spdev.yaml
 dev toolchain install Rust
 source ~/.bashrc
-dev env -- cargo build --release --features "sentry, migration-to-components, statsd, legacy-spk-version-tags"
+dev env -- cargo build --release --features "sentry, migration-to-components, statsd"
 
 # 2. create a new spfs layer
 spfs run - -- sh -c "mkdir -p /spfs/opt/spk.dist \

--- a/crates/spk-schema/crates/foundation/src/ident_ops/tag_path.rs
+++ b/crates/spk-schema/crates/foundation/src/ident_ops/tag_path.rs
@@ -16,3 +16,18 @@ pub trait TagPath {
     /// content into a repository, where normalization is required.
     fn verbatim_tag_path(&self) -> RelativePathBuf;
 }
+
+impl<T> TagPath for &T
+where
+    T: TagPath + ?Sized,
+{
+    #[inline]
+    fn tag_path(&self) -> RelativePathBuf {
+        (**self).tag_path()
+    }
+
+    #[inline]
+    fn verbatim_tag_path(&self) -> RelativePathBuf {
+        (**self).verbatim_tag_path()
+    }
+}

--- a/crates/spk-storage/Cargo.toml
+++ b/crates/spk-storage/Cargo.toml
@@ -13,7 +13,6 @@ description = { workspace = true }
 workspace = true
 
 [features]
-legacy-spk-version-tags = []
 migration-to-components = ["spk-schema/migration-to-components"]
 
 [dependencies]

--- a/crates/spk/Cargo.toml
+++ b/crates/spk/Cargo.toml
@@ -20,7 +20,6 @@ required-features = ["cli"]
 
 [features]
 default = ["cli"]
-legacy-spk-version-tags = ["spk-storage/legacy-spk-version-tags"]
 migration-to-components = [
     "spk-schema/migration-to-components",
     "spk-solve/migration-to-components",


### PR DESCRIPTION
This follows up #1196 and removes the legacy tags support originally added in #972.

SPI required this for a time while we were in the process of fixing all the non-normalized version tags in our repository, and updating to a build of spk that only wrote normalized tags.

Any other contemporary users of spk should not have any non-normalized tags to begin with.