### PR TITLE
Fix resolvo not populating Solution with global vars

### DIFF
--- a/crates/spk-schema/crates/foundation/src/name/mod.rs
+++ b/crates/spk-schema/crates/foundation/src/name/mod.rs
@@ -268,7 +268,7 @@ impl OptNameBuf {
 
 impl EnvName for OptNameBuf {
     fn env_name(&self) -> String {
-        self.0.replace('-', "_")
+        self.0.replace(['-', '.'], "_")
     }
 }
 

--- a/crates/spk-solve/src/solvers/resolvo/mod.rs
+++ b/crates/spk-solve/src/solvers/resolvo/mod.rs
@@ -42,6 +42,7 @@ use spk_solve_validation::{Validators, default_validators};
 use spk_storage::RepositoryHandle;
 
 use crate::solver::Solver as SolverTrait;
+use crate::solvers::resolvo::pkg_request_version_set::LocatedBuildIdentWithComponent;
 use crate::{DecisionFormatter, Error, Result, SolverExt, SolverMut, show_search_space_stats};
 
 #[cfg(test)]
@@ -201,16 +202,9 @@ impl Solver {
             let pool = &solver.provider().pool;
             Ok(solved
                 .into_iter()
-                .filter_map(|solvable_id| {
+                .map(|solvable_id| {
                     let solvable = pool.resolve_solvable(solvable_id);
-                    if let SpkSolvable::LocatedBuildIdentWithComponent(
-                        located_build_ident_with_component,
-                    ) = &solvable.record
-                    {
-                        Some(located_build_ident_with_component.clone())
-                    } else {
-                        None
-                    }
+                    solvable.record.clone()
                 })
                 .collect::<Vec<_>>())
         })
@@ -225,16 +219,22 @@ impl Solver {
         // two entries in this list with the same package name are for the same
         // package and this merging of components is valid.
         let mut seen_packages = HashMap::new();
-        for located_build_ident_with_component in solvables {
-            let SyntheticComponent::Actual(solvable_component) =
-                &located_build_ident_with_component.component
+        for spk_solvable in solvables {
+            if let SpkSolvable::GlobalVar { key, value } = &spk_solvable {
+                solution_options.insert(key.clone(), value.to_string());
+                continue;
+            }
+
+            let SpkSolvable::LocatedBuildIdentWithComponent(LocatedBuildIdentWithComponent {
+                ident,
+                component: SyntheticComponent::Actual(solvable_component),
+                requires_build_from_source,
+            }) = &spk_solvable
             else {
                 continue;
             };
 
-            if let Some(existing_index) =
-                seen_packages.get(located_build_ident_with_component.ident.name())
-            {
+            if let Some(existing_index) = seen_packages.get(ident.name()) {
                 if let Some((
                     PkgRequest {
                         pkg: RangeIdent { components, .. },
@@ -258,7 +258,7 @@ impl Solver {
             let pkg_request = PkgRequest {
                 pkg: RangeIdent {
                     repository_name: None,
-                    name: located_build_ident_with_component.ident.name().to_owned(),
+                    name: ident.name().to_owned(),
                     components: BTreeSet::from_iter([solvable_component.clone()]),
                     version: VersionFilter::default(),
                     build: None,
@@ -273,13 +273,9 @@ impl Solver {
             let repo = self
                 .repos
                 .iter()
-                .find(|repo| {
-                    repo.name() == located_build_ident_with_component.ident.repository_name()
-                })
+                .find(|repo| repo.name() == ident.repository_name())
                 .expect("Expected solved package's repository to be in the list of repositories");
-            let package = repo
-                .read_package(located_build_ident_with_component.ident.target())
-                .await?;
+            let package = repo.read_package(ident.target()).await?;
             let rendered_version = package.compat().render(package.version());
             solution_options.insert(package.name().as_opt_name().to_owned(), rendered_version);
             for option in package.get_build_options() {
@@ -307,21 +303,12 @@ impl Solver {
                 }
             }
             let next_index = solution_adds.len();
-            seen_packages.insert(
-                located_build_ident_with_component.ident.name().to_owned(),
-                next_index,
-            );
+            seen_packages.insert(ident.name().to_owned(), next_index);
             solution_adds.push((pkg_request, package, {
-                match located_build_ident_with_component.ident.build() {
-                    spk_schema::ident_build::Build::Source
-                        if located_build_ident_with_component.requires_build_from_source =>
-                    {
+                match ident.build() {
+                    spk_schema::ident_build::Build::Source if *requires_build_from_source => {
                         PackageSource::BuildFromSource {
-                            recipe: repo
-                                .read_recipe(
-                                    &located_build_ident_with_component.ident.to_version_ident(),
-                                )
-                                .await?,
+                            recipe: repo.read_recipe(&ident.clone().to_version_ident()).await?,
                         }
                     }
                     spk_schema::ident_build::Build::Source => {
@@ -330,9 +317,7 @@ impl Solver {
                         PackageSource::Repository {
                             repo: Arc::clone(repo),
                             // XXX: Why is this needed?
-                            components: repo
-                                .read_components(located_build_ident_with_component.ident.target())
-                                .await?,
+                            components: repo.read_components(ident.target()).await?,
                         }
                     }
                     spk_schema::ident_build::Build::Embedded(embedded_source) => {
@@ -344,9 +329,7 @@ impl Solver {
                                     parent: (**embedded_source_package).clone().try_into()?,
                                     // XXX: Why is this needed?
                                     components: repo
-                                        .read_components(
-                                            located_build_ident_with_component.ident.target(),
-                                        )
+                                        .read_components(ident.target())
                                         .await?
                                         .keys()
                                         .cloned()
@@ -360,9 +343,7 @@ impl Solver {
                         PackageSource::Repository {
                             repo: Arc::clone(repo),
                             // XXX: Why is this needed?
-                            components: repo
-                                .read_components(located_build_ident_with_component.ident.target())
-                                .await?,
+                            components: repo.read_components(ident.target()).await?,
                         }
                     }
                 }

--- a/crates/spk-solve/src/solvers/solver_test.rs
+++ b/crates/spk-solve/src/solvers/solver_test.rs
@@ -3083,3 +3083,32 @@ async fn request_for_all_component_picks_correct_version(
     let solution = run_and_print_resolve_for_tests(&mut solver).await.unwrap();
     assert_resolved!(solution, "mypkg", version = version);
 }
+
+/// An install.requirements of a global var should be present in the Solution
+#[rstest]
+#[case::step(step_solver())]
+#[case::resolvo(resolvo_solver())]
+#[tokio::test]
+async fn install_requirement_vars_found_in_solution(#[case] mut solver: SolverImpl) {
+    let repo = make_repo!(
+        [
+            {
+                "pkg": "mypkg/1.0.0",
+                "install": {
+                    "requirements": [{"var": "varname/value"}]
+                }
+            },
+        ]
+    );
+    let repo = Arc::new(repo);
+
+    solver.add_repository(repo);
+    solver.add_request(request!("mypkg"));
+
+    let solution = run_and_print_resolve_for_tests(&mut solver).await.unwrap();
+    assert!(
+        solution.options().get(opt_name!("varname")) == Some(&"value".to_string()),
+        "expected varname/value to be in solution options, got: {:#?}",
+        solution.options()
+    );
+}


### PR DESCRIPTION
As the test demonstrates, it is expected that any var install
requirements of packages in a solution are added to the solution
options, which then makes them turn into environment variables in build
environments.

Although the variables could be reconstructed from the packages in the
solution, resolvo returns this information in its list of solvables, which
includes the `GlobalVar` variant. The code was previously discarding them.