### PR TITLE
Demonstrate spfs clean can corrupt repository

### DIFF
--- a/crates/spfs/src/clean_test.rs
+++ b/crates/spfs/src/clean_test.rs
@@ -517,3 +517,44 @@ fn list_files<P: AsRef<std::path::Path>>(dirname: P) -> Vec<String> {
     }
     all_files
 }
+
+/// Clean must not delete items that referenced by other items.
+#[rstest]
+#[tokio::test]
+async fn clean_must_not_violate_invariants(#[future] tmprepo: TempRepo) {
+    init_logging();
+    let tmprepo = tmprepo.await;
+    let manifest = tracking::Manifest::<()>::default();
+    let layer = tmprepo
+        .create_layer(&manifest.to_graph_manifest())
+        .await
+        .unwrap();
+
+    // Note current time now.
+    let time_before_platform = Utc::now();
+
+    // Time passes...
+    sleep(Duration::from_millis(250)).await;
+
+    let platform = tmprepo
+        .create_platform(layer.digest().unwrap().into())
+        .await
+        .unwrap();
+
+    let cleaner = Cleaner::new(&tmprepo)
+        .with_required_age_cutoff(time_before_platform)
+        .with_reporter(TracingCleanReporter);
+    let result = cleaner
+        .prune_all_tags_and_clean()
+        .await
+        .expect("failed to clean objects");
+    println!("{result:#?}");
+
+    if let Err(Error::UnknownObject(_)) = tmprepo.read_platform(platform.digest().unwrap()).await {
+        panic!("expected platform to not be cleaned, because it is newer than the cutoff")
+    }
+
+    if let Err(Error::UnknownObject(_)) = tmprepo.read_layer(layer.digest().unwrap()).await {
+        panic!("expected layer to not be cleaned, because it is referenced by the platform")
+    }
+}


### PR DESCRIPTION
Clean can end up violating the invariant that all child objects of a parent must exist. This test demonstrates this with a manifest and a layer but the problem applies to other relationships as well.