### PR TITLE
Another attempt to fix spurious test failures

### DIFF
--- a/crates/spfs/src/config_test.rs
+++ b/crates/spfs/src/config_test.rs
@@ -7,7 +7,7 @@ use rstest::rstest;
 use super::{Config, Remote, RemoteConfig, RepositoryConfig};
 use crate::storage::RepositoryHandle;
 use crate::storage::prelude::*;
-use crate::{get_config, load_config};
+use crate::{get_config, load_config, reset_config};
 
 #[rstest]
 fn test_config_list_remote_names_empty() {
@@ -121,17 +121,19 @@ fn test_config_expands_tilde_in_paths() {
 #[rstest]
 #[serial_test::serial(config)]
 fn test_make_current_updates_config() {
-    let config1 = Config::default();
-    config1.make_current().unwrap();
+    reset_config! {
+        let config1 = Config::default();
+        config1.make_current().unwrap();
 
-    let changed_name = "changed";
+        let changed_name = "changed";
 
-    let mut config2 = Config::default();
-    changed_name.clone_into(&mut config2.user.name);
-    config2.make_current().unwrap();
+        let mut config2 = Config::default();
+        changed_name.clone_into(&mut config2.user.name);
+        config2.make_current().unwrap();
 
-    let current_config = get_config().unwrap();
-    assert_eq!(current_config.user.name, changed_name);
+        let current_config = get_config().unwrap();
+        assert_eq!(current_config.user.name, changed_name);
+    }
 }
 
 #[rstest]

--- a/crates/spfs/src/graph/layer_test.rs
+++ b/crates/spfs/src/graph/layer_test.rs
@@ -22,6 +22,72 @@ fn test_layer_encoding_manifest_only() {
     assert_eq!(actual.digest().unwrap(), expected.digest().unwrap())
 }
 
+/// A macro to reset the global config after running a block of code,
+/// even if that block of code panics.
+#[macro_export]
+macro_rules! reset_config {
+    ($($body:tt)*) => {{
+        let reset_config_original = Config::current().unwrap();
+        let _ = std::panic::catch_unwind(|| {
+            $($body)*
+        }).unwrap_or_else(|e| {
+            (*reset_config_original).clone().make_current().unwrap();
+
+            std::panic::resume_unwind(e);
+        });
+        (*reset_config_original).clone().make_current().unwrap();
+    }};
+}
+
+/// Sanity test to ensure that the reset_config macro catches panics
+#[rstest]
+#[should_panic]
+fn reset_config_catches_panics() {
+    reset_config! {
+        panic!("This is a test panic");
+
+        #[allow(unreachable_code)]
+        Ok::<(), ()>(())
+    };
+}
+
+/// A macro to reset the global config after running a block of code,
+/// even if that block of code panics.
+#[macro_export]
+macro_rules! reset_config_async {
+    ($($body:tt)*) => {{
+        let reset_config_original = Config::current().unwrap();
+        let reset_config_handle = tokio::task::spawn(async move {
+            $($body)*
+        });
+        let result = reset_config_handle.await;
+        (*reset_config_original).clone().make_current().unwrap();
+        match result {
+            Ok(_) => {}
+            Err(err) if err.is_panic() => {
+                let err = err.into_panic();
+                std::panic::resume_unwind(err);
+            }
+            Err(err) => {
+                panic!("Task failed to complete: {err}");
+            }
+        }
+    }};
+}
+
+/// Sanity test to ensure that the reset_config_async macro catches panics
+#[rstest]
+#[should_panic]
+#[tokio::test]
+async fn reset_config_async_catches_panics() {
+    reset_config_async! {
+        panic!("This is a test panic");
+
+        #[allow(unreachable_code)]
+        Ok::<(), ()>(())
+    };
+}
+
 #[rstest(
     write_encoding_format => [EncodingFormat::Legacy, EncodingFormat::FlatBuffers],
     write_digest_strategy => [DigestStrategy::Legacy, DigestStrategy::WithKindAndSalt],
@@ -31,34 +97,36 @@ fn test_layer_encoding_annotation_only(
     write_encoding_format: EncodingFormat,
     write_digest_strategy: DigestStrategy,
 ) {
-    let mut config = Config::default();
-    config.storage.encoding_format = write_encoding_format;
-    config.storage.digest_strategy = write_digest_strategy;
-    config.make_current().unwrap();
+    reset_config! {
+        let mut config = Config::default();
+        config.storage.encoding_format = write_encoding_format;
+        config.storage.digest_strategy = write_digest_strategy;
+        config.make_current().unwrap();
 
-    let expected = Layer::new_with_annotation("key", AnnotationValue::string("value"));
+        let expected = Layer::new_with_annotation("key", AnnotationValue::string("value"));
 
-    let mut stream = Vec::new();
-    match expected.encode(&mut stream) {
-        Ok(_) if write_encoding_format == EncodingFormat::Legacy => {
-            panic!("Encode should fail if encoding format is legacy")
-        }
-        Ok(_) => {}
-        Err(_) if write_encoding_format == EncodingFormat::Legacy => {
-            // This error is expected
-            return;
-        }
-        Err(e) => {
-            panic!("Error encoding layer: {e}")
-        }
+        let mut stream = Vec::new();
+        match expected.encode(&mut stream) {
+            Ok(_) if write_encoding_format == EncodingFormat::Legacy => {
+                panic!("Encode should fail if encoding format is legacy")
+            }
+            Ok(_) => {}
+            Err(_) if write_encoding_format == EncodingFormat::Legacy => {
+                // This error is expected
+                return;
+            }
+            Err(e) => {
+                panic!("Error encoding layer: {e}")
+            }
+        };
+
+        let decoded = Object::decode(&mut stream.as_slice());
+
+        let actual = decoded.unwrap().into_layer().unwrap();
+        println!(" Actual: {:?}", actual);
+
+        assert_eq!(actual.digest().unwrap(), expected.digest().unwrap())
     };
-
-    let decoded = Object::decode(&mut stream.as_slice());
-
-    let actual = decoded.unwrap().into_layer().unwrap();
-    println!(" Actual: {:?}", actual);
-
-    assert_eq!(actual.digest().unwrap(), expected.digest().unwrap())
 }
 
 #[rstest(
@@ -70,46 +138,48 @@ fn test_layer_encoding_manifest_and_annotations(
     write_encoding_format: EncodingFormat,
     write_digest_strategy: DigestStrategy,
 ) {
-    let mut config = Config::default();
-    config.storage.encoding_format = write_encoding_format;
-    config.storage.digest_strategy = write_digest_strategy;
-    config.make_current().unwrap();
+    reset_config! {
+        let mut config = Config::default();
+        config.storage.encoding_format = write_encoding_format;
+        config.storage.digest_strategy = write_digest_strategy;
+        config.make_current().unwrap();
 
-    let expected = Layer::new_with_manifest_and_annotations(
-        encoding::EMPTY_DIGEST.into(),
-        vec![("key", AnnotationValue::string("value"))],
-    );
-    println!("Expected: {:?}", expected);
+        let expected = Layer::new_with_manifest_and_annotations(
+            encoding::EMPTY_DIGEST.into(),
+            vec![("key", AnnotationValue::string("value"))],
+        );
+        println!("Expected: {:?}", expected);
 
-    let mut stream = Vec::new();
-    match expected.encode(&mut stream) {
-        Ok(_) if write_encoding_format == EncodingFormat::Legacy => {
-            panic!("Encode should fail if encoding format is legacy")
-        }
-        Ok(_) => {}
-        Err(_) if write_encoding_format == EncodingFormat::Legacy => {
-            // This error is expected
-            return;
-        }
-        Err(e) => {
-            panic!("Error encoding layer: {e}")
-        }
-    };
+        let mut stream = Vec::new();
+        match expected.encode(&mut stream) {
+            Ok(_) if write_encoding_format == EncodingFormat::Legacy => {
+                panic!("Encode should fail if encoding format is legacy")
+            }
+            Ok(_) => {}
+            Err(_) if write_encoding_format == EncodingFormat::Legacy => {
+                // This error is expected
+                return;
+            }
+            Err(e) => {
+                panic!("Error encoding layer: {e}")
+            }
+        };
 
-    let actual = Object::decode(&mut stream.as_slice())
-        .unwrap()
-        .into_layer()
-        .unwrap();
-    println!(" Actual: {:?}", actual);
+        let actual = Object::decode(&mut stream.as_slice())
+            .unwrap()
+            .into_layer()
+            .unwrap();
+        println!(" Actual: {:?}", actual);
 
-    match write_encoding_format {
-        EncodingFormat::Legacy => {
-            unreachable!();
-        }
-        EncodingFormat::FlatBuffers => {
-            // Under flatbuffers encoding both will contain the
-            // annotation data and will match
-            assert_eq!(actual.digest().unwrap(), expected.digest().unwrap())
+        match write_encoding_format {
+            EncodingFormat::Legacy => {
+                unreachable!();
+            }
+            EncodingFormat::FlatBuffers => {
+                // Under flatbuffers encoding both will contain the
+                // annotation data and will match
+                assert_eq!(actual.digest().unwrap(), expected.digest().unwrap())
+            }
         }
     }
 }

--- a/crates/spfs/src/storage/fs/renderer_test.rs
+++ b/crates/spfs/src/storage/fs/renderer_test.rs
@@ -12,7 +12,7 @@ use crate::fixtures::*;
 use crate::graph::object::{DigestStrategy, EncodingFormat};
 use crate::storage::fs::{MaybeOpenFsRepository, OpenFsRepository};
 use crate::storage::{RepositoryExt, RepositoryHandle};
-use crate::{Config, tracking};
+use crate::{Config, reset_config_async, tracking};
 
 #[rstest(
     write_encoding_format => [EncodingFormat::Legacy, EncodingFormat::FlatBuffers],
@@ -25,45 +25,47 @@ async fn test_render_manifest(
     write_encoding_format: EncodingFormat,
     write_digest_strategy: DigestStrategy,
 ) {
-    let mut config = Config::default();
-    config.storage.encoding_format = write_encoding_format;
-    config.storage.digest_strategy = write_digest_strategy;
-    config.make_current().unwrap();
+    reset_config_async! {
+        let mut config = Config::default();
+        config.storage.encoding_format = write_encoding_format;
+        config.storage.digest_strategy = write_digest_strategy;
+        config.make_current().unwrap();
 
-    let storage = OpenFsRepository::create(tmpdir.path().join("storage"))
-        .await
-        .unwrap();
+        let storage = OpenFsRepository::create(tmpdir.path().join("storage"))
+            .await
+            .unwrap();
 
-    let src_dir = tmpdir.path().join("source");
-    ensure(src_dir.join("dir1.0/dir2.0/file.txt"), "somedata");
-    ensure(src_dir.join("dir1.0/dir2.1/file.txt"), "someotherdata");
-    ensure(src_dir.join("dir2.0/file.txt"), "evenmoredata");
-    ensure(src_dir.join("file.txt"), "rootdata");
+        let src_dir = tmpdir.path().join("source");
+        ensure(src_dir.join("dir1.0/dir2.0/file.txt"), "somedata");
+        ensure(src_dir.join("dir1.0/dir2.1/file.txt"), "someotherdata");
+        ensure(src_dir.join("dir2.0/file.txt"), "evenmoredata");
+        ensure(src_dir.join("file.txt"), "rootdata");
 
-    let manifest = tracking::compute_manifest(&src_dir).await.unwrap();
+        let manifest = tracking::compute_manifest(&src_dir).await.unwrap();
 
-    for node in manifest.walk_abs(src_dir.to_str().unwrap()) {
-        if node.entry.kind.is_blob() {
-            let data = tokio::fs::File::open(&node.path.to_path("/"))
-                .await
-                .unwrap();
-            storage
-                .commit_blob(Box::pin(tokio::io::BufReader::new(data)))
-                .await
-                .unwrap();
+        for node in manifest.walk_abs(src_dir.to_str().unwrap()) {
+            if node.entry.kind.is_blob() {
+                let data = tokio::fs::File::open(&node.path.to_path("/"))
+                    .await
+                    .unwrap();
+                storage
+                    .commit_blob(Box::pin(tokio::io::BufReader::new(data)))
+                    .await
+                    .unwrap();
+            }
         }
-    }
 
-    let expected = manifest.to_graph_manifest();
-    let rendered_path = crate::storage::fs::Renderer::new(&storage)
-        .render_manifest(&expected, None)
-        .await
-        .expect("should successfully render manifest");
-    let actual = tracking::compute_manifest(rendered_path)
-        .await
-        .unwrap()
-        .to_graph_manifest();
-    assert_eq!(actual.digest().unwrap(), expected.digest().unwrap());
+        let expected = manifest.to_graph_manifest();
+        let rendered_path = crate::storage::fs::Renderer::new(&storage)
+            .render_manifest(&expected, None)
+            .await
+            .expect("should successfully render manifest");
+        let actual = tracking::compute_manifest(rendered_path)
+            .await
+            .unwrap()
+            .to_graph_manifest();
+        assert_eq!(actual.digest().unwrap(), expected.digest().unwrap());
+    }
 }
 
 #[rstest(
@@ -77,55 +79,57 @@ async fn test_render_manifest_with_repo(
     write_encoding_format: EncodingFormat,
     write_digest_strategy: DigestStrategy,
 ) {
-    let mut config = Config::default();
-    config.storage.encoding_format = write_encoding_format;
-    config.storage.digest_strategy = write_digest_strategy;
-    config.make_current().unwrap();
+    reset_config_async! {
+        let mut config = Config::default();
+        config.storage.encoding_format = write_encoding_format;
+        config.storage.digest_strategy = write_digest_strategy;
+        config.make_current().unwrap();
 
-    let tmprepo = Arc::new(
-        MaybeOpenFsRepository::create(tmpdir.path().join("repo"))
+        let tmprepo = Arc::new(
+            MaybeOpenFsRepository::create(tmpdir.path().join("repo"))
+                .await
+                .unwrap()
+                .into(),
+        );
+        let src_dir = tmpdir.path().join("source");
+        ensure(src_dir.join("dir1.0/dir2.0/file.txt"), "somedata");
+        ensure(src_dir.join("dir1.0/dir2.1/file.txt"), "someotherdata");
+        ensure(src_dir.join("dir2.0/file.txt"), "evenmoredata");
+        ensure(src_dir.join("file.txt"), "rootdata");
+
+        let expected_manifest = crate::Committer::new(&tmprepo)
+            .commit_dir(&src_dir)
             .await
+            .unwrap();
+        let manifest = expected_manifest.to_graph_manifest();
+
+        // Safety: tmprepo was created as an FsRepository
+        let tmprepo = match &*tmprepo {
+            RepositoryHandle::FS(fs) => fs.opened().await.unwrap(),
+            _ => panic!("Unexpected tmprepo type!"),
+        };
+
+        let render = tmprepo
+            .fs_impl
+            .renders
+            .as_ref()
             .unwrap()
-            .into(),
-    );
-    let src_dir = tmpdir.path().join("source");
-    ensure(src_dir.join("dir1.0/dir2.0/file.txt"), "somedata");
-    ensure(src_dir.join("dir1.0/dir2.1/file.txt"), "someotherdata");
-    ensure(src_dir.join("dir2.0/file.txt"), "evenmoredata");
-    ensure(src_dir.join("file.txt"), "rootdata");
-
-    let expected_manifest = crate::Committer::new(&tmprepo)
-        .commit_dir(&src_dir)
-        .await
-        .unwrap();
-    let manifest = expected_manifest.to_graph_manifest();
-
-    // Safety: tmprepo was created as an FsRepository
-    let tmprepo = match &*tmprepo {
-        RepositoryHandle::FS(fs) => fs.opened().await.unwrap(),
-        _ => panic!("Unexpected tmprepo type!"),
-    };
-
-    let render = tmprepo
-        .fs_impl
-        .renders
-        .as_ref()
-        .unwrap()
-        .renders
-        .build_digest_path(&manifest.digest().unwrap());
-    assert!(!render.exists(), "render should NOT be seen as existing");
-    super::Renderer::new(&tmprepo)
-        .render_manifest(&manifest, None)
-        .await
-        .unwrap();
-    assert!(render.exists(), "render should be seen as existing");
-    assert!(was_render_completed(&render).await);
-    let rendered_manifest = tracking::compute_manifest(&render).await.unwrap();
-    let diffs = tracking::compute_diff(&expected_manifest, &rendered_manifest);
-    println!("DIFFS:");
-    println!("{}", crate::io::format_diffs(diffs.iter()));
-    assert_eq!(
-        expected_manifest.to_graph_manifest().digest().unwrap(),
-        rendered_manifest.to_graph_manifest().digest().unwrap()
-    );
+            .renders
+            .build_digest_path(&manifest.digest().unwrap());
+        assert!(!render.exists(), "render should NOT be seen as existing");
+        super::Renderer::new(&tmprepo)
+            .render_manifest(&manifest, None)
+            .await
+            .unwrap();
+        assert!(render.exists(), "render should be seen as existing");
+        assert!(was_render_completed(&render).await);
+        let rendered_manifest = tracking::compute_manifest(&render).await.unwrap();
+        let diffs = tracking::compute_diff(&expected_manifest, &rendered_manifest);
+        println!("DIFFS:");
+        println!("{}", crate::io::format_diffs(diffs.iter()));
+        assert_eq!(
+            expected_manifest.to_graph_manifest().digest().unwrap(),
+            rendered_manifest.to_graph_manifest().digest().unwrap()
+        );
+    }
 }


### PR DESCRIPTION
Following up on #1052 there are still spurious test failures in other tests, e.g., sync::sync_test::test_sync_ref_including_annotation_blob, that fail because the spfs config is set to legacy encoding format.

These tests that change the config were not putting the config back to defaults, so that could explain the spurious failures depending on the order that tests run. Although, it is suspicious that the tests weren't failing more often if this is the cause.