### PR TITLE
Adds test specs access from a build spec

### DIFF
--- a/crates/spk-schema/src/package.rs
+++ b/crates/spk-schema/src/package.rs
@@ -14,6 +14,7 @@ use spk_schema_foundation::version::VERSION_SEP;
 use super::RequirementsList;
 use crate::foundation::ident_component::Component;
 use crate::foundation::option_map::OptionMap;
+use crate::spec::SpecTest;
 use crate::{DeprecateMut, Opt, RuntimeEnvironment};
 
 #[cfg(test)]
@@ -135,6 +136,9 @@ pub trait Package:
     /// Requests that must be met to use this package
     fn runtime_requirements(&self) -> Cow<'_, RequirementsList>;
 
+    /// Package's test specs for all test stages
+    fn get_all_tests(&self) -> Vec<SpecTest>;
+
     /// Requests that must be satisfied by the build
     /// environment of any package built against this one
     ///
@@ -213,6 +217,10 @@ impl<T: Package + Send + Sync> Package for std::sync::Arc<T> {
         (**self).runtime_requirements()
     }
 
+    fn get_all_tests(&self) -> Vec<SpecTest> {
+        (**self).get_all_tests()
+    }
+
     fn downstream_build_requirements<'a>(
         &self,
         components: impl IntoIterator<Item = &'a Component>,
@@ -282,6 +290,10 @@ impl<T: Package + Send + Sync> Package for Box<T> {
         (**self).runtime_requirements()
     }
 
+    fn get_all_tests(&self) -> Vec<SpecTest> {
+        (**self).get_all_tests()
+    }
+
     fn downstream_build_requirements<'a>(
         &self,
         components: impl IntoIterator<Item = &'a Component>,
@@ -349,6 +361,10 @@ impl<T: Package + Send + Sync> Package for &T {
 
     fn runtime_requirements(&self) -> Cow<'_, RequirementsList> {
         (**self).runtime_requirements()
+    }
+
+    fn get_all_tests(&self) -> Vec<SpecTest> {
+        (**self).get_all_tests()
     }
 
     fn downstream_build_requirements<'a>(

--- a/crates/spk-schema/src/spec.rs
+++ b/crates/spk-schema/src/spec.rs
@@ -739,6 +739,12 @@ impl Package for Spec {
         }
     }
 
+    fn get_all_tests(&self) -> Vec<SpecTest> {
+        match self {
+            Spec::V0Package(spec) => spec.get_all_tests(),
+        }
+    }
+
     fn validation(&self) -> &super::ValidationSpec {
         match self {
             Spec::V0Package(spec) => spec.validation(),

--- a/crates/spk-schema/src/v0/package_spec.rs
+++ b/crates/spk-schema/src/v0/package_spec.rs
@@ -41,6 +41,7 @@ use crate::ident::{
 };
 use crate::metadata::Meta;
 use crate::option::VarOpt;
+use crate::spec::SpecTest;
 use crate::v0::EmbeddedPackageSpec;
 use crate::{
     BuildSpec,
@@ -322,6 +323,10 @@ impl Package for PackageSpec {
 
     fn runtime_requirements(&self) -> Cow<'_, RequirementsList> {
         Cow::Borrowed(&self.install.requirements)
+    }
+
+    fn get_all_tests(&self) -> Vec<SpecTest> {
+        self.tests.clone().into_iter().map(SpecTest::V0).collect()
     }
 
     fn downstream_build_requirements<'a>(


### PR DESCRIPTION
This adds  `get_all_tests()` method to the Package, Spec etc. APIs to allow a build's test specs to be accessed from a build spec (a v0::Spec). Build spec's have the data aready, but accessing it is a bit convoluted without these changes.