### PR TITLE
Change how namespaced options are populated into the env

### DIFF
--- a/crates/spk-schema/crates/foundation/src/name/mod.rs
+++ b/crates/spk-schema/crates/foundation/src/name/mod.rs
@@ -12,7 +12,7 @@ pub use error::{Error, Result};
 use miette::Diagnostic;
 use thiserror::Error;
 
-use crate::spec_ops::EnvName;
+use crate::spec_ops::{EnvName, Named};
 
 #[cfg(test)]
 #[path = "./name_test.rs"]
@@ -71,6 +71,12 @@ impl InvalidNameError {
 parsedbuf::parsed!(OptName, Error, "option");
 parsedbuf::parsed!(PkgName, Error, "package");
 parsedbuf::parsed!(RepositoryName, Error, "repository");
+
+impl Named for PkgName {
+    fn name(&self) -> &PkgName {
+        self
+    }
+}
 
 impl Borrow<OptName> for PkgName {
     fn borrow(&self) -> &OptName {
@@ -267,6 +273,12 @@ impl OptNameBuf {
 }
 
 impl EnvName for OptNameBuf {
+    fn env_name(&self) -> String {
+        self.0.replace('-', "_")
+    }
+}
+
+impl EnvName for OptName {
     fn env_name(&self) -> String {
         self.0.replace('-', "_")
     }

--- a/crates/spk-schema/crates/foundation/src/option_map/mod.rs
+++ b/crates/spk-schema/crates/foundation/src/option_map/mod.rs
@@ -191,8 +191,22 @@ impl OptionMap {
     pub fn to_environment(&self) -> HashMap<String, String> {
         let mut out = HashMap::default();
         for (name, value) in self.iter() {
-            let var_name = format!("SPK_OPT_{}", name.env_name());
-            out.insert(var_name, value.into());
+            if let Some(namespace) = name.namespace() {
+                let var_name = format!(
+                    "SPK_PKG_{}_OPT_{}",
+                    namespace.env_name(),
+                    name.without_namespace().env_name()
+                );
+                out.insert(var_name, value.into());
+
+                // Also insert in the original format for compatibility,
+                // to be removed in a future release.
+                let var_name = format!("SPK_OPT_{}", name.env_name());
+                out.insert(var_name, value.into());
+            } else {
+                let var_name = format!("SPK_OPT_{}", name.env_name());
+                out.insert(var_name, value.into());
+            }
         }
         out
     }
@@ -228,7 +242,10 @@ impl OptionMap {
     pub fn clean_environment(env: &mut HashMap<String, String>) {
         let to_remove = env
             .keys()
-            .filter(|name| name.starts_with("SPK_OPT_"))
+            .filter(|name| {
+                name.starts_with("SPK_OPT_")
+                    || (name.starts_with("SPK_PKG_") && name.contains("_OPT_"))
+            })
             .map(|k| k.to_owned())
             .collect_vec();
         for name in to_remove.into_iter() {

--- a/crates/spk-schema/crates/foundation/src/spec_ops/env_name.rs
+++ b/crates/spk-schema/crates/foundation/src/spec_ops/env_name.rs
@@ -12,7 +12,7 @@ pub trait EnvName {
 
 impl<T> EnvName for T
 where
-    T: Named,
+    T: Named + ?Sized,
 {
     fn env_name(&self) -> String {
         self.name().replace('-', "_")

--- a/docs/use/create/build.md
+++ b/docs/use/create/build.md
@@ -20,7 +20,14 @@ build:
 
 All options that are declared in your package should be used in the build script, otherwise they are not relevant build options and your package may need rebuilding unnecessarily.
 
-When writing your build script, the value of each option is made available in an environment variable with the name `SPK_OPT_{name}`. Package options are also resolved into the build environment and can be accessed more concretely with the variables `SPK_PKG_{name}`, `SPK_PKG_{name}_VERSION`, `SPK_PKG_{name}_BUILD`, `SPK_PKG_{name}_VERSION_MAJOR`, `SPK_PKG_{name}_VERSION_MINOR`, `SPK_PKG_{name}_VERSION_PATCH`
+When writing your build script, the value of each option is made available in an
+environment variable with the name `SPK_OPT_{name}`. Options specific to a
+package are in the form `SPK_PKG_{pkg_name}_OPT_{opt_name}`.
+Package properties are also resolved into the build environment and can be
+accessed more concretely with the variables `SPK_PKG_{pkg_name}`,
+`SPK_PKG_{pkg_name}_VERSION`, `SPK_PKG_{pkg_name}_BUILD`,
+`SPK_PKG_{pkg_name}_VERSION_MAJOR`, `SPK_PKG_{pkg_name}_VERSION_MINOR`,
+`SPK_PKG_{pkg_name}_VERSION_PATCH`
 
 > [!TIP]
 > Best practice for defining boolean options is to follow the cmake convention of having two choices: `on` and `off`


### PR DESCRIPTION
Instead of `$SPK_OPT_pkgname.optname`, which is an invalid environment variable name, use `$SPK_PKG_pkgname_OPT_optname`. This format then resembles how other environment variables are named, such as `$SPK_PKG_pkgname_VERSION`.

The old format is also still populated for backward compatibility and to allow projects to update to the new format.