### PR TITLE
Prevent config from changing during this test

### DIFF
--- a/crates/spfs/src/check_test.rs
+++ b/crates/spfs/src/check_test.rs
@@ -253,6 +253,8 @@ impl CheckReporter for &DebugReporter {
 /// The check should complete successfully and report a missing object.
 #[rstest]
 #[tokio::test]
+// This test just needs the config to not change while it is running.
+#[serial_test::serial(config)]
 async fn check_missing_annotation_blob(#[future] tmprepo: TempRepo) {
     init_logging();
     let tmprepo = tmprepo.await;


### PR DESCRIPTION
If a parallel test changes the config to use legacy encoding then this test will fail when trying to write a layer with blob annotation.

Spun out of #1289 since we're still experiencing spurious CI failures.