### PR TITLE
Hotfix packages with unpinned var opts on load

### DIFF
--- a/crates/spk-schema/src/option.rs
+++ b/crates/spk-schema/src/option.rs
@@ -416,6 +416,15 @@ impl VarOpt {
         }
     }
 
+    /// If this option is not already pinned, and it has a non-empty default,
+    /// pin the default value.
+    pub fn pin_with_default(&mut self) {
+        if self.value.is_some() || self.default.is_empty() {
+            return;
+        }
+        self.value = Some(self.default.clone());
+    }
+
     pub fn set_value(&mut self, value: String) -> Result<()> {
         if !self.choices.is_empty() && !value.is_empty() && !self.choices.contains(&value) {
             return Err(Error::String(format!(


### PR DESCRIPTION
Given a package with an embedded package that defines a var with a
default value, such as in:

```yaml
install:
  embedded:
    - pkg: python/3.10.8
      build:
        options:
          - var: abi/3.10.8
```

Until the fix in #1302, these vars were not getting pinned
when the package is built and the stub created:

```yaml
pkg: python/3.10.8/embedded[some-parent-pkg:run/3.10.8/P7SZECZD]
api: v0/package
build:
  options:
  - var: python.abi/cp310
```

This created a problem for solving correctly because
`Satisfy<VarRequest>` would incorrectly claim that this package is compatible
with _any_ value for `python.abi`.

In order to fix solves for the existing embedded stubs, these missing
pinned values are pinned as the package specs are read from storage, so
they end up with the intended content:

```yaml
pkg: python/3.10.8/embedded[some-parent-pkg:run/3.10.8/P7SZECZD]
api: v0/package
build:
  options:
  - var: python.abi/cp310
    static: cp310
```

Now `Satisfy<VarRequest>` will correctly reject this package as not
being compatible with, e.g., `python.abi/cp311`.

The best we can do is assume `python.abi` was not overridden to some
other value at the time the parent package was built and that the
default on the option is the appropriate value for the pin.