### PR TITLE
Fix VarOpt Hash and Ord implementations

### DIFF
--- a/crates/spk-schema/src/option.rs
+++ b/crates/spk-schema/src/option.rs
@@ -335,6 +335,7 @@ impl<'de> Deserialize<'de> for Opt {
 pub struct VarOpt {
     pub var: OptNameBuf,
     pub default: String,
+    // This field does not implement `Ord` so this struct can't derive it.
     pub choices: IndexSet<String>,
     pub inheritance: Inheritance,
     pub description: Option<String>,


### PR DESCRIPTION
The compat field was not being considered. Use destructuring to prevent this kind of error in the future.

In Ord, `self.description` was being compared to `other.value`. It didn't matter because the result was thrown away. However, since `description` is included in the Hash, it should also be included in the Ord implementation to maintain consistency. No justification for it being skipped was given in #954.