### PR TITLE
Allow built packages to have a default build script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1063,7 +1063,7 @@ checksum = "ef941ded77d15ca19b40374869ac6000af1c9f2a4c0f3d4c70926287e6364a8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.106",
 ]
 
 [[package]]

--- a/crates/spk-schema/src/v0/embedded_build_spec_test.rs
+++ b/crates/spk-schema/src/v0/embedded_build_spec_test.rs
@@ -10,9 +10,9 @@ use super::EmbeddedBuildSpec;
 fn options_are_valid() {
     let _spec: EmbeddedBuildSpec = serde_yaml::from_str(
         r#"
-      options:
-        - {var: python.abi/cp37}
-    "#,
+        options:
+          - {var: python.abi/cp37}
+        "#,
     )
     .unwrap();
 }
@@ -22,10 +22,33 @@ fn script_is_invalid() {
     assert!(
         serde_yaml::from_str::<EmbeddedBuildSpec>(
             r#"
-      script: echo "hello"
-    "#,
+            options:
+              - {var: python.abi/cp37}
+            script: echo "hello"
+            "#,
         )
         .is_err()
+    );
+}
+
+/// For backwards compatibility a build script is tolerated if it matches the
+/// default build script.
+///
+/// The original way the code tested if a build script is missing was to test if
+/// the value matched the default script but that doesn't cover when the build
+/// script is present but still matches the default.
+#[rstest]
+fn default_script_is_allowed() {
+    assert!(
+        serde_yaml::from_str::<EmbeddedBuildSpec>(
+            r#"
+            options:
+              - {var: python.abi/cp37}
+            script:
+              - sh ./build.sh
+            "#,
+        )
+        .is_ok()
     );
 }
 
@@ -33,10 +56,10 @@ fn script_is_invalid() {
 fn unknown_field_is_allowed() {
     let _spec: EmbeddedBuildSpec = serde_yaml::from_str(
         r#"
-      options:
-        - {var: python.abi/cp37}
-      unknown_field: some_value
-    "#,
+        options:
+          - {var: python.abi/cp37}
+        unknown_field: some_value
+        "#,
     )
     .unwrap();
 }


### PR DESCRIPTION
Specifically any embedded spec in a built package is allowed to contain a default build script because this is how package specs used to be generated and now these packages must still be able to be parsed.

The recent new code wasn't tolerating any build script.