### PR TITLE
Remove dbg! left behind in #1314

### DIFF
--- a/crates/spk-schema/crates/foundation/src/ident_build/build.rs
+++ b/crates/spk-schema/crates/foundation/src/ident_build/build.rs
@@ -92,7 +92,7 @@ pub enum EmbeddedSource {
 
 impl MetadataPath for EmbeddedSource {
     fn metadata_path(&self) -> RelativePathBuf {
-        match dbg!(self) {
+        match self {
             package @ EmbeddedSource::Package(esp) => RelativePathBuf::from(format!(
                 "{}{}",
                 EmbeddedSourcePackage::EMBEDDED_BY_PREFIX,


### PR DESCRIPTION
An unwanted `dbg!` slipped in from #1314.