### PR TITLE
Scope namespaced var requirements to their package

### DIFF
--- a/crates/spk-cli/cmd-build/src/cmd_build_test/mod.rs
+++ b/crates/spk-cli/cmd-build/src/cmd_build_test/mod.rs
@@ -859,6 +859,97 @@ build:
     .expect("Expected build of mypkg to succeed");
 }
 
+#[spfstest]
+#[rstest]
+#[case::cli("cli")]
+#[case::checks("checks")]
+#[case::resolvo("resolvo")]
+#[tokio::test]
+async fn test_build_var_name_collides_with_package_name(
+    tmpdir: tempfile::TempDir,
+    #[case] solver_to_run: &str,
+) {
+    let _rt = spfs_runtime().await;
+
+    build_package!(
+        tmpdir,
+        "demo.spk.yaml",
+        br#"
+api: v0/package
+pkg: demo/1.0.0
+
+build:
+  options:
+    - var: samenameaspkg/true
+  script:
+    - "true"
+"#,
+        solver_to_run
+    );
+
+    build_package!(
+        tmpdir,
+        "samenameaspkg.spk.yaml",
+        br#"
+api: v0/package
+pkg: samenameaspkg/1.2.3
+
+build:
+  script:
+    - "true"
+"#,
+        solver_to_run
+    );
+
+    build_package!(
+        tmpdir,
+        "middle.spk.yaml",
+        br#"
+api: v0/package
+pkg: middle/1.0.0
+
+build:
+  options:
+    - pkg: demo
+    - var: demo.samenameaspkg/true
+  script:
+    - "true"
+
+install:
+  requirements:
+    - pkg: demo
+      fromBuildEnv: true
+    - var: demo.samenameaspkg/true
+"#,
+        solver_to_run
+    );
+
+    // Building `consumer` brings both the `samenameaspkg` package and the
+    // `middle` package (which carries an install requirement for the
+    // namespaced var `demo.samenameaspkg/true`) into the same environment.
+    // A namespaced var is scoped to its package, so the `demo.samenameaspkg`
+    // var must not be confused with the unrelated `samenameaspkg` package's
+    // version. All solvers should agree that this build succeeds.
+    try_build_package!(
+        tmpdir,
+        "consumer.spk.yaml",
+        br#"
+api: v0/package
+pkg: consumer/1.0.0
+
+build:
+  options:
+    - pkg: samenameaspkg
+    - pkg: middle
+  script:
+    - "true"
+"#,
+        solver_to_run
+    )
+    .1
+    .expect("Expected build of consumer to succeed");
+}
+
 #[rstest]
 #[case::cli("cli")]
 #[case::checks("checks")]

--- a/crates/spk-solve/crates/validation/src/validators/var_requirements.rs
+++ b/crates/spk-solve/crates/validation/src/validators/var_requirements.rs
@@ -22,9 +22,22 @@ impl ValidatorT for VarRequirementsValidator {
         for request in spec.runtime_requirements().iter() {
             if let RequestWithOptions::Var(request) = request {
                 for (name, value) in options.iter() {
-                    let is_not_requested = *name != request.var;
-                    let is_not_same_base = request.var.base_name() != name.base_name();
-                    if is_not_requested && is_not_same_base {
+                    // Determine whether this option is relevant to the var
+                    // request. An option is relevant if it names the exact
+                    // same var, or — for un-namespaced (global) requests —
+                    // if it shares the same base name.
+                    //
+                    // A namespaced request such as `demo.samenameaspkg` is
+                    // scoped to its package and must match exactly; it must
+                    // not be satisfied or contradicted by an unrelated option
+                    // that merely shares its base name, such as the version of
+                    // a package named `samenameaspkg`. This mirrors the resolvo
+                    // solver, which scopes namespaced var requests to their
+                    // package and treats global vars as distinct.
+                    let is_exact_match = *name == request.var;
+                    let is_global_base_match = request.var.namespace().is_none()
+                        && request.var.base_name() == name.base_name();
+                    if !is_exact_match && !is_global_base_match {
                         continue;
                     }
                     if value.is_empty() {

--- a/cspell.json
+++ b/cspell.json
@@ -669,6 +669,7 @@
     "rustup",
     "rwlock",
     "safeseh",
+    "samenameaspkg",
     "sccache",
     "sched",
     "sddl",


### PR DESCRIPTION
## Summary

- Fixes a bug in the step-based solvers (cli, checks) where `VarRequirementsValidator` matched options by **base name**, so a namespaced var install requirement such as `demo.samenameaspkg/true` collided with an unrelated option sharing that base name — e.g. the version of a package named `samenameaspkg`, stored in the option map as `samenameaspkg=~1.2.3`. This caused valid builds to be incorrectly rejected.
- Makes the step solver consistent with resolvo: a namespaced var is scoped to its package, so only an exactly-matching option is relevant; base-name matching now applies **only** to un-namespaced (global) requests.
- Adds a test (`test_build_var_name_collides_with_package_name`) run against all three solvers (cli, checks, resolvo); the consumer build now succeeds for all of them.

## Root cause

`crates/spk-solve/crates/validation/src/validators/var_requirements.rs` skipped an option only when it was neither the exact request nor a base-name match:

```rust
let is_not_requested = *name != request.var;
let is_not_same_base = request.var.base_name() != name.base_name();
if is_not_requested && is_not_same_base {
    continue;
}
```

So `demo.samenameaspkg` (a namespaced var) matched the option `samenameaspkg` (a package version) because they share the base name.

## Fix

An option is relevant only when it names the exact same var, or — for un-namespaced (global) requests — when it shares the same base name. Namespaced requests must match exactly. This mirrors resolvo, which scopes namespaced var requests to their package (`is_satisfied_by(&package)`) and treats global vars as distinct pseudo-packages.

## Test plan

- [x] `cargo test -p spk-cmd-build test_build_var_name_collides_with_package_name` passes for cli, checks, and resolvo
- [x] `cargo test -p spk-cmd-build test_build_package_with_required_var_dependency` still passes (legitimate namespaced var requirement)
- [x] `cargo test -p spk-solve-validation` and `cargo test -p spk-solve var` pass (41 solver var tests, both solvers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)