### PR TITLE
Indexes 10: Adds index update listeners and Indexer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4377,6 +4377,7 @@ name = "spk-cli-group1"
 version = "0.44.0"
 dependencies = [
  "async-trait",
+ "chrono",
  "clap 4.5.47",
  "clap_complete",
  "colored",
@@ -4405,6 +4406,7 @@ name = "spk-cli-group2"
 version = "0.44.0"
 dependencies = [
  "async-trait",
+ "chrono",
  "clap 4.5.47",
  "colored",
  "futures",
@@ -4686,6 +4688,7 @@ dependencies = [
  "itertools 0.14.0",
  "miette",
  "spk-cli-common",
+ "spk-config",
  "spk-schema",
  "spk-storage",
  "tracing",
@@ -4727,6 +4730,7 @@ dependencies = [
  "spfs",
  "thiserror 1.0.69",
  "tokio",
+ "tracing",
  "whoami",
 ]
 
@@ -5040,6 +5044,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "bytes",
+ "chrono",
  "colored",
  "dashmap",
  "data-encoding",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2306,6 +2306,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "millisecond"
+version = "0.15.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63befb9f9db85caa92fe71eb3e7a42d76b90b38914f0356983d726442825770"
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3267,9 +3273,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3279,9 +3285,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.10"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5059,6 +5065,7 @@ dependencies = [
  "libc",
  "memmap2",
  "miette",
+ "millisecond",
  "nom",
  "nom-supreme",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ itertools = "0.14"
 libc = "0.2.172"
 memmap2 = "0.9.10"
 miette = "7.0"
+millisecond = "0.15.12"
 nix = { version = "0.29", features = ["mount", "sched", "user"] }
 nom = "7.1"
 nom-supreme = "0.8"

--- a/crates/spk-cli/cmd-repo/Cargo.toml
+++ b/crates/spk-cli/cmd-repo/Cargo.toml
@@ -18,6 +18,7 @@ async-trait = { workspace = true }
 clap = { workspace = true }
 itertools = { workspace = true }
 spk-cli-common = { workspace = true }
+spk-config = { workspace = true }
 spk-schema = { workspace = true }
 spk-storage = { workspace = true }
 tracing = { workspace = true }

--- a/crates/spk-cli/cmd-repo/src/cmd_repo.rs
+++ b/crates/spk-cli/cmd-repo/src/cmd_repo.rs
@@ -10,7 +10,13 @@ use itertools::Itertools;
 use miette::{Context, Result};
 use spk_cli_common::{CommandArgs, Run, flags};
 use spk_schema::ident::OptVersionIdent;
-use spk_storage::{self as storage, FlatBufferRepoIndex, RepositoryHandle, RepositoryIndexMut};
+use spk_storage::{
+    self as storage,
+    FlatBufferRepoIndex,
+    RepositoryHandle,
+    RepositoryIndexMut,
+    run_index_update_server,
+};
 use storage::Repository;
 
 /// Perform repository-level actions and maintenance
@@ -69,6 +75,19 @@ pub enum RepoCommand {
         #[clap(long, name = "PACKAGE/VERSION")]
         update: Vec<String>,
     },
+    /// Run a configured index updating server (an indexer).
+    ///
+    /// An indexer will listen for package events, for a particular
+    /// repository, from a package updates topic/queue in a messaging
+    /// channel, and kicks off index updates as packages are published
+    /// or modified. The indexer will send heartbeat messages to the
+    /// index updates topic/queue.
+    Indexer {
+        /// Name of the configured indexer to run. Indexers must be
+        /// configured in the SPK config file before they can be used.
+        #[clap(long)]
+        name: String,
+    },
 }
 
 impl RepoCommand {
@@ -86,7 +105,7 @@ impl RepoCommand {
                 Ok(1)
             }
 
-            // spk repo index ...
+            // spk repo index -r ...
             Self::Index { repo, update } => {
                 // Generate or update an index in a repo. The repo must
                 // be the underlying repo and not an indexed repo. So as
@@ -184,6 +203,19 @@ impl RepoCommand {
                     );
                 }
 
+                Ok(0)
+            }
+            // spk repo indexer --name ...
+            Self::Indexer { name } => {
+                // Run a long running process that listens for package
+                // update events and kicks off index updates to pick
+                // up those package changes.
+                if let Some(indexer_config) = spk_config::get_indexer_config(name) {
+                    tracing::info!("Running the '{}' indexer ...", name);
+                    run_index_update_server(name.to_string(), &indexer_config).await?;
+                } else {
+                    tracing::error!("Unable to find an indexer configuration called '{name}'");
+                }
                 Ok(0)
             }
         }

--- a/crates/spk-cli/group1/Cargo.toml
+++ b/crates/spk-cli/group1/Cargo.toml
@@ -18,6 +18,7 @@ sentry = ["spk-solve/sentry"]
 [dependencies]
 miette = { workspace = true, features = ["fancy"] }
 async-trait = { workspace = true }
+chrono = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
 colored = { workspace = true }

--- a/crates/spk-cli/group1/src/cmd_deprecate.rs
+++ b/crates/spk-cli/group1/src/cmd_deprecate.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::io::Write;
 use std::sync::Arc;
 
-use chrono::{DateTime, Utc};
+use chrono::Utc;
 use clap::Args;
 use colored::Colorize;
 use miette::Result;
@@ -336,10 +336,9 @@ pub(crate) async fn change_deprecation_state(
 
     // Wait for the index(es) to be updated before finishing. This
     // might involve waiting on several repos.
-    let utc_now: DateTime<Utc> = Utc::now();
-    let deprecation_change_time = utc_now.timestamp();
+    let deprecation_change_time = Utc::now();
     for (_repo_name, repo) in updated_repos.iter() {
-        repo.wait_for_index_to_update(deprecation_change_time)
+        repo.wait_for_index_to_update(&deprecation_change_time)
             .await?;
     }
 

--- a/crates/spk-cli/group1/src/cmd_deprecate.rs
+++ b/crates/spk-cli/group1/src/cmd_deprecate.rs
@@ -2,15 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/spkenv/spk
 
+use std::collections::HashMap;
 use std::io::Write;
 use std::sync::Arc;
 
+use chrono::{DateTime, Utc};
 use clap::Args;
 use colored::Colorize;
 use miette::Result;
 use spk_cli_common::{CommandArgs, Run, flags};
 use spk_schema::foundation::format::FormatIdent;
 use spk_schema::ident::{AnyIdent, parse_ident};
+use spk_schema::name::RepositoryNameBuf;
 use spk_schema::{Deprecate, DeprecateMut, Package, Recipe, Spec, SpecRecipe};
 use spk_storage as storage;
 
@@ -298,6 +301,10 @@ pub(crate) async fn change_deprecation_state(
     // Change all the item's statuses to the correct state based on
     // the action, unless they are already in that state.
     let new_status = action == ChangeAction::Deprecate;
+
+    let mut updated_repos: HashMap<RepositoryNameBuf, Arc<&storage::RepositoryHandle>> =
+        HashMap::new();
+
     for (mut target, repo_name, repo) in to_action.into_iter() {
         let fmt = target.ident().format_ident();
 
@@ -318,10 +325,24 @@ pub(crate) async fn change_deprecation_state(
         }
         match target {
             DeprecationTarget::Recipe(r) => repo.force_publish_recipe(&r).await?,
-            DeprecationTarget::Package(p) => repo.update_package(&p).await?,
+            DeprecationTarget::Package(p) => {
+                repo.update_package(&p).await?;
+                // Record the repo that had the change
+                updated_repos.insert(repo.name().into(), repo.clone());
+            }
         }
         tracing::info!(repo=%repo_name, "{} {fmt}", action.as_past_tense());
     }
+
+    // Wait for the index(es) to be updated before finishing. This
+    // might involve waiting on several repos.
+    let utc_now: DateTime<Utc> = Utc::now();
+    let deprecation_change_time = utc_now.timestamp();
+    for (_repo_name, repo) in updated_repos.iter() {
+        repo.wait_for_index_to_update(deprecation_change_time)
+            .await?;
+    }
+
     Ok(0)
 }
 enum DeprecationTarget {

--- a/crates/spk-cli/group2/Cargo.toml
+++ b/crates/spk-cli/group2/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 [dependencies]
 miette = { workspace = true, features = ["fancy"] }
 async-trait = { workspace = true }
+chrono = { workspace = true }
 clap = { workspace = true }
 colored = { workspace = true }
 futures = { workspace = true }

--- a/crates/spk-cli/group2/src/cmd_publish.rs
+++ b/crates/spk-cli/group2/src/cmd_publish.rs
@@ -3,12 +3,14 @@
 // https://github.com/spkenv/spk
 
 use std::sync::Arc;
+use std::time::Instant;
 
+use chrono::{DateTime, Utc};
 use clap::Args;
 use miette::Result;
 use spk_cli_common::{CommandArgs, PublishLabel, Publisher, Run};
 use spk_schema::AnyIdent;
-use spk_storage as storage;
+use spk_storage::{self as storage};
 
 #[cfg(test)]
 #[path = "./cmd_publish_test.rs"]
@@ -57,13 +59,17 @@ impl Run for Publish {
     type Output = i32;
 
     async fn run(&mut self) -> Result<Self::Output> {
+        let start = Instant::now();
+
         let (source, target) = tokio::try_join!(storage::local_repository(), async {
             Ok(Into::<storage::RepositoryHandle>::into(
                 storage::remote_repository(&self.target_repo).await?,
             ))
         })?;
 
-        let publisher = Publisher::new(Arc::new(source.into()), Arc::new(target))
+        let destination = Arc::new(target);
+
+        let publisher = Publisher::new(Arc::new(source.into()), destination.clone())
             .skip_source_packages(self.no_source)
             .allow_existing_with_label(self.allow_existing_with_label.clone())
             .force(self.force);
@@ -77,6 +83,17 @@ impl Run for Publish {
             tracing::warn!(
                 "No packages were published, did you forget to specify a version number? (spk publish my-package/1.0.2)"
             )
+        } else {
+            tracing::debug!(
+                "Published {} packages in {} seconds",
+                published.len(),
+                start.elapsed().as_secs()
+            );
+
+            // Wait for the index to be updated before finishing
+            let utc_now: DateTime<Utc> = Utc::now();
+            let publish_ended = utc_now.timestamp();
+            destination.wait_for_index_to_update(publish_ended).await?;
         }
 
         tracing::info!("done");

--- a/crates/spk-cli/group2/src/cmd_publish.rs
+++ b/crates/spk-cli/group2/src/cmd_publish.rs
@@ -5,7 +5,7 @@
 use std::sync::Arc;
 use std::time::Instant;
 
-use chrono::{DateTime, Utc};
+use chrono::Utc;
 use clap::Args;
 use miette::Result;
 use spk_cli_common::{CommandArgs, PublishLabel, Publisher, Run};
@@ -91,9 +91,8 @@ impl Run for Publish {
             );
 
             // Wait for the index to be updated before finishing
-            let utc_now: DateTime<Utc> = Utc::now();
-            let publish_ended = utc_now.timestamp();
-            destination.wait_for_index_to_update(publish_ended).await?;
+            let publish_ended = Utc::now();
+            destination.wait_for_index_to_update(&publish_ended).await?;
         }
 
         tracing::info!("done");

--- a/crates/spk-cli/group2/src/cmd_remove.rs
+++ b/crates/spk-cli/group2/src/cmd_remove.rs
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/spkenv/spk
 
+use std::collections::HashMap;
 use std::io::Write;
 
+use chrono::{DateTime, Utc};
 use clap::Args;
 use colored::Colorize;
 use itertools::Itertools;
@@ -11,6 +13,7 @@ use miette::{IntoDiagnostic, Result};
 use spk_cli_common::{CommandArgs, Run, flags};
 use spk_schema::foundation::format::FormatIdent;
 use spk_schema::ident::parse_ident;
+use spk_schema::name::RepositoryNameBuf;
 use spk_schema::spec_ops::WithVersion;
 use spk_schema::{BuildIdent, VersionIdent};
 use spk_storage as storage;
@@ -43,6 +46,9 @@ impl Run for Remove {
             );
             return Ok(1);
         }
+
+        let mut updated_repos: HashMap<RepositoryNameBuf, storage::RepositoryHandle> =
+            HashMap::new();
 
         for name in &self.packages {
             if !name.contains('/') && !self.yes {
@@ -84,12 +90,23 @@ impl Run for Remove {
                             remove_all(repo_name, repo, &version).await?;
                         }
                         (version, Some(build)) => {
-                            remove_build(repo_name, repo, &version.into_build_ident(build)).await?;
+                            let ident = version.into_build_ident(build);
+                            remove_build(repo_name, repo, &ident).await?;
+
+                            updated_repos.insert(repo.name().into(), repo.clone());
                         }
                     }
                 }
             }
         }
+
+        // Wait for the index to be updated before finishing
+        let utc_now: DateTime<Utc> = Utc::now();
+        let remove_time = utc_now.timestamp();
+        for (_repo_name, repo) in updated_repos.iter() {
+            repo.wait_for_index_to_update(remove_time).await?;
+        }
+
         Ok(0)
     }
 }

--- a/crates/spk-cli/group2/src/cmd_remove.rs
+++ b/crates/spk-cli/group2/src/cmd_remove.rs
@@ -5,7 +5,7 @@
 use std::collections::HashMap;
 use std::io::Write;
 
-use chrono::{DateTime, Utc};
+use chrono::Utc;
 use clap::Args;
 use colored::Colorize;
 use itertools::Itertools;
@@ -88,6 +88,8 @@ impl Run for Remove {
                     match version.into_inner() {
                         (version, None) => {
                             remove_all(repo_name, repo, &version).await?;
+
+                            updated_repos.insert(repo.name().into(), repo.clone());
                         }
                         (version, Some(build)) => {
                             let ident = version.into_build_ident(build);
@@ -101,10 +103,9 @@ impl Run for Remove {
         }
 
         // Wait for the index to be updated before finishing
-        let utc_now: DateTime<Utc> = Utc::now();
-        let remove_time = utc_now.timestamp();
+        let remove_time = Utc::now();
         for (_repo_name, repo) in updated_repos.iter() {
-            repo.wait_for_index_to_update(remove_time).await?;
+            repo.wait_for_index_to_update(&remove_time).await?;
         }
 
         Ok(0)

--- a/crates/spk-config/Cargo.toml
+++ b/crates/spk-config/Cargo.toml
@@ -24,6 +24,7 @@ serde_json = { workspace = true }
 spfs = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+tracing = { workspace = true }
 whoami = { workspace = true }
 
 [dev-dependencies]

--- a/crates/spk-config/src/config.rs
+++ b/crates/spk-config/src/config.rs
@@ -265,9 +265,9 @@ fn default_kafka_index_update_listener_recent_past_duration_ms() -> i64 {
 
 /// Helper for a default kafka index update listener's broker fetch
 /// timeout in seconds, when not specified in config file.
-fn default_kafka_index_update_listener_broker_fetch_timeout_s() -> u64 {
+fn default_kafka_index_update_listener_broker_fetch_timeout_ms() -> u64 {
     // 20 seconds
-    20
+    20 * 1000
 }
 
 /// Configuration for using Kafka as a message channel.
@@ -322,9 +322,9 @@ pub struct KafkaChannel {
     pub index_update_listener_recent_past_duration_ms: i64,
 
     /// The data fetching timeout used by an index update listener
-    /// when querying a kafka broker, in seconds.
-    #[serde(default = "default_kafka_index_update_listener_broker_fetch_timeout_s")]
-    pub index_update_listener_broker_fetch_timeout_s: u64,
+    /// when querying a kafka broker, in milliseconds.
+    #[serde(default = "default_kafka_index_update_listener_broker_fetch_timeout_ms")]
+    pub index_update_listener_broker_fetch_timeout_ms: u64,
 }
 
 /// Types of message channels.

--- a/crates/spk-config/src/config.rs
+++ b/crates/spk-config/src/config.rs
@@ -317,7 +317,7 @@ pub struct KafkaChannel {
 
     /// How far back in time counts as recent for an index update
     /// listener when it is trying to workout if an indexer is running
-    /// for the repository index it wants to know about, in seconds.
+    /// for the repository index it wants to know about, in milliseconds.
     #[serde(default = "default_kafka_index_update_listener_recent_past_duration_ms")]
     pub index_update_listener_recent_past_duration_ms: i64,
 

--- a/crates/spk-config/src/config.rs
+++ b/crates/spk-config/src/config.rs
@@ -120,6 +120,14 @@ pub struct Index {
     /// Maximum number of times to try to get a write lock on the
     /// index data, for index generation and updates.
     pub lock_max_tries: u64,
+
+    /// Name of the configured messaging channel (see MessageChannel)
+    /// to send index status update messages too.
+    pub update_message_channel: String,
+
+    /// How often index generation and update processing should send
+    /// index update event messages.
+    pub update_event_send_freq_ms: u64,
 }
 
 impl Default for Index {
@@ -135,6 +143,9 @@ impl Default for Index {
             // for index writing.
             lock_sleep_seconds: 6,
             lock_max_tries: 5,
+            update_message_channel: String::from("kafka"),
+            // 5 seconds in milliseconds
+            update_event_send_freq_ms: 5000,
         }
     }
 }
@@ -204,28 +215,175 @@ pub struct HostOptions {
     pub distro_rules: HashMap<String, DistroRule>,
 }
 
-/// Helper for testing default kafka timeout ms when not specified in
-/// config
+/// Helper for the default kafka message channel name, when not
+/// specified in config.
+fn default_kafka_channel_name() -> String {
+    String::from("kafka")
+}
+
+/// Helper for a default kafka message timeout in ms, when not specified in
+/// config file.
 fn default_kafka_message_timeout_ms() -> u64 {
-    5000
+    // 5 seconds
+    5 * 1000
+}
+
+/// Helper for a default kafka producer queue timeout in ms, when not specified in
+/// config file.
+fn default_kafka_producer_queue_timeout_ms() -> u64 {
+    // 4 seconds
+    4 * 1000
+}
+
+/// Helper for a default kafka index update listener's timeout in ms,
+/// when not specified in config file.
+fn default_kafka_index_update_listener_timeout_ms() -> u64 {
+    // 10 seconds
+    10 * 1000
+}
+
+/// Helper for a default kafka index update listener's session timeout
+/// in ms, when not specified in config file.
+fn default_kafka_index_update_listener_session_timeout_ms() -> u64 {
+    // 10 seconds
+    10 * 1000
+}
+
+/// Helper for a default kafka index update listener's maximum polling
+/// timeout in ms, when not specified in config file.
+fn default_kafka_index_update_listener_max_polling_interval_ms() -> u64 {
+    // 10 seconds
+    10 * 1000
+}
+
+/// Helper for a default kafka index update listener's recent past
+/// duration amount in seconds, when not specified in config file.
+fn default_kafka_index_update_listener_recent_past_duration_ms() -> i64 {
+    // 2 minutes
+    2 * 60 * 1000
+}
+
+/// Helper for a default kafka index update listener's broker fetch
+/// timeout in seconds, when not specified in config file.
+fn default_kafka_index_update_listener_broker_fetch_timeout_s() -> u64 {
+    // 20 seconds
+    20
 }
 
 /// Configuration for using Kafka as a message channel.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct KafkaChannel {
+    /// Name of this configured messaging system. Used to distinguish
+    /// it from other configured messaging systems.
+    #[serde(default = "default_kafka_channel_name")]
+    pub name: String,
     /// List of brokers to connect to, specified as "hostname:port"
     pub brokers: Vec<String>,
+
     /// Topic name to push package updates to
     pub package_updates_topic_name: Option<String>,
-    /// Message timeout in milliseconds, defaults to 5000 ms (5 seconds)
+
+    /// Topic name to push index status updates to
+    pub index_updates_topic_name: Option<String>,
+
+    /// Names of the SPK repositories that can send package update
+    /// messages to the 'package_updates_topic_name'.
+    pub repo_names: Vec<String>,
+
+    /// Message sending timeout in milliseconds, defaults to
+    /// 5000 ms (5 seconds)
     #[serde(default = "default_kafka_message_timeout_ms")]
     pub message_timeout_ms: u64,
+
+    /// Producer sending queue timeout in milliseconds, defaults to
+    /// 4000 ms (4 seconds). This determines how to long retry for if
+    /// the producer queue is full.
+    #[serde(default = "default_kafka_producer_queue_timeout_ms")]
+    pub producer_queue_timeout_ms: u64,
+
+    /// How long an index update message listener should wait after
+    /// the last index update message before timing out and assuming
+    /// no more updates are coming. Defaults to 10000 ms (10 seconds)
+    #[serde(default = "default_kafka_index_update_listener_timeout_ms")]
+    pub index_update_listener_timeout_ms: u64,
+
+    /// The kafka session timeout for an index update listener in milliseconds
+    #[serde(default = "default_kafka_index_update_listener_session_timeout_ms")]
+    pub index_update_listener_session_timeout_ms: u64,
+
+    /// The maximum polling interval for an index update listener in milliseconds
+    #[serde(default = "default_kafka_index_update_listener_max_polling_interval_ms")]
+    pub index_update_listener_max_polling_interval_ms: u64,
+
+    /// How far back in time counts as recent for an index update
+    /// listener when it is trying to workout if an indexer is running
+    /// for the repository index it wants to know about, in seconds.
+    #[serde(default = "default_kafka_index_update_listener_recent_past_duration_ms")]
+    pub index_update_listener_recent_past_duration_ms: i64,
+
+    /// The data fetching timeout used by an index update listener
+    /// when querying a kafka broker, in seconds.
+    #[serde(default = "default_kafka_index_update_listener_broker_fetch_timeout_s")]
+    pub index_update_listener_broker_fetch_timeout_s: u64,
 }
 
 /// Types of message channels.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum MessageChannel {
     Kafka(KafkaChannel),
+}
+
+/// Helper for a default kafka indexer heartbeat frequency in ms when
+/// not specified in the config file.
+fn default_indexer_heartbeat_freq_ms() -> u64 {
+    // 1 minute
+    60 * 1000
+}
+
+/// Helper for a default kafka indexer session timeout in ms when
+/// not specified in the config file.
+fn default_indexer_session_timeout_ms() -> u64 {
+    // 2 minutes
+    120 * 1000
+}
+
+/// Helper for a default kafka indexer's maximum polling interval in
+/// ms, when not specified in the config file.
+fn default_indexer_max_polling_interval_ms() -> u64 {
+    // 24 hours
+    86400000
+}
+
+/// Configuration for an index update server (an indexer)
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Indexer {
+    /// Name of the configured message channel to use. The
+    /// MessageChannel must have a publish modification topic, an
+    /// index status update topic, and at least one repo name
+    /// configured.
+    pub message_channel_name: String,
+
+    /// SPK repository name to listen for package modifications about.
+    /// The name must be present in the configure MessageChannel's
+    /// list of repo names. The indexer will ignore package updates
+    /// for other repositories, and will only update the named
+    /// repository's index,
+    pub repo_name: String,
+
+    /// How frequently this indexer should send heartbeat messages to
+    /// the index status channel, when not updating an index. Defaults
+    /// to 60000 ms (1 minute). When updating an index it will send
+    /// index status messages more frequently.
+    #[serde(default = "default_indexer_heartbeat_freq_ms")]
+    pub heartbeat_freq_ms: u64,
+
+    /// Indexer's kafka session timeout in milliseconds
+    #[serde(default = "default_indexer_session_timeout_ms")]
+    pub session_timeout_ms: u64,
+
+    /// Indexer's kafka broker maximum polling interval in milliseconds
+    #[serde(default = "default_indexer_max_polling_interval_ms")]
+    pub max_polling_interval_ms: u64,
 }
 
 /// Configuration values for spk.
@@ -243,6 +401,7 @@ pub struct Config {
     pub cli: Cli,
     pub host_options: HostOptions,
     pub messaging: Vec<MessageChannel>,
+    pub indexers: HashMap<String, Indexer>,
 }
 
 impl Config {
@@ -281,6 +440,35 @@ pub fn get_config() -> Result<Arc<Config>> {
         .read()
         .map_err(|err| crate::Error::LockPoisonedRead(err.to_string()))?;
     Ok(Arc::clone(&*lock))
+}
+
+/// Get the current index config for the given repo name
+pub fn get_index_config(repo_name: &str) -> Index {
+    match get_config() {
+        Ok(config) => {
+            if let Some(repo_config) = config.repositories.get(repo_name) {
+                repo_config.index.clone()
+            } else {
+                Index::default()
+            }
+        }
+        Err(err) => {
+            tracing::warn!("Unable to read spk config file, using Index defaults, due to: {err}");
+            Index::default()
+        }
+    }
+}
+
+/// Get the index update server (indexer) config with the given name,
+/// if one exits.
+pub fn get_indexer_config(indexer_name: &str) -> Option<Indexer> {
+    match get_config() {
+        Ok(config) => config.indexers.get(indexer_name).cloned(),
+        Err(err) => {
+            tracing::warn!("Unable to read spk config file to get indexers config, due to: {err}");
+            None
+        }
+    }
 }
 
 /// Load the spk configuration from disk, even if it has already been loaded.

--- a/crates/spk-solve/crates/macros/src/lib.rs
+++ b/crates/spk-solve/crates/macros/src/lib.rs
@@ -25,6 +25,7 @@ macro_rules! make_repo {
     }};
     ( [ $( $spec:tt ),+ $(,)? ], options=$options:expr ) => {{
         tracing::debug!("creating in-memory repository");
+        spk_storage::fixtures::disable_messaging_channels_for_tests();
         let repo = spk_storage::RepositoryHandle::new_mem();
         let _opts = $options;
         $(

--- a/crates/spk-storage/Cargo.toml
+++ b/crates/spk-storage/Cargo.toml
@@ -24,6 +24,7 @@ async-trait = { workspace = true }
 async-stream = { workspace = true }
 bytes = { workspace = true }
 colored = { workspace = true }
+chrono = { workspace = true }
 dashmap = { workspace = true }
 data-encoding = "2.3.0"
 enum_dispatch = { workspace = true }
@@ -63,7 +64,7 @@ sys-info = "0.9.0"
 tar = "0.4.45"
 tempfile = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["rt"] }
+tokio = { workspace = true, features = ["rt", "signal"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 ulid = { workspace = true }

--- a/crates/spk-storage/Cargo.toml
+++ b/crates/spk-storage/Cargo.toml
@@ -41,6 +41,7 @@ itertools = { workspace = true }
 libc = { workspace = true }
 memmap2 = { workspace = true }
 miette = { workspace = true }
+millisecond = { workspace = true }
 nom = { workspace = true }
 nom-supreme = { workspace = true }
 once_cell = { workspace = true }

--- a/crates/spk-storage/src/fixtures.rs
+++ b/crates/spk-storage/src/fixtures.rs
@@ -96,9 +96,21 @@ pub async fn spfsrepo() -> TempRepo {
     make_repo(RepoKind::Spfs).await
 }
 
+pub fn disable_messaging_channels_for_tests() {
+    let config = spk_config::get_config().unwrap();
+
+    let mut test_config = (*config).clone();
+    // Removing all the MessageChannels from the config will stop all
+    // messaging.
+    test_config.messaging.clear();
+    test_config.make_current().unwrap();
+}
+
 /// Create a temporary repository of the desired flavor
 pub async fn make_repo(kind: RepoKind) -> TempRepo {
     tracing::trace!(?kind, "creating repo for test...");
+
+    disable_messaging_channels_for_tests();
 
     let tmpdir = tempfile::Builder::new()
         .prefix("spk-test-spfs-repo")

--- a/crates/spk-storage/src/lib.rs
+++ b/crates/spk-storage/src/lib.rs
@@ -28,6 +28,7 @@ pub use storage::{
     IndexedRepository,
     MemRepository,
     NameAndRepository,
+    PackageEvent,
     Repository,
     RepositoryHandle,
     RepositoryIndexMut,
@@ -40,5 +41,6 @@ pub use storage::{
     local_repository,
     pretty_print_filepath,
     remote_repository,
+    run_index_update_server,
 };
 pub use walker::{RepoWalker, RepoWalkerBuilder, RepoWalkerItem};

--- a/crates/spk-storage/src/storage/flatbuffer_index.rs
+++ b/crates/spk-storage/src/storage/flatbuffer_index.rs
@@ -608,7 +608,7 @@ impl FlatBufferRepoIndex {
     /// Gather packages and global vars from the given repos.
     async fn gather_all_data_from_repo(
         repos: &Vec<(String, crate::RepositoryHandle)>,
-        send_index_event_period_ms: Option<u64>,
+        send_index_event_period_ms: Option<Duration>,
         index_start_time: &DateTime<Utc>,
     ) -> miette::Result<(HashMap<PkgNameBuf, PackageInfo>, GlobalVarsInfo)> {
         if repos.len() != 1 {
@@ -659,7 +659,7 @@ impl FlatBufferRepoIndex {
         while let Some(item) = traversal.try_next().await? {
             // Periodically send an index in-progress event
             if let Some(send_next_event_delay_ms) = send_index_event_period_ms
-                && last_event_sent.elapsed().as_millis() > send_next_event_delay_ms.into()
+                && last_event_sent.elapsed() > send_next_event_delay_ms
             {
                 announce_index_event(
                     IndexEvent::InProgress,
@@ -763,7 +763,7 @@ impl FlatBufferRepoIndex {
         &self,
         repo: &crate::RepositoryHandle,
         package_versions: &[OptVersionIdent],
-        send_index_event_period: u64,
+        send_index_event_period: Duration,
         index_start_time: &DateTime<Utc>,
     ) -> miette::Result<(HashMap<PkgNameBuf, PackageInfo>, GlobalVarsInfo)> {
         let start = Instant::now();
@@ -825,7 +825,7 @@ impl FlatBufferRepoIndex {
         // pulling from the correct data source for each.
         for name in &package_names {
             // Periodically send an index in-progress event
-            if last_event_sent.elapsed().as_secs() > send_index_event_period {
+            if last_event_sent.elapsed() > send_index_event_period {
                 announce_index_event(
                     IndexEvent::InProgress,
                     repo.address(),
@@ -1437,7 +1437,9 @@ impl RepositoryIndexMut for FlatBufferRepoIndex {
         let index_config = spk_config::get_index_config(repo.name());
         let (packages, global_vars) = FlatBufferRepoIndex::gather_all_data_from_repo(
             repos,
-            Some(index_config.update_event_send_freq_ms),
+            Some(Duration::from_millis(
+                index_config.update_event_send_freq_ms,
+            )),
             &index_start_time,
         )
         .await?;
@@ -1516,7 +1518,7 @@ impl RepositoryIndexMut for FlatBufferRepoIndex {
             .gather_updates_from_repo(
                 repo,
                 package_versions,
-                index_config.update_event_send_freq_ms,
+                Duration::from_millis(index_config.update_event_send_freq_ms),
                 &index_start_time,
             )
             .await?;

--- a/crates/spk-storage/src/storage/flatbuffer_index.rs
+++ b/crates/spk-storage/src/storage/flatbuffer_index.rs
@@ -11,6 +11,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use chrono::{DateTime, Utc};
 use futures::TryStreamExt;
 use itertools::Itertools;
 use spk_schema::foundation::ident_component::Component;
@@ -353,7 +354,7 @@ impl FileLock {
     }
 
     /// Get the timestamp of the lock file's creation/locking time
-    pub fn locked_at_timestamp(&self) -> Result<i64> {
+    pub fn locked_at_datetime(&self) -> Result<DateTime<Utc>> {
         if self.has_been_deleted {
             return Err(Error::String(
                 "Unable to get lock timestamp: lock file has been deleted".to_string(),
@@ -363,16 +364,7 @@ impl FileLock {
         match std::fs::File::open(&self.lock_file) {
             Ok(f) => match std::fs::File::metadata(&f) {
                 Ok(metadata) => match metadata.modified() {
-                    Ok(time) => {
-                        // Turn it into seconds since epoch timestamp
-                        let duration = time
-                            .duration_since(std::time::UNIX_EPOCH)
-                            .expect("Lock file time should be after the start of the epoch");
-                        Ok(duration
-                            .as_secs()
-                            .try_into()
-                            .expect("timestamp since epoch should be convertible"))
-                    }
+                    Ok(time) => Ok(time.into()),
                     Err(mod_time_err) => Err(Error::String(format!(
                         "Unable to get time from lock file due to: {mod_time_err})"
                     ))),
@@ -565,11 +557,11 @@ impl FlatBufferRepoIndex {
         // Gathering data from an in-memory repo should not send
         // in-progress events with the index update start time.
         let do_not_send_index_events_periodically = None;
-        let placeholder_start_time = 0;
+        let placeholder_start_time = Utc::now();
         let (packages, global_vars) = FlatBufferRepoIndex::gather_all_data_from_repo(
             &repos,
             do_not_send_index_events_periodically,
-            placeholder_start_time,
+            &placeholder_start_time,
         )
         .await?;
 
@@ -617,7 +609,7 @@ impl FlatBufferRepoIndex {
     async fn gather_all_data_from_repo(
         repos: &Vec<(String, crate::RepositoryHandle)>,
         send_index_event_period_ms: Option<u64>,
-        index_start_time: i64,
+        index_start_time: &DateTime<Utc>,
     ) -> miette::Result<(HashMap<PkgNameBuf, PackageInfo>, GlobalVarsInfo)> {
         if repos.len() != 1 {
             return Err(Error::String(
@@ -772,7 +764,7 @@ impl FlatBufferRepoIndex {
         repo: &crate::RepositoryHandle,
         package_versions: &[OptVersionIdent],
         send_index_event_period: u64,
-        index_start_time: i64,
+        index_start_time: &DateTime<Utc>,
     ) -> miette::Result<(HashMap<PkgNameBuf, PackageInfo>, GlobalVarsInfo)> {
         let start = Instant::now();
 
@@ -1430,14 +1422,14 @@ impl RepositoryIndexMut for FlatBufferRepoIndex {
 
         // Lock the index file until the data has been updated
         let lock_guard = lock_index_file(repo).await?;
-        let index_start_time = lock_guard.locked_at_timestamp()?;
+        let index_start_time = lock_guard.locked_at_datetime()?;
 
         // Send start index event
         announce_index_event(
             IndexEvent::Started,
             repo.address(),
             repo.name(),
-            index_start_time,
+            &index_start_time,
         )
         .await?;
 
@@ -1446,7 +1438,7 @@ impl RepositoryIndexMut for FlatBufferRepoIndex {
         let (packages, global_vars) = FlatBufferRepoIndex::gather_all_data_from_repo(
             repos,
             Some(index_config.update_event_send_freq_ms),
-            index_start_time,
+            &index_start_time,
         )
         .await?;
 
@@ -1454,7 +1446,7 @@ impl RepositoryIndexMut for FlatBufferRepoIndex {
             IndexEvent::InProgress,
             repo.address(),
             repo.name(),
-            index_start_time,
+            &index_start_time,
         )
         .await?;
 
@@ -1466,7 +1458,7 @@ impl RepositoryIndexMut for FlatBufferRepoIndex {
             IndexEvent::InProgress,
             repo.address(),
             repo.name(),
-            index_start_time,
+            &index_start_time,
         )
         .await?;
 
@@ -1483,7 +1475,7 @@ impl RepositoryIndexMut for FlatBufferRepoIndex {
             IndexEvent::Completed,
             repo.address(),
             repo.name(),
-            index_start_time,
+            &index_start_time,
         )
         .await?;
 
@@ -1505,7 +1497,7 @@ impl RepositoryIndexMut for FlatBufferRepoIndex {
         // Lock the index file until the data has been updated
         tracing::debug!("Locking index file for update packages...");
         let lock_guard = lock_index_file(repo).await?;
-        let index_start_time = lock_guard.locked_at_timestamp()?;
+        let index_start_time = lock_guard.locked_at_datetime()?;
         tracing::debug!("Index file locked at: {index_start_time}");
 
         // Send start index event
@@ -1513,7 +1505,7 @@ impl RepositoryIndexMut for FlatBufferRepoIndex {
             IndexEvent::Started,
             repo.address(),
             repo.name(),
-            index_start_time,
+            &index_start_time,
         )
         .await?;
 
@@ -1525,7 +1517,7 @@ impl RepositoryIndexMut for FlatBufferRepoIndex {
                 repo,
                 package_versions,
                 index_config.update_event_send_freq_ms,
-                index_start_time,
+                &index_start_time,
             )
             .await?;
         tracing::debug!("Gathered updates from repo.");
@@ -1535,7 +1527,7 @@ impl RepositoryIndexMut for FlatBufferRepoIndex {
             IndexEvent::InProgress,
             repo.address(),
             repo.name(),
-            index_start_time,
+            &index_start_time,
         )
         .await?;
 
@@ -1550,7 +1542,7 @@ impl RepositoryIndexMut for FlatBufferRepoIndex {
             IndexEvent::InProgress,
             repo.address(),
             repo.name(),
-            index_start_time,
+            &index_start_time,
         )
         .await?;
 
@@ -1568,7 +1560,7 @@ impl RepositoryIndexMut for FlatBufferRepoIndex {
             IndexEvent::Completed,
             repo.address(),
             repo.name(),
-            index_start_time,
+            &index_start_time,
         )
         .await?;
 

--- a/crates/spk-storage/src/storage/flatbuffer_index.rs
+++ b/crates/spk-storage/src/storage/flatbuffer_index.rs
@@ -1430,7 +1430,7 @@ impl RepositoryIndexMut for FlatBufferRepoIndex {
 
         // Lock the index file until the data has been updated
         let lock_guard = lock_index_file(repo).await?;
-        let index_start_time = lock.locked_at_timestamp()?;
+        let index_start_time = lock_guard.locked_at_timestamp()?;
 
         // Send start index event
         announce_index_event(
@@ -1505,7 +1505,7 @@ impl RepositoryIndexMut for FlatBufferRepoIndex {
         // Lock the index file until the data has been updated
         tracing::debug!("Locking index file for update packages...");
         let lock_guard = lock_index_file(repo).await?;
-        let index_start_time = lock.locked_at_timestamp()?;
+        let index_start_time = lock_guard.locked_at_timestamp()?;
         tracing::debug!("Index file locked at: {index_start_time}");
 
         // Send start index event

--- a/crates/spk-storage/src/storage/flatbuffer_index.rs
+++ b/crates/spk-storage/src/storage/flatbuffer_index.rs
@@ -46,6 +46,7 @@ use spk_schema::{
 use tokio::io::AsyncReadExt;
 
 use super::RepositoryHandle;
+use crate::storage::messaging::{IndexEvent, announce_index_event};
 use crate::storage::{RepositoryIndex, RepositoryIndexMut};
 use crate::{Error, RepoWalkerBuilder, RepoWalkerItem, Result};
 
@@ -93,19 +94,7 @@ async fn lock_index_file(repo: &RepositoryHandle) -> Result<FileLock> {
     let pid = std::process::id();
     let lock_contents = format!("host: {hostname}\npid: {pid}");
 
-    let index_config = match spk_config::get_config() {
-        Ok(config) => {
-            if let Some(repo_config) = config.repositories.get(&repo.name().to_string()) {
-                repo_config.index.clone()
-            } else {
-                spk_config::Index::default()
-            }
-        }
-        Err(err) => {
-            tracing::warn!("Unable to read spk config file, using defaults, due to: {err}");
-            spk_config::Index::default()
-        }
-    };
+    let index_config = spk_config::get_index_config(repo.name());
 
     FileLock::new(
         filepath,
@@ -362,6 +351,41 @@ impl FileLock {
         }
         Ok(())
     }
+
+    /// Get the timestamp of the lock file's creation/locking time
+    pub fn locked_at_timestamp(&self) -> Result<i64> {
+        if self.has_been_deleted {
+            return Err(Error::String(
+                "Unable to get lock timestamp: lock file has been deleted".to_string(),
+            ));
+        }
+
+        match std::fs::File::open(&self.lock_file) {
+            Ok(f) => match std::fs::File::metadata(&f) {
+                Ok(metadata) => match metadata.modified() {
+                    Ok(time) => {
+                        // Turn it into seconds since epoch timestamp
+                        let duration = time
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .expect("Lock file time should be after the start of the epoch");
+                        Ok(duration
+                            .as_secs()
+                            .try_into()
+                            .expect("timestamp since epoch should be convertible"))
+                    }
+                    Err(mod_time_err) => Err(Error::String(format!(
+                        "Unable to get time from lock file due to: {mod_time_err})"
+                    ))),
+                },
+                Err(metadata_err) => Err(Error::String(format!(
+                    "Unable to get metadata for lock file: {metadata_err})"
+                ))),
+            },
+            Err(open_err) => Err(Error::String(format!(
+                "Unknown to open the lock file to stat it: {open_err})"
+            ))),
+        }
+    }
 }
 
 impl Drop for FileLock {
@@ -538,8 +562,16 @@ impl FlatBufferRepoIndex {
         let name = repo.name();
         let repos = vec![(repo.name().to_string(), source_repo)];
 
-        let (packages, global_vars) =
-            FlatBufferRepoIndex::gather_all_data_from_repo(&repos).await?;
+        // Gathering data from an in-memory repo should not send
+        // in-progress events with the index update start time.
+        let do_not_send_index_events_periodically = None;
+        let placeholder_start_time = 0;
+        let (packages, global_vars) = FlatBufferRepoIndex::gather_all_data_from_repo(
+            &repos,
+            do_not_send_index_events_periodically,
+            placeholder_start_time,
+        )
+        .await?;
 
         tracing::info!(
             "'{name}' repo data gathered from memory in: {} secs",
@@ -584,6 +616,8 @@ impl FlatBufferRepoIndex {
     /// Gather packages and global vars from the given repos.
     async fn gather_all_data_from_repo(
         repos: &Vec<(String, crate::RepositoryHandle)>,
+        send_index_event_period_ms: Option<u64>,
+        index_start_time: i64,
     ) -> miette::Result<(HashMap<PkgNameBuf, PackageInfo>, GlobalVarsInfo)> {
         if repos.len() != 1 {
             return Err(Error::String(
@@ -614,13 +648,37 @@ impl FlatBufferRepoIndex {
 
         let package_names = HashSet::from_iter(repo.list_packages().await?);
 
+        announce_index_event(
+            IndexEvent::InProgress,
+            repo.address(),
+            repo.name(),
+            index_start_time,
+        )
+        .await?;
+
         let mut num_versions = 0;
         let mut num_builds = 0;
         let mut num_erroring_builds = 0;
         let mut num_deprecated_builds = 0;
 
+        let mut last_event_sent = Instant::now();
+
         let mut traversal = repo_walker.walk();
         while let Some(item) = traversal.try_next().await? {
+            // Periodically send an index in-progress event
+            if let Some(send_next_event_delay_ms) = send_index_event_period_ms
+                && last_event_sent.elapsed().as_millis() > send_next_event_delay_ms.into()
+            {
+                announce_index_event(
+                    IndexEvent::InProgress,
+                    repo.address(),
+                    repo.name(),
+                    index_start_time,
+                )
+                .await?;
+                last_event_sent = Instant::now();
+            }
+
             match item {
                 RepoWalkerItem::Version(version) => {
                     num_versions += 1;
@@ -675,6 +733,14 @@ impl FlatBufferRepoIndex {
             }
         }
 
+        announce_index_event(
+            IndexEvent::InProgress,
+            repo.address(),
+            repo.name(),
+            index_start_time,
+        )
+        .await?;
+
         // Debugging and logging
         let mut vars: Vec<String> = global_vars.keys().map(|k| k.to_string()).collect();
         vars.sort();
@@ -687,6 +753,14 @@ impl FlatBufferRepoIndex {
             global_vars.keys().len()
         );
 
+        announce_index_event(
+            IndexEvent::InProgress,
+            repo.address(),
+            repo.name(),
+            index_start_time,
+        )
+        .await?;
+
         Ok((packages, global_vars))
     }
 
@@ -697,6 +771,8 @@ impl FlatBufferRepoIndex {
         &self,
         repo: &crate::RepositoryHandle,
         package_versions: &[OptVersionIdent],
+        send_index_event_period: u64,
+        index_start_time: i64,
     ) -> miette::Result<(HashMap<PkgNameBuf, PackageInfo>, GlobalVarsInfo)> {
         let start = Instant::now();
 
@@ -751,9 +827,23 @@ impl FlatBufferRepoIndex {
         let mut num_versions = 0;
         let mut num_builds = 0;
 
+        let mut last_event_sent = start;
+
         // Process the packages, checking for the ones to update and
         // pulling from the correct data source for each.
         for name in &package_names {
+            // Periodically send an index in-progress event
+            if last_event_sent.elapsed().as_secs() > send_index_event_period {
+                announce_index_event(
+                    IndexEvent::InProgress,
+                    repo.address(),
+                    repo.name(),
+                    index_start_time,
+                )
+                .await?;
+                last_event_sent = Instant::now();
+            }
+
             // Get the current versions of the packages to update from
             // the repository not the index, to account for any
             // deleted, updated, or newly published versions.
@@ -1334,15 +1424,51 @@ impl RepositoryIndexMut for FlatBufferRepoIndex {
             .into());
         }
         let repo = &repos[0].1;
+        // Ensure any direct repo access gets the latest data from the
+        // repo itself, not any caches it might have.
+        repo.clear_caches();
 
         // Lock the index file until the data has been updated
         let lock_guard = lock_index_file(repo).await?;
+        let index_start_time = lock.locked_at_timestamp()?;
 
-        let (packages, global_vars) = FlatBufferRepoIndex::gather_all_data_from_repo(repos).await?;
+        // Send start index event
+        announce_index_event(
+            IndexEvent::Started,
+            repo.address(),
+            repo.name(),
+            index_start_time,
+        )
+        .await?;
+
+        // Get all the package data from the repository
+        let index_config = spk_config::get_index_config(repo.name());
+        let (packages, global_vars) = FlatBufferRepoIndex::gather_all_data_from_repo(
+            repos,
+            Some(index_config.update_event_send_freq_ms),
+            index_start_time,
+        )
+        .await?;
+
+        announce_index_event(
+            IndexEvent::InProgress,
+            repo.address(),
+            repo.name(),
+            index_start_time,
+        )
+        .await?;
 
         // Assemble the data into a flatbuffer index and save it
         let builder =
             FlatBufferRepoIndex::generate_index_builder(repo, packages, global_vars).await?;
+
+        announce_index_event(
+            IndexEvent::InProgress,
+            repo.address(),
+            repo.name(),
+            index_start_time,
+        )
+        .await?;
 
         let start = Instant::now();
         let _filepath = FlatBufferRepoIndex::save_index(&lock_guard, repo, &builder).await?;
@@ -1351,6 +1477,15 @@ impl RepositoryIndexMut for FlatBufferRepoIndex {
             repo.name(),
             start.elapsed().as_secs_f64()
         );
+
+        // Send end index event
+        announce_index_event(
+            IndexEvent::Completed,
+            repo.address(),
+            repo.name(),
+            index_start_time,
+        )
+        .await?;
 
         Ok(())
     }
@@ -1363,18 +1498,63 @@ impl RepositoryIndexMut for FlatBufferRepoIndex {
         repo: &crate::RepositoryHandle,
         package_versions: &[OptVersionIdent],
     ) -> miette::Result<()> {
+        // Ensure any direct repo access gets the latest data from the
+        // repo itself, not any caches it might have.
+        repo.clear_caches();
+
         // Lock the index file until the data has been updated
+        tracing::debug!("Locking index file for update packages...");
         let lock_guard = lock_index_file(repo).await?;
+        let index_start_time = lock.locked_at_timestamp()?;
+        tracing::debug!("Index file locked at: {index_start_time}");
+
+        // Send start index event
+        announce_index_event(
+            IndexEvent::Started,
+            repo.address(),
+            repo.name(),
+            index_start_time,
+        )
+        .await?;
 
         // Get the updated package data from the index and the repo
+        let index_config = spk_config::get_index_config(repo.name());
+        tracing::debug!("Gathering updates from repo ...");
         let (packages, global_vars) = self
-            .gather_updates_from_repo(repo, package_versions)
+            .gather_updates_from_repo(
+                repo,
+                package_versions,
+                index_config.update_event_send_freq_ms,
+                index_start_time,
+            )
             .await?;
+        tracing::debug!("Gathered updates from repo.");
+
+        // Send in-progress index event
+        announce_index_event(
+            IndexEvent::InProgress,
+            repo.address(),
+            repo.name(),
+            index_start_time,
+        )
+        .await?;
 
         // Assemble the data into a flatbuffer index and save it
+        tracing::debug!("Generating index builder...");
         let builder =
             FlatBufferRepoIndex::generate_index_builder(repo, packages, global_vars).await?;
+        tracing::debug!("Gathered index builder.");
 
+        // Send in-progress index event
+        announce_index_event(
+            IndexEvent::InProgress,
+            repo.address(),
+            repo.name(),
+            index_start_time,
+        )
+        .await?;
+
+        tracing::debug!("Saving update index ...");
         let start = Instant::now();
         let _filepath = FlatBufferRepoIndex::save_index(&lock_guard, repo, &builder).await?;
         tracing::info!(
@@ -1382,6 +1562,15 @@ impl RepositoryIndexMut for FlatBufferRepoIndex {
             repo.name(),
             start.elapsed().as_secs_f64()
         );
+
+        // Send competed index event
+        announce_index_event(
+            IndexEvent::Completed,
+            repo.address(),
+            repo.name(),
+            index_start_time,
+        )
+        .await?;
 
         Ok(())
     }

--- a/crates/spk-storage/src/storage/handle.rs
+++ b/crates/spk-storage/src/storage/handle.rs
@@ -4,6 +4,7 @@
 
 use std::path::PathBuf;
 
+use chrono::{DateTime, Utc};
 use spk_schema::{Spec, SpecRecipe};
 use variantly::Variantly;
 
@@ -91,7 +92,7 @@ impl RepositoryHandle {
     /// to be updated. This is used by package changing operations
     /// (publish, remove, un/deprecate) to wait until the index has
     /// been updated with their changes before finishing.
-    pub async fn wait_for_index_to_update(&self, update_time: i64) -> Result<()> {
+    pub async fn wait_for_index_to_update(&self, update_time: &DateTime<Utc>) -> Result<()> {
         listen_to_index_status_until_updated(self, update_time).await
     }
 }

--- a/crates/spk-storage/src/storage/handle.rs
+++ b/crates/spk-storage/src/storage/handle.rs
@@ -8,6 +8,7 @@ use spk_schema::{Spec, SpecRecipe};
 use variantly::Variantly;
 
 use super::Repository;
+use super::messaging::listen_to_index_status_until_updated;
 use crate::{Error, Result};
 
 type Handle = dyn Repository<Recipe = SpecRecipe, Package = Spec>;
@@ -74,6 +75,24 @@ impl RepositoryHandle {
                 Box::pin(indexed_repo.wrapped_repo_index_location_path()).await
             }
         }
+    }
+
+    /// Clear any internal caches the repository has
+    pub fn clear_caches(&self) {
+        match self {
+            Self::SPFS(spfs_repo) => spfs_repo.invalidate_caches(),
+            _ => {
+                // The other kinds of repository do not have and caches
+            }
+        }
+    }
+
+    /// Wait for the index associated with this repo, if there is one,
+    /// to be updated. This is used by package changing operations
+    /// (publish, remove, un/deprecate) to wait until the index has
+    /// been updated with their changes before finishing.
+    pub async fn wait_for_index_to_update(&self, update_time: i64) -> Result<()> {
+        listen_to_index_status_until_updated(self, update_time).await
     }
 }
 

--- a/crates/spk-storage/src/storage/messaging/kafka.rs
+++ b/crates/spk-storage/src/storage/messaging/kafka.rs
@@ -10,6 +10,7 @@ use std::time::Duration;
 use chrono::{DateTime, Utc};
 use futures::StreamExt;
 use itertools::Itertools;
+use millisecond::prelude::*;
 use once_cell::sync::Lazy;
 use rdkafka::consumer::{CommitMode, Consumer, StreamConsumer};
 use rdkafka::error::KafkaError;
@@ -37,9 +38,6 @@ use crate::{Error, FlatBufferRepoIndex, RepositoryHandle, RepositoryIndexMut, Re
 /// Number of milliseconds to sleep while waiting for next message,
 /// when listening for new messages.
 const LISTEN_YIELD_SLEEP_TIME: Duration = Duration::from_millis(100);
-
-/// Number of milliseconds in a second, used in time conversions
-const NUM_MS_IN_ONE_SECOND: u64 = 1000;
 
 type ProducersByBrokers = HashMap<Vec<String>, std::result::Result<FutureProducer, KafkaError>>;
 
@@ -434,9 +432,9 @@ pub(crate) async fn listen_to_index_status_updates(
                     // to the index updating process and stop waiting.
                     time_since_last_message += LISTEN_YIELD_SLEEP_TIME.as_millis();
                     if time_since_last_message >= kafka_channel.index_update_listener_timeout_ms.into() {
-                        tracing::warn!("Index updates  consumer timed out after {} seconds. The index may not have been updated.",
-                                       kafka_channel.index_update_listener_timeout_ms / NUM_MS_IN_ONE_SECOND
-                        );
+                        let ms = Millisecond::from_millis(kafka_channel.index_update_listener_timeout_ms);
+                        let time_description = ms.pretty_with(MillisecondOption::long());
+                        tracing::warn!("Index updates consumer timed out after {time_description}. The index may not have been updated.");
                         running.store(false, std::sync::atomic::Ordering::Relaxed);
                     }
 

--- a/crates/spk-storage/src/storage/messaging/kafka.rs
+++ b/crates/spk-storage/src/storage/messaging/kafka.rs
@@ -36,7 +36,7 @@ use crate::{Error, FlatBufferRepoIndex, RepositoryHandle, RepositoryIndexMut, Re
 
 /// Number of milliseconds to sleep while waiting for next message,
 /// when listening for new messages.
-const LISTEN_YIELD_SLEEP_TIME: u64 = 100;
+const LISTEN_YIELD_SLEEP_TIME: Duration = Duration::from_millis(100);
 
 /// Number of milliseconds in a second, used in time conversions
 const NUM_MS_IN_ONE_SECOND: u64 = 1000;
@@ -120,7 +120,7 @@ pub(crate) async fn announce_index_event(
     event: IndexEvent,
     to: &url::Url,
     repo_name: &RepositoryName,
-    index_start_time: i64,
+    index_start_time: &DateTime<Utc>,
 ) -> Result<()> {
     // Only send a message if the index updates topic is configured
     let Some(topic_name) = kafka_channel.index_updates_topic_name.as_ref() else {
@@ -158,7 +158,7 @@ pub(crate) async fn announce_index_event(
         event,
         repo: to.to_string(),
         name: repo_name.to_string(),
-        start: index_start_time,
+        start: index_start_time.timestamp(),
     };
 
     // Send the index update message
@@ -204,7 +204,7 @@ fn setup_running_interrupt_handling() -> Arc<AtomicBool> {
                     eprintln!("Received SIGQUIT, shutting down...");
                 }
             }
-            running.store(false, std::sync::atomic::Ordering::SeqCst);
+            running.store(false, std::sync::atomic::Ordering::Relaxed);
         });
     }
     running
@@ -274,7 +274,7 @@ fn set_offsets_to_one_before_the_latest_message(
 /// messages.
 pub(crate) async fn listen_to_index_status_updates(
     kafka_channel: &KafkaChannel,
-    min_update_time: i64,
+    min_update_time: &DateTime<Utc>,
     repo: &RepositoryHandle,
 ) -> Result<()> {
     // Only subscribe to index update messages if the index updates topic is configured
@@ -336,7 +336,7 @@ pub(crate) async fn listen_to_index_status_updates(
         consumer.clone(),
         topic_name,
         "index updates".to_string(),
-        kafka_channel.index_update_listener_broker_fetch_timeout_s,
+        kafka_channel.index_update_listener_broker_fetch_timeout_ms,
     )?;
 
     // Set up signal handlers to stop if interrupted
@@ -358,7 +358,7 @@ pub(crate) async fn listen_to_index_status_updates(
 
     let mut stream = consumer.stream();
 
-    while running.load(std::sync::atomic::Ordering::SeqCst) {
+    while running.load(std::sync::atomic::Ordering::Relaxed) {
         tokio::select! {
             maybe_message = stream.next() => {
                 match maybe_message {
@@ -388,14 +388,14 @@ pub(crate) async fn listen_to_index_status_updates(
                             time_since_last_message = 0;
                             tracing::debug!("Read index update message: {index_update:?}");
 
-                            if index_update.start >= min_update_time {
-                                tracing::debug!("Message is from an index update that started after the min_update_time: {}",  index_update.start - min_update_time);
+                            if index_update.start >= min_update_time.timestamp() {
+                                tracing::debug!("Message is from an index update that started after the min_update_time: {}",  index_update.start - min_update_time.timestamp());
 
                                 if repo.address().as_str() == index_update.repo {
                                     // The message is for correct repository
                                     if index_update.event.is_completed() {
                                         // And the index has been updated. So this can stop listening now.
-                                        running.store(false, std::sync::atomic::Ordering::SeqCst);
+                                        running.store(false, std::sync::atomic::Ordering::Relaxed);
                                         tracing::debug!("Recent index update completed. Stopping waiting: '{}'", index_update.event);
                                         break;
                                     }
@@ -403,7 +403,7 @@ pub(crate) async fn listen_to_index_status_updates(
                             } else {
                                 // This message is about an older
                                 // index update than we are interested in.
-                                tracing::debug!("Index update message is not for recent enough update: {}",  index_update.start - min_update_time);
+                                tracing::debug!("Index update message is not for recent enough update: {}",  index_update.start - min_update_time.timestamp());
                             }
                         }
                     },
@@ -416,25 +416,25 @@ pub(crate) async fn listen_to_index_status_updates(
                     }
                 }
             }
-            _ = tokio::time::sleep(Duration::from_millis(LISTEN_YIELD_SLEEP_TIME)) => {
+            _ = tokio::time::sleep(LISTEN_YIELD_SLEEP_TIME) => {
                 // Yield periodically so interrupting is responsive.
                 if there_is_a_recent_message {
                     // If enough time has passed since the last recent
                     // message was read, then assume something has happened
                     // to the index updating process and stop waiting.
-                    time_since_last_message += LISTEN_YIELD_SLEEP_TIME;
-                    if time_since_last_message >= kafka_channel.index_update_listener_timeout_ms {
+                    time_since_last_message += LISTEN_YIELD_SLEEP_TIME.as_millis();
+                    if time_since_last_message >= kafka_channel.index_update_listener_timeout_ms.into() {
                         tracing::warn!("Index updates  consumer timed out after {} seconds. The index may not have been updated.",
                                        kafka_channel.index_update_listener_timeout_ms / NUM_MS_IN_ONE_SECOND
                         );
-                        running.store(false, std::sync::atomic::Ordering::SeqCst);
+                        running.store(false, std::sync::atomic::Ordering::Relaxed);
                     }
 
                 } else {
                     // Without a recent enough message, assume the indexer is down
                     // and stop waiting for the index to update.
                     tracing::warn!("Index updates consumer cannot see a recent message. The indexer might be down. Not waiting for the index update.");
-                    running.store(false, std::sync::atomic::Ordering::SeqCst);
+                    running.store(false, std::sync::atomic::Ordering::Relaxed);
                 }
             }
         }
@@ -539,7 +539,7 @@ pub async fn listen_to_package_events_and_run_index_updates(
         indexer_name,
         // This does not have an index start time so
         // this is a placeholder.
-        0,
+        &Utc::now(),
     )
     .await?;
 
@@ -551,7 +551,7 @@ pub async fn listen_to_package_events_and_run_index_updates(
 
     let mut stream = consumer.stream();
 
-    while running.load(std::sync::atomic::Ordering::SeqCst) {
+    while running.load(std::sync::atomic::Ordering::Relaxed) {
         tokio::select! {
             maybe_message = stream.next() => {
                 match maybe_message {
@@ -623,7 +623,7 @@ pub async fn listen_to_package_events_and_run_index_updates(
                     }
                 }
             }
-            _ = tokio::time::sleep(Duration::from_millis(LISTEN_YIELD_SLEEP_TIME)) => {
+            _ = tokio::time::sleep(LISTEN_YIELD_SLEEP_TIME) => {
                 // Yield periodically so interrupting is responsive,
                 // to send heartbeat message, and to set off index updates.
                 if !package_versions.is_empty() || generate_full_index {
@@ -690,15 +690,15 @@ pub async fn listen_to_package_events_and_run_index_updates(
 
                     // If enough time has passed since the last heartbeat,
                     // send another heartbeat message.
-                    time_since_last_message += LISTEN_YIELD_SLEEP_TIME;
-                    if time_since_last_message >= indexer_config.heartbeat_freq_ms {
+                    time_since_last_message += LISTEN_YIELD_SLEEP_TIME.as_millis();
+                    if time_since_last_message >= indexer_config.heartbeat_freq_ms.into() {
                         announce_index_event(kafka_channel,
                                              IndexEvent::IndexerHeartbeat,
                                              repo_to_index.address(),
                                              indexer_name,
                                              // This does not have an index start time so
                                              // this is a placeholder.
-                                             0
+                                             &Utc::now()
                         ).await?;
 
                         time_since_last_message = 0;

--- a/crates/spk-storage/src/storage/messaging/kafka.rs
+++ b/crates/spk-storage/src/storage/messaging/kafka.rs
@@ -55,6 +55,9 @@ pub(crate) async fn announce_package_event(
 ) -> Result<()> {
     // Only send a message if the package events topic is configured
     let Some(topic_name) = kafka_channel.package_updates_topic_name.as_ref() else {
+        tracing::debug!(
+            "Not sending package event: no 'package_updates_topic_name' configured for kafka messaging channel",
+        );
         return Ok(());
     };
 
@@ -104,6 +107,10 @@ pub(crate) async fn announce_package_event(
             ))
         })?;
 
+    tracing::debug!(
+        "Sent package update message: {event} - {repo_name} - {to} - {ident} as:\n{message:?}"
+    );
+
     Ok(())
 }
 
@@ -117,6 +124,9 @@ pub(crate) async fn announce_index_event(
 ) -> Result<()> {
     // Only send a message if the index updates topic is configured
     let Some(topic_name) = kafka_channel.index_updates_topic_name.as_ref() else {
+        tracing::debug!(
+            "Not sending index event: no 'index_updates_topic_name' configured for kafka messaging channel",
+        );
         return Ok(());
     };
 

--- a/crates/spk-storage/src/storage/messaging/kafka.rs
+++ b/crates/spk-storage/src/storage/messaging/kafka.rs
@@ -376,8 +376,18 @@ pub(crate) async fn listen_to_index_status_updates(
                         // Get the message details to check the index
                         // start time, repo it is for, and kind of
                         // update event.
-                        let Some(payload) = message.payload_view::<str>().map(|s| s.map(|s| s.to_owned()).expect("payload is legal UTF-8")) else {
-                            continue;
+                        let payload = match message.payload_view::<str>().map(|s| s.map(|s| s.to_owned())) {
+                            Some(result) => match result {
+                                Ok(pl) => pl,
+                                Err(err) => {
+                                    // This broken message will be discarded
+                                    let message = format!("Indexer get index update message payload as str: {err}");
+                                    tracing::warn!(message);
+                                    send_issue_to_sentry(message, &Error::String(err.to_string()));
+                                    continue;
+                                }
+                            } ,
+                            None => continue,
                         };
 
                         if let Ok(index_update) = serde_json::from_str::<IndexUpdateMessage>(&payload).inspect_err(|err| {
@@ -557,7 +567,19 @@ pub async fn listen_to_package_events_and_run_index_updates(
                 match maybe_message {
                     Some(Ok(message)) => {
                         // Get the package event details
-                        let Some(payload) = message.payload_view::<str>().map(|s| s.map(|s| s.to_owned()).expect("payload is legal UTF-8")) else { continue; };
+                        let payload = match message.payload_view::<str>().map(|s| s.map(|s| s.to_owned())) {
+                            Some(result) => match result {
+                                Ok(pl) => pl,
+                                Err(err) => {
+                                    // This broken message will be discarded
+                                    let message = format!("Indexer get index update message payload as str: {err}");
+                                    tracing::warn!(message);
+                                    send_issue_to_sentry(message, &Error::String(err.to_string()));
+                                    continue;
+                                }
+                            } ,
+                            None => continue,
+                        };
 
                         if let Ok(package_event) = serde_json::from_str::<PackageEventMessage>(&payload).inspect_err(|err| {
                             // This problem message will be discarded

--- a/crates/spk-storage/src/storage/messaging/kafka.rs
+++ b/crates/spk-storage/src/storage/messaging/kafka.rs
@@ -35,8 +35,8 @@ use crate::storage::messaging::{
 };
 use crate::{Error, FlatBufferRepoIndex, RepositoryHandle, RepositoryIndexMut, Result};
 
-/// Number of milliseconds to sleep while waiting for next message,
-/// when listening for new messages.
+/// Amount of time to sleep while waiting for next message, when
+/// listening for new messages.
 const LISTEN_YIELD_SLEEP_TIME: Duration = Duration::from_millis(100);
 
 type ProducersByBrokers = HashMap<Vec<String>, std::result::Result<FutureProducer, KafkaError>>;
@@ -348,7 +348,10 @@ pub(crate) async fn listen_to_index_status_updates(
     );
 
     let mut there_is_a_recent_message = false;
-    let mut time_since_last_message = 0;
+    let mut time_since_last_message = Duration::new(0, 0);
+
+    let index_update_timeout =
+        Duration::from_millis(kafka_channel.index_update_listener_timeout_ms);
 
     tracing::debug!(
         "Looking for a recent index update message that was sent after: {min_update_time}"
@@ -393,7 +396,7 @@ pub(crate) async fn listen_to_index_status_updates(
                         }) {
                             // This is a valid recent message, so reset the
                             // "indexer might be down" timeout timer.
-                            time_since_last_message = 0;
+                            time_since_last_message = Duration::new(0, 0);
                             tracing::debug!("Read index update message: {index_update:?}");
 
                             if index_update.start >= min_update_time.timestamp() {
@@ -430,8 +433,8 @@ pub(crate) async fn listen_to_index_status_updates(
                     // If enough time has passed since the last recent
                     // message was read, then assume something has happened
                     // to the index updating process and stop waiting.
-                    time_since_last_message += LISTEN_YIELD_SLEEP_TIME.as_millis();
-                    if time_since_last_message >= kafka_channel.index_update_listener_timeout_ms.into() {
+                    time_since_last_message += LISTEN_YIELD_SLEEP_TIME;
+                    if time_since_last_message >= index_update_timeout {
                         let ms = Millisecond::from_millis(kafka_channel.index_update_listener_timeout_ms);
                         let time_description = ms.pretty_with(MillisecondOption::long());
                         tracing::warn!("Index updates consumer timed out after {time_description}. The index may not have been updated.");
@@ -552,10 +555,12 @@ pub async fn listen_to_package_events_and_run_index_updates(
     .await?;
 
     // Start listening to index update messages
-    let mut time_since_last_message = 0;
+    let mut time_since_last_message = Duration::new(0, 0);
     let mut read_messages = 0;
     let mut generate_full_index = false;
     let mut package_versions: HashSet<OptVersionIdent> = HashSet::new();
+
+    let heartbeat_delay = Duration::from_millis(indexer_config.heartbeat_freq_ms);
 
     let mut stream = consumer.stream();
 
@@ -587,7 +592,7 @@ pub async fn listen_to_package_events_and_run_index_updates(
                         }) {
                             // Process a valid message
                             tracing::debug!("Indexer read package event message: {package_event:?}");
-                            time_since_last_message = 0;
+                            time_since_last_message = Duration::new(0, 0);
 
                             // Store the repo and the package that changed, but only if the repo
                             // matches the one this indexer cares about
@@ -710,8 +715,8 @@ pub async fn listen_to_package_events_and_run_index_updates(
 
                     // If enough time has passed since the last heartbeat,
                     // send another heartbeat message.
-                    time_since_last_message += LISTEN_YIELD_SLEEP_TIME.as_millis();
-                    if time_since_last_message >= indexer_config.heartbeat_freq_ms.into() {
+                    time_since_last_message += LISTEN_YIELD_SLEEP_TIME;
+                    if time_since_last_message >= heartbeat_delay {
                         announce_index_event(kafka_channel,
                                              IndexEvent::IndexerHeartbeat,
                                              repo_to_index.address(),
@@ -721,7 +726,7 @@ pub async fn listen_to_package_events_and_run_index_updates(
                                              &Utc::now()
                         ).await?;
 
-                        time_since_last_message = 0;
+                        time_since_last_message = Duration::new(0, 0);
                     }
                 }
             }

--- a/crates/spk-storage/src/storage/messaging/kafka.rs
+++ b/crates/spk-storage/src/storage/messaging/kafka.rs
@@ -2,39 +2,125 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/spkenv/spk
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 use std::time::Duration;
 
+use chrono::{DateTime, Utc};
+use futures::StreamExt;
+use itertools::Itertools;
 use once_cell::sync::Lazy;
-use rdkafka::ClientConfig;
+use rdkafka::consumer::{CommitMode, Consumer, StreamConsumer};
 use rdkafka::error::KafkaError;
 use rdkafka::producer::{FutureProducer, FutureRecord};
+use rdkafka::util::Timeout;
+use rdkafka::{ClientConfig, Message, Offset, TopicPartitionList};
 use serde_json::json;
-use spk_config::KafkaChannel;
+use spk_config::{Indexer, KafkaChannel};
 use spk_schema::BuildIdent;
+use spk_schema::ident::{OptVersionIdent, parse_build_ident};
+use spk_schema::name::RepositoryName;
+#[cfg(unix)]
+use tokio::signal::unix::{SignalKind, signal};
 use tokio::sync::Mutex;
+use ulid::Ulid;
 
-use crate::storage::messaging::PackageEvent;
-use crate::{Error, Result};
+use crate::storage::messaging::{
+    IndexEvent,
+    IndexUpdateMessage,
+    PackageEvent,
+    PackageEventMessage,
+};
+use crate::{Error, FlatBufferRepoIndex, RepositoryHandle, RepositoryIndexMut, Result};
 
-/// The queue timeout for a producer sending a message to a queue.
-/// This determines how to long retry for if the producer queue is full.
-const PRODUCER_QUEUE_TIMEOUT: Duration = Duration::from_secs(4);
+/// Number of milliseconds to sleep while waiting for next message,
+/// when listening for new messages.
+const LISTEN_YIELD_SLEEP_TIME: u64 = 100;
+
+/// Number of milliseconds in a second, used in time conversions
+const NUM_MS_IN_ONE_SECOND: u64 = 1000;
 
 type ProducersByBrokers = HashMap<Vec<String>, std::result::Result<FutureProducer, KafkaError>>;
 
 static KAFKA_PRODUCERS: Lazy<Mutex<ProducersByBrokers>> = Lazy::new(|| Mutex::new(HashMap::new()));
 
+/// Send a package update event message
 pub(crate) async fn announce_package_event(
     kafka_channel: &KafkaChannel,
     event: PackageEvent,
     to: &url::Url,
+    repo_name: &RepositoryName,
     ident: &BuildIdent,
 ) -> Result<()> {
+    // Only send a message if the package events topic is configured
     let Some(topic_name) = kafka_channel.package_updates_topic_name.as_ref() else {
         return Ok(());
     };
 
+    // Get the producer client connection
+    let mut kafka_producers = KAFKA_PRODUCERS.lock().await;
+
+    let producer = kafka_producers
+        .entry(kafka_channel.brokers.clone())
+        .or_insert_with(|| {
+            ClientConfig::new()
+                // XXX: probably should expose all configuration parameters in
+                // spk config
+                .set("bootstrap.servers", kafka_channel.brokers.join(","))
+                .set("message.timeout.ms", kafka_channel.message_timeout_ms.to_string())
+                .create()
+        })
+        .as_ref()
+        .map_err(|err| {
+            Error::String(format!(
+                "failed to create kafka producer (for package updates events topic) from config: {err}"
+            ))
+        })?;
+
+    // Assemble the message
+    let message = PackageEventMessage {
+        event,
+        repo: to.to_string(),
+        repo_name: repo_name.to_string(),
+        package: ident.to_string(),
+    };
+
+    // Send the package event message
+    producer
+        .send(
+            FutureRecord::to(topic_name)
+                // Using the package name as the key for purposes of sending
+                // all messages about the same package to the same topic
+                // partition.
+                .key(ident.name().as_str())
+                .payload(&json!(message).to_string()),
+            Duration::from_millis(kafka_channel.producer_queue_timeout_ms),
+        )
+        .await
+        .map_err(|err| {
+            Error::String(format!(
+                "failed to send kafka package event message: {err:?}"
+            ))
+        })?;
+
+    Ok(())
+}
+
+/// Send an index event message
+pub(crate) async fn announce_index_event(
+    kafka_channel: &KafkaChannel,
+    event: IndexEvent,
+    to: &url::Url,
+    repo_name: &RepositoryName,
+    index_start_time: i64,
+) -> Result<()> {
+    // Only send a message if the index updates topic is configured
+    let Some(topic_name) = kafka_channel.index_updates_topic_name.as_ref() else {
+        return Ok(());
+    };
+
+    // Get the producer client connection
     let mut kafka_producers = KAFKA_PRODUCERS.lock().await;
 
     let producer = kafka_producers
@@ -57,25 +143,560 @@ pub(crate) async fn announce_package_event(
             ))
         })?;
 
+    // Create the message
+    let message = IndexUpdateMessage {
+        event,
+        repo: to.to_string(),
+        name: repo_name.to_string(),
+        start: index_start_time,
+    };
+
+    // Send the index update message
     producer
         .send(
             FutureRecord::to(topic_name)
-                // Using the package name as the key for purposes of sending
-                // all messages about the same package to the same topic
-                // partition.
-                .key(ident.name().as_str())
-                .payload(
-                    &json!({
-                        "event": event.to_string(),
-                        "repo": to.to_string(),
-                        "package": ident.to_string(),
-                    })
-                    .to_string(),
-                ),
-            PRODUCER_QUEUE_TIMEOUT,
+                // Using the repo name as the key for purposes of sending
+                // all messages about the same index to the same topic partition.
+                .key(repo_name.as_str())
+                .payload(&json!(message).to_string()),
+            Duration::from_millis(kafka_channel.producer_queue_timeout_ms),
         )
         .await
-        .map_err(|err| Error::String(format!("failed to send kafka message: {err:?}")))?;
+        .map_err(|err| {
+            Error::String(format!(
+                "failed to send kafka index update message: {err:?}"
+            ))
+        })?;
+
+    tracing::debug!(
+        "Sent index update message: {event} - {repo_name} - {to} - {index_start_time} as:\n{message:?}"
+    );
+
+    Ok(())
+}
+
+/// Helper for interrupt handling in message stream consumer
+/// loops. Note this only works on unix at the moment.
+fn setup_running_interrupt_handling() -> Arc<AtomicBool> {
+    let running = Arc::new(AtomicBool::new(true));
+    #[cfg(unix)]
+    {
+        let running = Arc::clone(&running);
+        tokio::spawn(async move {
+            let mut sigint = signal(SignalKind::interrupt()).expect("sigint supported");
+            let mut sigquit = signal(SignalKind::quit()).expect("sigquit supported");
+
+            tokio::select! {
+                _ = sigint.recv() => {
+                    eprintln!("Received SIGINT, shutting down...");
+                }
+                _ = sigquit.recv() => {
+                    eprintln!("Received SIGQUIT, shutting down...");
+                }
+            }
+            running.store(false, std::sync::atomic::Ordering::SeqCst);
+        });
+    }
+    running
+}
+
+/// Helper for consumers that want to start with the message before
+/// the latest message because they want to use it to check whether
+/// the usual message producer is running by seeing if it has sent a
+/// message recently.
+fn set_offsets_to_one_before_the_latest_message(
+    consumer: Arc<StreamConsumer>,
+    topic_name: &str,
+    consumer_label: String,
+    broker_fetch_timeout: u64,
+) -> Result<()> {
+    let timeout = Timeout::After(Duration::new(broker_fetch_timeout, 0));
+
+    // Set up the message reading offset to the just before the last
+    // message in the topics.
+    let metadata = consumer
+        .fetch_metadata(Some(topic_name), timeout)
+        .map_err(|err| {
+            Error::String(format!(
+                "failed to fetch metadata for '{topic_name}' topic for a kafka index update consumer: {err}"
+            ))
+        })?;
+
+    let mut offsets = TopicPartitionList::new();
+    for topic in metadata.topics() {
+        for partition in topic.partitions() {
+            let (_low, high) = consumer
+                .fetch_watermarks(topic.name(), partition.id(), timeout)
+                .unwrap_or((-1, -1));
+
+            // Go back one message from the latest
+            let new_offset = std::cmp::max(0, high - 1);
+            tracing::debug!(
+                "New offset for {} part: {}, was {}, will be {}",
+                topic.name(),
+                partition.id(),
+                high,
+                new_offset
+            );
+            offsets
+                .add_partition_offset(topic.name(), partition.id(), Offset::Offset(new_offset))
+                .map_err(|err| {
+                    Error::String(format!(
+                        "failed to add partition offset to TopicPartitionList for the kafka {consumer_label} consumer: {err}"
+                    ))
+                })?;
+        }
+    }
+
+    // Update the offsets so the previous message(s) will be the first
+    // read from the stream.
+    consumer.commit(&offsets, CommitMode::Sync).map_err(|err| {
+        Error::String(format!(
+            "failed to commit new starting offsets for the kafka {consumer_label} consumer: {err}"
+        ))
+    })
+}
+
+/// Listen to the index updates topic until there's an "index completed"
+/// message for the given repository's index with an index update
+/// start time after the given update timestamp. This will also
+/// timeout if too much time passes without receiving any index update
+/// messages.
+pub(crate) async fn listen_to_index_status_updates(
+    kafka_channel: &KafkaChannel,
+    min_update_time: i64,
+    repo: &RepositoryHandle,
+) -> Result<()> {
+    // Only subscribe to index update messages if the index updates topic is configured
+    let Some(topic_name) = kafka_channel.index_updates_topic_name.as_ref() else {
+        return Ok(());
+    };
+
+    tracing::info!(
+        "Waiting for '{}' repo's index to be updated ...",
+        repo.name()
+    );
+
+    // Subscribe to index status updates with a unique group id that
+    // is just for this consumer.
+    let group_id = format!("spk-publish-{}", Ulid::new());
+    tracing::debug!(
+        "Index status update consumer's unique group id: {group_id} ({})",
+        group_id.len()
+    );
+
+    let consumer: StreamConsumer = ClientConfig::new()
+        .set("bootstrap.servers", kafka_channel.brokers.join(","))
+        .set("group.id", group_id)
+        .set("enable.partition.eof", "false")
+        .set("enable.auto.commit", "false")
+        .set("enable.auto.offset.store", "false")
+        .set(
+            "session.timeout.ms",
+            kafka_channel
+                .index_update_listener_session_timeout_ms
+                .to_string(),
+        )
+        .set(
+            "max.poll.interval.ms",
+            kafka_channel
+                .index_update_listener_max_polling_interval_ms
+                .to_string(),
+        )
+        // This will be changed below before the first message it read.
+        // The offset will be set to the one before the latest message.
+        .set("auto.offset.reset", "earliest")
+        .create()
+        .map_err(|err| {
+            Error::String(format!(
+                "failed to create kafka index updates consumer from config: {err}"
+            ))
+        })?;
+
+    let consumer = Arc::new(consumer);
+    consumer.subscribe(&[topic_name]).map_err(|err| {
+        Error::String(format!(
+            "failed to subscribe to kafka index updates topic: {err}"
+        ))
+    })?;
+
+    // Change the starting message offset for reading to the just
+    // before the last message in the topic.
+    set_offsets_to_one_before_the_latest_message(
+        consumer.clone(),
+        topic_name,
+        "index updates".to_string(),
+        kafka_channel.index_update_listener_broker_fetch_timeout_s,
+    )?;
+
+    // Set up signal handlers to stop if interrupted
+    let running = setup_running_interrupt_handling();
+
+    // Start listening to index update messages
+    let utc_now: DateTime<Utc> = Utc::now();
+    let now_timestamp = utc_now.timestamp_millis();
+    let recent_past_messages_time = rdkafka::Timestamp::from(
+        now_timestamp - kafka_channel.index_update_listener_recent_past_duration_ms,
+    );
+
+    let mut there_is_a_recent_message = false;
+    let mut time_since_last_message = 0;
+
+    tracing::debug!(
+        "Looking for a recent index update message that was sent after: {min_update_time}"
+    );
+
+    let mut stream = consumer.stream();
+
+    while running.load(std::sync::atomic::Ordering::SeqCst) {
+        tokio::select! {
+            maybe_message = stream.next() => {
+                match maybe_message {
+                    Some(Ok(message)) => {
+                        // Get message header to see if this is a recent enough message.
+                        if !there_is_a_recent_message && message.timestamp() < recent_past_messages_time {
+                            // This message was sent so long ago that the indexer might not be running
+                            tracing::debug!("Message read. Too old, ignoring it: {:?} < {:?}",  message.timestamp(), recent_past_messages_time);
+                            continue;
+                        }
+
+                        tracing::debug!("New message read: {:?} >= {:?}",  message.timestamp(), recent_past_messages_time);
+                        there_is_a_recent_message = true;
+
+                        // Get the message details to check the index
+                        // start time, repo it is for, and kind of
+                        // update event.
+                        let Some(payload) = message.payload_view::<str>().map(|s| s.map(|s| s.to_owned()).expect("payload is legal UTF-8")) else {
+                            continue;
+                        };
+
+                        if let Ok(index_update) = serde_json::from_str::<IndexUpdateMessage>(&payload).inspect_err(|err| {
+                            tracing::warn!("Failed to index update message parse payload ('{payload}') as IndexUpdateMessage: {err}");
+                        }) {
+                            // This is a valid recent message, so reset the
+                            // "indexer might be down" timeout timer.
+                            time_since_last_message = 0;
+                            tracing::debug!("Read index update message: {index_update:?}");
+
+                            if index_update.start >= min_update_time {
+                                tracing::debug!("Message is from an index update that started after the min_update_time: {}",  index_update.start - min_update_time);
+
+                                if repo.address().as_str() == index_update.repo {
+                                    // The message is for correct repository
+                                    if index_update.event.is_completed() {
+                                        // And the index has been updated. So this can stop listening now.
+                                        running.store(false, std::sync::atomic::Ordering::SeqCst);
+                                        tracing::debug!("Recent index update completed. Stopping waiting: '{}'", index_update.event);
+                                        break;
+                                    }
+                                }
+                            } else {
+                                // This message is about an older
+                                // index update than we are interested in.
+                                tracing::debug!("Index update message is not for recent enough update: {}",  index_update.start - min_update_time);
+                            }
+                        }
+                    },
+                    Some(err @ Err(_)) => {
+                        return Err(Error::String(format!("Unexpected error consuming next index update message: {err:?}")));
+                    }
+                    None => {
+                        // Stream ended?
+                        break;
+                    }
+                }
+            }
+            _ = tokio::time::sleep(Duration::from_millis(LISTEN_YIELD_SLEEP_TIME)) => {
+                // Yield periodically so interrupting is responsive.
+                if there_is_a_recent_message {
+                    // If enough time has passed since the last recent
+                    // message was read, then assume something has happened
+                    // to the index updating process and stop waiting.
+                    time_since_last_message += LISTEN_YIELD_SLEEP_TIME;
+                    if time_since_last_message >= kafka_channel.index_update_listener_timeout_ms {
+                        tracing::warn!("Index updates  consumer timed out after {} seconds. The index may not have been updated.",
+                                       kafka_channel.index_update_listener_timeout_ms / NUM_MS_IN_ONE_SECOND
+                        );
+                        running.store(false, std::sync::atomic::Ordering::SeqCst);
+                    }
+
+                } else {
+                    // Without a recent enough message, assume the indexer is down
+                    // and stop waiting for the index to update.
+                    tracing::warn!("Index updates consumer cannot see a recent message. The indexer might be down. Not waiting for the index update.");
+                    running.store(false, std::sync::atomic::Ordering::SeqCst);
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn send_issue_to_sentry(message: String, err: &Error) {
+    tracing::warn!("Sending messaging issue to sentry is not implemented: {message} - {err}");
+    // TODO: implement this
+}
+
+// Runs an indexer to continuously listen to package update messages,
+// de-duplicate them by package/version, and kick off an index update
+// (or full index generation) when there's a pause in messages.
+//
+// The indexer will also send a heartbeat message to the index status
+// topic periodically when not running an index update. It relies on
+// the index update processing to also emit status messages, in lieu
+// of heartbeat messages, when an index update is happening.
+#[allow(dead_code)]
+pub async fn listen_to_package_events_and_run_index_updates(
+    indexer_id: String,
+    kafka_channel: &KafkaChannel,
+    indexer_config: &Indexer,
+    repo_to_index: &RepositoryHandle,
+) -> Result<()> {
+    // Check there is an incoming package modification events topic
+    let Some(package_event_topic_name) = kafka_channel.package_updates_topic_name.as_ref() else {
+        return Err(Error::String(
+            "Indexer unable to start: package event topic name is required".to_string(),
+        ));
+    };
+
+    // Check there is an index update topic to send heartbeat messages to.
+    let Some(_index_update_topic_name) = kafka_channel.index_updates_topic_name.as_ref() else {
+        return Err(Error::String(
+            "Indexer unable to start: index update topic name is required".to_string(),
+        ));
+    };
+
+    // Subscribe to package modification events
+    let group_id = format!("spk-indexer-{}", indexer_id);
+
+    let consumer: StreamConsumer = ClientConfig::new()
+        .set("bootstrap.servers", kafka_channel.brokers.join(","))
+        .set("group.id", group_id)
+        .set("enable.partition.eof", "false")
+        .set("enable.auto.commit", "false")
+        // Only commit offsets offsets stored via
+        // the `consumer.store_offset()` calls
+        .set("enable.auto.offset.store", "false")
+        .set(
+            "session.timeout.ms",
+            indexer_config.session_timeout_ms.to_string(),
+        )
+        .set(
+            "max.poll.interval.ms",
+            indexer_config.max_polling_interval_ms.to_string(),
+        )
+        // Replaying lots of messages on restart is fine for an
+        // indexer and its updates to an index.
+        .set("auto.offset.reset", "earliest")
+        .create()
+        .map_err(|err| {
+            Error::String(format!(
+                "Indexer failed to create kafka consumer of package events from config: {err}"
+            ))
+        })?;
+
+    let consumer = Arc::new(consumer);
+    consumer
+        .subscribe(&[package_event_topic_name])
+        .map_err(|err| {
+            Error::String(format!(
+                "Indexer failed to subscribe to kafka package event topic: {err}"
+            ))
+        })?;
+
+    // Set up signal handlers to stop if interrupted
+    let running = setup_running_interrupt_handling();
+
+    // Setup placeholder used in indexer's heartbeat messages
+    let indexer_name = RepositoryName::new(&indexer_id)?;
+
+    // Setup name-repo pair list, used when generating a full index
+    // either because the index is missing or when a generate index
+    // message is read.
+    let repos = vec![(repo_to_index.name().to_string(), repo_to_index.clone())];
+
+    // Send an initial heartbeat message to indicate this is now running.
+    //
+    // Without this step, a timing issue can occur with something
+    // using the listen_to_index_status_updates() function to detect
+    // an indexer or index status updates. It can miss that the
+    // indexer is running, but hasn't started an index update yet.
+    announce_index_event(
+        kafka_channel,
+        IndexEvent::IndexerHeartbeat,
+        repo_to_index.address(),
+        indexer_name,
+        // This does not have an index start time so
+        // this is a placeholder.
+        0,
+    )
+    .await?;
+
+    // Start listening to index update messages
+    let mut time_since_last_message = 0;
+    let mut read_messages = 0;
+    let mut generate_full_index = false;
+    let mut package_versions: HashSet<OptVersionIdent> = HashSet::new();
+
+    let mut stream = consumer.stream();
+
+    while running.load(std::sync::atomic::Ordering::SeqCst) {
+        tokio::select! {
+            maybe_message = stream.next() => {
+                match maybe_message {
+                    Some(Ok(message)) => {
+                        // Get the package event details
+                        let Some(payload) = message.payload_view::<str>().map(|s| s.map(|s| s.to_owned()).expect("payload is legal UTF-8")) else { continue; };
+
+                        if let Ok(package_event) = serde_json::from_str::<PackageEventMessage>(&payload).inspect_err(|err| {
+                            // This problem message will be discarded
+                            let message = format!("Indexer failed to parse package event message payload ('{payload}') as PackageEventMessage: {err}");
+                            tracing::warn!(message);
+                            send_issue_to_sentry(message, &Error::String(err.to_string()));
+                        }) {
+                            // Process a valid message
+                            tracing::debug!("Indexer read package event message: {package_event:?}");
+                            time_since_last_message = 0;
+
+                            // Store the repo and the package that changed, but only if the repo
+                            // matches the one this indexer cares about
+                            if repo_to_index.address().to_string() == package_event.repo {
+
+                                if PackageEvent::GenerateFullIndex == package_event.event {
+                                    // This special event will trigger a full index (re-)generation
+                                    // when the indexer next kicks off an index update.
+                                    generate_full_index = true;
+                                    tracing::info!("Got a special (re-)generate full index message for '{}' repo", repo_to_index.address());
+                                } else {
+                                    // Capture the package/version that was updated from the message,
+                                    // It will have build ident (pkg/ver/build) in it, but only the
+                                    // pkg/ver matters for index updates.
+                                    let package_ident = match parse_build_ident(package_event.package) {
+                                        Ok(ident) => ident,
+                                        Err(err) => {
+                                            let message = format!(
+                                                "Ignoring message. Indexer unable to get package ident from package event message: {err}"
+                                            );
+                                            tracing::warn!(message);
+                                            send_issue_to_sentry(message, &Error::SpkIdentError(err));
+                                            continue;
+                                        },
+                                    };
+
+                                    let version_ident = package_ident.to_version_ident();
+                                    tracing::info!("Storing package ('{version_ident}') from package event message for '{}' repo", repo_to_index.address());
+                                    package_versions.insert(
+                                        OptVersionIdent::new(version_ident.base().clone(), Some(version_ident.version().clone())));
+                                }
+                            }
+                        }
+
+                        // Record message's offset in the consumer, for now.
+                        // The accumulated stored offsets are committed once
+                        // index update processing has completed, see below.
+                        consumer.store_offset_from_message(&message).map_err(|err| {
+                            Error::String(format!(
+                                "Error while storing message offset in indexer's consumer: {err}"
+                            ))
+                        })?;
+                        read_messages += 1;
+                        tracing::info!("Stored message offset in indexer's consumer");
+
+                    },
+                    Some(err @ Err(_)) => {
+                        return Err(Error::String(format!("Unexpected error consuming next index update message: {err:?}")));
+                    }
+                    None => {
+                        // Stream ended?
+                        break;
+                    }
+                }
+            }
+            _ = tokio::time::sleep(Duration::from_millis(LISTEN_YIELD_SLEEP_TIME)) => {
+                // Yield periodically so interrupting is responsive,
+                // to send heartbeat message, and to set off index updates.
+                if !package_versions.is_empty() || generate_full_index {
+                    tracing::info!("About to update the index. Package versions collected so far: {:?}", package_versions);
+
+                    if generate_full_index {
+                        // Ignore the accumulated package updates and
+                        // rebuild the whole index instead.
+                        tracing::info!("Generating a full index for '{}'", repo_to_index.name());
+                        FlatBufferRepoIndex::index_repo(&repos).await.map_err(|err| Error::String(format!("Full index generation failed: {err}")))?;
+                        tracing::info!("Full index generation finished");
+                        generate_full_index = false;
+                    } else {
+                        // Run an index update to include any modified packages.
+                        //
+                        // The method to updating the index will also output index update
+                        // status messages. Those messages will act as heartbeat messages
+                        // for this indexer.
+                        tracing::warn!("Reading index for '{}'", repo_to_index.name());
+                        match FlatBufferRepoIndex::from_repo_file(repo_to_index).await {
+                            Ok(current_index) => {
+                                tracing::debug!("Got the current index for '{}'", repo_to_index.name());
+                                let idents: Vec<_> = package_versions.iter().cloned().collect();
+
+                                tracing::info!("Staring index update as if running: 'spk repo index -r {} {}'", repo_to_index.name(), idents.iter().map(|pv| format!("--update {pv}")).join(" "));
+
+                                current_index.update_packages(repo_to_index, &idents).await.map_err(|err| Error::String(format!("Indexer has a problem updating index: {err}")))?;
+                                tracing::info!("Index update finished");
+                            }
+                            Err(err) => {
+                                // There isn't an existing index, so generate one from
+                                // scratch. This will include all package updates so far.
+                                tracing::warn!("Failed to load flatbuffer index: {err}");
+                                tracing::warn!("No current index to update. Generating a new full index for '{}' repo", repo_to_index.name());
+                                FlatBufferRepoIndex::index_repo(&repos).await.map_err(|err| Error::String(format!("Full index generation failed: {err}")))?;
+                                tracing::warn!("Full index generation finished for previously missing index of '{}' repo", repo_to_index.name());
+                            }
+                        }
+                    };
+
+                    // Now the index update (or generation) is done, clear the versions
+                    // and update the consumer's message offsets.
+                    consumer.commit_consumer_state(CommitMode::Sync).map_err(|err| {
+                        Error::String(format!(
+                            "Error while committing indexer's consumer state: {err}"
+                        ))
+                    })?;
+                    package_versions.clear();
+                    read_messages = 0;
+                    tracing::info!("Committed consumer state, updated broker with all processed package event message offsets.");
+                } else {
+                    // Not making an index this time around because no update
+                    // messages have been read.
+                    if read_messages > 0 {
+                        // Commit any consumed messages that could not be processed due
+                        // to problems with the message, e.g. parsing errors.
+                        consumer.commit_consumer_state(CommitMode::Sync).map_err(|err| {
+                             tracing::error!("{err}");
+                             Error::String(format!("Error while committing indexer's consumer state: {err}"))
+                         })?;
+                        read_messages = 0;
+                        tracing::info!("Committed indexer's consumer state for messages processed so far.");
+                    }
+
+                    // If enough time has passed since the last heartbeat,
+                    // send another heartbeat message.
+                    time_since_last_message += LISTEN_YIELD_SLEEP_TIME;
+                    if time_since_last_message >= indexer_config.heartbeat_freq_ms {
+                        announce_index_event(kafka_channel,
+                                             IndexEvent::IndexerHeartbeat,
+                                             repo_to_index.address(),
+                                             indexer_name,
+                                             // This does not have an index start time so
+                                             // this is a placeholder.
+                                             0
+                        ).await?;
+
+                        time_since_last_message = 0;
+                    }
+                }
+            }
+        }
+    }
 
     Ok(())
 }

--- a/crates/spk-storage/src/storage/messaging/mod.rs
+++ b/crates/spk-storage/src/storage/messaging/mod.rs
@@ -63,12 +63,22 @@ pub(crate) async fn announce_package_event(
     // Sends an index event message to all configured messaging systems
     let name = repo_name.to_string();
     for channel in &config.messaging {
+        tracing::debug!("Found a configured messaging channel for a package event");
         match channel {
             MessageChannel::Kafka(kafka_channel) => {
+                tracing::debug!(
+                    "Found kafka messaging channel called: '{}' for index event",
+                    kafka_channel.name
+                );
                 // Filter on the configured repo_name
                 if kafka_channel.repo_names.contains(&name) {
                     kafka::announce_package_event(kafka_channel, event, to, repo_name, ident)
                         .await?
+                } else {
+                    tracing::debug!(
+                        "Kafka messaging channel '{}' is not configured for '{name}' repo package events",
+                        kafka_channel.name
+                    );
                 }
             }
         }
@@ -127,6 +137,10 @@ pub(crate) async fn announce_index_event(
     for channel in &config.messaging {
         match channel {
             MessageChannel::Kafka(kafka_channel) => {
+                tracing::debug!(
+                    "Found kafka messaging channel called: '{}' for index event",
+                    kafka_channel.name
+                );
                 kafka::announce_index_event(kafka_channel, event, to, repo_name, index_start_time)
                     .await?
             }

--- a/crates/spk-storage/src/storage/messaging/mod.rs
+++ b/crates/spk-storage/src/storage/messaging/mod.rs
@@ -6,6 +6,7 @@ mod kafka;
 
 //use std::collections::HashMap;
 
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use spk_config::{Indexer, MessageChannel};
 use spk_schema::BuildIdent;
@@ -128,7 +129,7 @@ pub(crate) async fn announce_index_event(
     event: IndexEvent,
     to: &url::Url,
     repo_name: &RepositoryName,
-    index_start_time: i64,
+    index_start_time: &DateTime<Utc>,
 ) -> Result<()> {
     let config = spk_config::get_config()?;
 
@@ -155,7 +156,7 @@ pub(crate) async fn announce_index_event(
 /// the given update time.
 pub(crate) async fn listen_to_index_status_until_updated(
     repo: &RepositoryHandle,
-    update_time: i64,
+    update_time: &DateTime<Utc>,
 ) -> Result<()> {
     let name = repo.name().to_string();
 

--- a/crates/spk-storage/src/storage/messaging/mod.rs
+++ b/crates/spk-storage/src/storage/messaging/mod.rs
@@ -4,35 +4,242 @@
 
 mod kafka;
 
-use spk_config::MessageChannel;
+//use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use spk_config::{Indexer, MessageChannel};
 use spk_schema::BuildIdent;
+use spk_schema::name::RepositoryName;
+use variantly::Variantly;
 
-use crate::Result;
+use super::{RepositoryHandle, remote_repository};
+use crate::{Error, Result};
 
+// TODO: make this pub for testing, put it back to pub(crate)
 /// Types of events than can be reported about a package
-#[derive(Copy, Clone, Debug, strum::Display)]
-pub(crate) enum PackageEvent {
+#[derive(Copy, Clone, Debug, strum::Display, Deserialize, Serialize, PartialEq)]
+pub enum PackageEvent {
+    /// A package has been published to a repo
+    #[serde(alias = "package published")]
     #[strum(to_string = "package published")]
     Published,
+    /// A packaged has been modified, e.g. deprecated/undeprecated
+    #[serde(alias = "package modified")]
     #[strum(to_string = "package modified")]
     Modified,
+    /// A package has been removed from a repo
+    #[serde(alias = "package removed")]
     #[strum(to_string = "package removed")]
     Removed,
+    /// A special admin message to make an indexer generate a
+    /// full index from scratch for the repo
+    #[serde(alias = "generate index")]
+    #[strum(to_string = "generate index")]
+    GenerateFullIndex,
 }
 
+/// A package event message
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct PackageEventMessage {
+    /// The kind of index update event
+    pub event: PackageEvent,
+    /// The address of the repo being indexed
+    pub repo: String,
+    /// The name of the repo being indexed
+    pub repo_name: String,
+    // TODO: this is optional for a GenerateFullIndex event
+    /// The name of the repo being indexed
+    pub package: String,
+}
+
+/// Send a package event to each configured messaging system
 pub(crate) async fn announce_package_event(
     event: PackageEvent,
     to: &url::Url,
+    repo_name: &RepositoryName,
     ident: &BuildIdent,
 ) -> Result<()> {
     let config = spk_config::get_config()?;
+    // Sends an index event message to all configured messaging systems
+    let name = repo_name.to_string();
     for channel in &config.messaging {
         match channel {
             MessageChannel::Kafka(kafka_channel) => {
-                kafka::announce_package_event(kafka_channel, event, to, ident).await?
+                // Filter on the configured repo_name
+                if kafka_channel.repo_names.contains(&name) {
+                    kafka::announce_package_event(kafka_channel, event, to, repo_name, ident)
+                        .await?
+                }
             }
         }
     }
 
     Ok(())
+}
+
+/// Types of events than can be reported about an index
+#[derive(Copy, Clone, Debug, strum::Display, Deserialize, Serialize, PartialEq, Variantly)]
+pub(crate) enum IndexEvent {
+    /// An index update or full generation has started
+    #[serde(alias = "index started")]
+    #[strum(to_string = "index started")]
+    Started,
+    /// An index update or full generation is in-progress
+    #[serde(alias = "index in-progress")]
+    #[strum(to_string = "index in-progress")]
+    InProgress,
+    /// An index update or full generation has completed
+    #[serde(alias = "index completed")]
+    #[strum(to_string = "index completed")]
+    Completed,
+    /// An indexer is alive and monitoring the repo for package updates
+    #[serde(alias = "indexer heartbeat")]
+    #[strum(to_string = "indexer heartbeat")]
+    IndexerHeartbeat,
+}
+
+/// An index update event message
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct IndexUpdateMessage {
+    /// The kind of index update event
+    pub event: IndexEvent,
+    /// The address of the repo being indexed
+    pub repo: String,
+    /// The name of the repo being indexed
+    pub name: String,
+    // TODO: this is optional for indexer heartbeat events
+    /// Timestamp when the index generation for this status update
+    /// message first started.
+    pub start: i64,
+}
+
+/// Send an index event to each configured messaging system
+pub(crate) async fn announce_index_event(
+    event: IndexEvent,
+    to: &url::Url,
+    repo_name: &RepositoryName,
+    index_start_time: i64,
+) -> Result<()> {
+    let config = spk_config::get_config()?;
+
+    // Sends an index event message to all configured messaging
+    // systems.
+    for channel in &config.messaging {
+        match channel {
+            MessageChannel::Kafka(kafka_channel) => {
+                kafka::announce_index_event(kafka_channel, event, to, repo_name, index_start_time)
+                    .await?
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Subscribes to index updates topic and listens to updates until it
+/// gets one that indicates the repo's index has been updated after
+/// the given update time.
+pub(crate) async fn listen_to_index_status_until_updated(
+    repo: &RepositoryHandle,
+    update_time: i64,
+) -> Result<()> {
+    let name = repo.name().to_string();
+
+    let index_config = spk_config::get_index_config(&name);
+    let update_channel_name = index_config.update_message_channel;
+
+    let config = spk_config::get_config()?;
+    for channel in &config.messaging {
+        match channel {
+            MessageChannel::Kafka(kafka_channel) => {
+                // Only listen to index update channel with the
+                // matching name.
+                if kafka_channel.name == update_channel_name {
+                    // Filter on the configured repo name
+                    if kafka_channel.repo_names.contains(&name) {
+                        kafka::listen_to_index_status_updates(kafka_channel, update_time, repo)
+                            .await?
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Runs an index update server (an indexer) that listens publish
+/// modification events on one channel, launches index updates, and
+/// sends index status messages to another channel.
+///
+/// The indexer will run forever, or until it is interrupted or
+/// encounters an error it cannot handle.
+pub async fn run_index_update_server(indexer_id: String, indexer_config: &Indexer) -> Result<()> {
+    // This only supports an indexer that uses kafka channels for both
+    // message flows: listening to publish modifications, and sending
+    // status updates.
+    let mut message_channel = None;
+
+    let config = spk_config::get_config()?;
+    for channel in &config.messaging {
+        match channel {
+            MessageChannel::Kafka(kafka_channel) => {
+                if kafka_channel.name == indexer_config.message_channel_name
+                    && kafka_channel.repo_names.contains(&indexer_config.repo_name)
+                {
+                    message_channel = Some(kafka_channel);
+                }
+            }
+        }
+    }
+
+    // Check indexer's configured repo has indexing enabled before getting it.
+    let repo = match config.repositories.get(&indexer_config.repo_name) {
+        Some(repo_config) => {
+            if repo_config.use_index {
+                match indexer_config.repo_name.as_str() {
+                    "local" => {
+                        return Err(Error::String(
+                            "Unable to run indexer '{indexer_id}' due to: indexer is configured with the 'local' repo, which cannot be updated by an indexer".to_string()));
+                    }
+                    name => {
+                        // Ensure the repo handle is not for an
+                        // Indexed repo, or else all the subsequent
+                        // processing will be using the index instead
+                        // of the underlying repo.
+                        let handle: RepositoryHandle = remote_repository(name).await?.into();
+                        handle
+                    }
+                }
+            } else {
+                return Err(Error::String(format!(
+                    "Unable to run indexer '{indexer_id}' due to: indexer's configured repo '{}' has 'use_index' set to false, so indexing is disabled on that repo",
+                    indexer_config.repo_name
+                )));
+            }
+        }
+        None => {
+            return Err(Error::String(
+                "No indexer '{indexer_id}' configured in SPK config file".to_string(),
+            ));
+        }
+    };
+
+    // Run the indexer. This will run forever, or until it is
+    // interrupted or encounters an error it cannot handle.
+    match message_channel {
+        Some(kafka_channel) => {
+            kafka::listen_to_package_events_and_run_index_updates(
+                indexer_id,
+                kafka_channel,
+                indexer_config,
+                &repo,
+            )
+            .await
+        }
+        _ => Err(crate::Error::String(format!(
+            "Unable to run indexer: Running an indexer requires a kafka messaging channel called '{}'. But it is not configured.",
+            indexer_config.message_channel_name
+        ))),
+    }
 }

--- a/crates/spk-storage/src/storage/mod.rs
+++ b/crates/spk-storage/src/storage/mod.rs
@@ -19,6 +19,7 @@ pub use handle::RepositoryHandle;
 pub use indexed::IndexedRepository;
 pub use mem::MemRepository;
 pub(crate) use messaging::announce_package_event;
+pub use messaging::{PackageEvent, run_index_update_server};
 pub use repository::{CachePolicy, Repository, Storage};
 pub use repository_index::{RepoIndex, RepositoryIndex, RepositoryIndexMut};
 pub use runtime::{RuntimeRepository, find_path_providers, pretty_print_filepath};

--- a/crates/spk-storage/src/storage/repository.rs
+++ b/crates/spk-storage/src/storage/repository.rs
@@ -431,7 +431,13 @@ pub trait Repository: Storage + Sync {
             }
         }
 
-        announce_package_event(PackageEvent::Published, self.address(), package.ident()).await?;
+        announce_package_event(
+            PackageEvent::Published,
+            self.address(),
+            self.name(),
+            package.ident(),
+        )
+        .await?;
 
         Ok(())
     }
@@ -542,7 +548,13 @@ pub trait Repository: Storage + Sync {
         // else if there was no original spec, assume there is nothing needed
         // to do.
 
-        announce_package_event(PackageEvent::Modified, self.address(), package.ident()).await?;
+        announce_package_event(
+            PackageEvent::Modified,
+            self.address(),
+            self.name(),
+            package.ident(),
+        )
+        .await?;
 
         Ok(())
     }
@@ -565,7 +577,7 @@ pub trait Repository: Storage + Sync {
 
         self.remove_package_from_storage(pkg).await?;
 
-        announce_package_event(PackageEvent::Removed, self.address(), pkg).await
+        announce_package_event(PackageEvent::Removed, self.address(), self.name(), pkg).await
     }
 
     /// Identify the payloads for this identified package's components.

--- a/crates/spk-storage/src/storage/repository.rs
+++ b/crates/spk-storage/src/storage/repository.rs
@@ -15,8 +15,7 @@ use spk_schema::option_map::get_host_options_filters;
 use spk_schema::{BuildIdent, Components, Deprecate, Package, PackageMut, VersionIdent};
 
 use self::internal::RepositoryExt;
-use super::announce_package_event;
-use crate::storage::messaging::PackageEvent;
+use super::{PackageEvent, announce_package_event};
 use crate::{Error, Result};
 
 #[cfg(test)]
@@ -163,7 +162,8 @@ pub(in crate::storage) mod internal {
         Recipe,
     };
 
-    use crate::Result;
+    use crate::storage::announce_package_event;
+    use crate::{PackageEvent, Result};
 
     /// Reusable methods for [`super::Repository`] that are not intended to be
     /// part of its public interface.
@@ -199,7 +199,17 @@ pub(in crate::storage) mod internal {
             ))));
             spec_for_embedded_pkg.set_deprecated(spec_for_parent.is_deprecated())?;
             self.publish_embed_stub_to_storage(&spec_for_embedded_pkg)
-                .await
+                .await?;
+
+            announce_package_event(
+                PackageEvent::Modified,
+                self.address(),
+                self.name(),
+                spec_for_embedded_pkg.ident(),
+            )
+            .await?;
+
+            Ok(())
         }
 
         /// Get all the embedded packages described by a [`Package`] and
@@ -232,7 +242,7 @@ pub(in crate::storage) mod internal {
             spec_for_embedded_pkg: &Self::Package,
             components_that_embed_this_pkg: BTreeSet<Component>,
         ) -> Result<()> {
-            let spec_for_embedded_pkg =
+            let embedded_pkg_ident =
                 spec_for_embedded_pkg
                     .ident()
                     .with_build(Build::Embedded(EmbeddedSource::Package(Box::new(
@@ -242,8 +252,17 @@ pub(in crate::storage) mod internal {
                             unparsed: None,
                         },
                     ))));
-            self.remove_embed_stub_from_storage(&spec_for_embedded_pkg)
+            self.remove_embed_stub_from_storage(&embedded_pkg_ident)
                 .await?;
+
+            announce_package_event(
+                PackageEvent::Modified,
+                self.address(),
+                self.name(),
+                &embedded_pkg_ident,
+            )
+            .await?;
+
             Ok(())
         }
     }
@@ -471,6 +490,17 @@ pub trait Repository: Storage + Sync {
         let components = self.read_components(package.ident()).await?;
         self.publish_package_to_storage(package, &components)
             .await?;
+        // The package has been updated so send an event about that
+        // immediately. The package or embedded packages related to it
+        // may be updated later in this method and those updates will
+        // send additional package events.
+        announce_package_event(
+            PackageEvent::Modified,
+            self.address(),
+            self.name(),
+            package.ident(),
+        )
+        .await?;
 
         // Changes that affect embedded stubs:
         // - change in deprecation status
@@ -547,15 +577,6 @@ pub trait Repository: Storage + Sync {
         }
         // else if there was no original spec, assume there is nothing needed
         // to do.
-
-        announce_package_event(
-            PackageEvent::Modified,
-            self.address(),
-            self.name(),
-            package.ident(),
-        )
-        .await?;
-
         Ok(())
     }
 

--- a/crates/spk-storage/src/storage/spfs.rs
+++ b/crates/spk-storage/src/storage/spfs.rs
@@ -995,7 +995,7 @@ impl SpfsRepository {
     }
 
     /// Invalidate (clear) all cached results.
-    fn invalidate_caches(&self) {
+    pub(crate) fn invalidate_caches(&self) {
         self.caches.ls_tags.clear();
         self.caches.package_versions.clear();
         self.caches.recipe.clear();

--- a/docs/admin/config.md
+++ b/docs/admin/config.md
@@ -318,13 +318,64 @@ verify_index_before_use = true
 # The kind of index format to use for this repository. SPK currently supports
 # a flatbuffer based index.
 index_kind = "flatb"
+# Time to sleep between getting a write lock on the index data,
+# for index generation and updates.
+lock_sleep_seconds = 6
+# Maximum number of times to try to get a write lock on this index's
+# data, for index generation and updates.
+lock_max_tries = 5
+# Name of the configured messaging channel (see MessageChannels below)
+# to send index status update messages too.
+update_message_channel = "kafka"
+# How often index generation and update processing should send
+# index update event messages, in milliseconds.
+update_event_send_freq_ms = 5000
 
 # SPK can send messages to external messaging systems when packages are:
 # published, modified, or removed. Each messaging system must be configured here.
 # Currently, only kafka is supported.
 #
-# To send messages to a kafka system, the brokers and package_updates_topic_name
-# must be configured. The timeout_ms is optional and defaults to 5 seconds:
+# To send messages to a kafka system: the name, the brokers, package_updates_topic_name,
+# index_updates_topic_name, and the repo_names list must be configured.
 # [[messaging]]
-# kafka = { brokers = [ "brokername:port", "otherbrokername:port", ... ], package_updates_topic_name = "spk-package-updates-or-whatever-your-topic-name-is", timeout_ms = 5000 }
+# kafka = { brokers = [ name = "kafka", "brokername:port", "otherbrokername:port", ... ], package_updates_topic_name = "spk-package-updates-or-whatever-your-topic-name-is", index_updates_topic_name = "spk-index-updates-or-whatever-your-topic-name-is", repo_names = [ "origin" ] }
+#
+# SPK supports other optional properties for configuring a kafka messaging system.
+# They are shown below with their defaults. Each must be added to the kafka = { ... } 
+# table above to configure them for that messaging channel
+# The kafka message sending timeout in milliseconds:
+#   message_timeout_ms = 5000
+# The kafka producer send queue timeout in milliseconds:
+#   producer_queue_timeout_ms = 4000
+# The timeout while waiting for an index update to complete, in milliseconds
+#   index_update_listener_timeout_ms = 10000,
+# The kafka message reading session timeout in milliseconds
+#   index_update_listener_session_timeout_ms = 10000,
+# The index listener's maximum polling interval in milliseconds
+#   index_update_listener_max_polling_interval_ms = 10000,
+# How far back in time is consider recent enough for messages to be current, in seconds
+#   index_update_listener_recent_past_duration_s = 120,
+# The timeout for fetching data from the brokers
+#   index_update_listener_broker_fetch_timeout_s = 20,
+# For example, a kafka messaging channel with all the settings configured
+# would look like this:
+kafka = { brokers = [ name = "kafka", "brokername:port", "otherbrokername:port", ... ], package_updates_topic_name = "spk-package-updates-or-whatever-your-topic-name-is", index_updates_topic_name = "spk-index-updates-or-whatever-your-topic-name-is", repo_names = [ "origin" ], message_timeout_ms = 5000, producer_queue_timeout_ms = 4000, index_update_listener_timeout_ms = 10000, index_update_listener_session_timeout_ms = 10000, index_update_listener_max_polling_interval_ms = 10000, index_update_listener_recent_past_duration_s = 120, index_update_listener_broker_fetch_timeout_s = 20 }
+
+# SPK can run an index update server, known  as an indexer, When a messaging system
+# is configured. An indexer will update a single repository' index when package changes
+# happen.
+#
+# Indexers are configured to use a named message channel (one configured above)
+[indexers.kafka]
+message_channel_name = "kafka"
+# The name of the repository this indexer will monitor.
+# An indexer works on a single repository.
+repo_name = "origin"
+# How often the indexer should send heartbeat messages, to indicate it
+# is running, to the messaging system's 'index_updates_topic_name' topic/queue
+heartbeat_freq_ms = 60000
+# The kafka session timeout for the indexer
+session_timeout_ms = 120000
+# The maximum polling interval for an indexer for keeping in touch with the kafka brokers
+max_polling_interval_ms = 86400000
 ```

--- a/docs/ref/indexes.md
+++ b/docs/ref/indexes.md
@@ -8,10 +8,9 @@ This explains indexes, indexing, index controls, and index requirements in `SPK`
 
 ## SPK Repository Indexes
 
-`SPK` supports generating a packages index for a repository to help
-with solves. An index must have been generated separately for a
-repository before it can be used. Using an index speeds up solves
-using that repository.
+`SPK` supports generating a packages index for a repository to speed
+up solves. An index must have been generated separately for that
+repository before it can be used. 
 
 The index is designed to help the solvers with solves (package
 look-ups, deprecation checks, pre-loading non-package variable
@@ -19,7 +18,7 @@ references, getting install requirements, etc.). It does not contain
 the full package data. So it does not have the information needed to
 help other `SPK` operations, e.g. building or testing a package.
 
-If indexing is enabled, you have to generate an index before trying to
+If indexing is enabled, the index must be generated before trying to
 use it in a solve. They are not generated on the fly (outside of tiny
 repositories for automated tests).
 
@@ -45,7 +44,7 @@ repository index use on a per command basis. The `spk repo index ...`
 command always has index use disabled because it operates on the
 indexes themselves. `spk info ...` also disables indexes because
 displaying complete package information requires reading the package
-from the repository directly, not from an index.
+from the repository directly, not just the subset of data in an index.
 
 If index use is enabled in the config file, it can be disabled with
 the `--index-use disabled` command line option.
@@ -53,7 +52,7 @@ the `--index-use disabled` command line option.
 
 ### Generating an Index
 
-To generate an index for a repository (e.g. origin), run:
+To generate an index for a repository (e.g. origin), you can run:
 `spk repo index -r origin`
 
 This will generate a flatbuffer schema based index file. The index
@@ -66,11 +65,24 @@ once for each repository.
 
 See `spk repo index -h` for more details.
 
+You can also set up a SPK Indexer, if you also have a SPK message
+channel configured. See the 'Automatic index updates ...' sections
+below.
+
 You do not have to generate a full index every time a package changes,
 you can update a package in an existing index, see the next section.
 
 
-### Updating an Existing Index
+### Index vs Repository mismatches - updates are important
+
+When index use is enabled, it is important to update the indexes when
+changes happen to the repository and its packages. Otherwise, the
+index and real package data will get out of sync. An index that is old
+will not have the same data as the repositories it is based on. This
+can lead to discrepancies in solves.
+
+
+### Updating an existing Index
 
 Updating a package in an existing index, such as after a new build is
 published or a package is deprecated, is not automatic.
@@ -89,31 +101,136 @@ The `--update` option can be given multiple times to update several
 packages at a once, e.g.:
 `spk repo index -r origin --update python --update zlib`
 
-The `--update` option takes a package/version as well. This lets the
+The `--update` option can also take a package/version. This lets the
 update be restricted to a specific version of a package. This can make
-for shorter update times for packages with a large number of versions,
-or builds per version, e.g.: 
+for shorter update times for packages with large numbers of versions,
+or builds per version, e.g.:
 `spk repo index -r origin --update python/3.10.8 --update zlib/1.2.12`
 
-Those commands will read in the existing index for the repository and
-update the versions and builds of the named package in the index. It
-is faster than generating an index from scratch. It has to be run once
-per repository to update the given package or packages in each
-repository's index.
+These commands will read in the existing index for the repository, and
+update the versions and builds of the named package in the index. This
+is faster than generating an index from scratch. But it has to be run
+once per repository to update the give packages in that repository's
+index.
 
 See `spk repo index -h` for more details.
 
+You can also set up a SPK Indexer to update a repositories index when
+a package changes, if you also have a SPK message channel configured.
+See the 'Automatic index updates ...' sections below.
 
-## Index vs Repository Mismatches - Updates are Important
+### Automatic index updates when published or modifying packages
 
-When index use is enabled, it is important to update the indexes when
-changes happen to the repository and its packages. Otherwise, the
-index and real package data will get out of sync. An index that is old
-will not have the same data as the repositories it is based on. This
-can lead to discrepancies in solves.
+SPK has support for automatically updating a repository's index when a
+package is published, or modified (e.g. deprecated), if there is an
+external messaging channel configured for SPK to talk to.
+
+SPK current only supports kafka as a messaging channel.
+
+With a messaging channel configured, SPK will be able to send package
+update messages (to a topic/queue) when any of these spk command are used:
+- `spk publish`
+- `spk deprecate`
+- `spk undeprecate`
+- `spk remove`
+
+This allows an external monitoring system to see package updates and
+act on them, e.g. by triggering an index update.
+
+SPK's `spk repo indexer --name ...` command can be used to run such a
+monitoring system that works with SPK's configured messaging channels
+(e.g. `spk repo indexer --name my_indexer_config_name`, see `spk repo
+indexer -h` for more options).
+
+An SPK Indexer will run forever and listen to the package update
+messages for a single repository. It wil accumulate the package
+updates, and when there is a pause in messages, it will perform an
+index update on that repository's index, and then wait for more
+package update messages.
+
+While it is running, the SPK indexer will send heartbeat messages (to
+a topic/queue) to indicate it is alive. While it is updating an index,
+the SPK indexer will send index status update messages to indicate
+when an index update has started, is in-progress, and has completed.
+
+The SPK commands that send package update messages will also wait and
+listen for index status update messages. They do this after they have
+finished publishing or updating the packages they were acting on, and
+only if a message channel is configured for their use.
+
+Those SPK commands use the index status update messages to workout
+when that repository's index update is complete, and then they return
+control to the user.  This allows a site to ensure package updates are
+reflected in an index before a user's next spk command is run. The
+indexer's heartbeat and index update messages are used to detect if
+the indexer isn't running so the commands do not wait forever.
+
+See the [SPK messaging docs]({{< ref "./messaging" >}}) and the [SPK
+config file reference docs]({{< ref "../admin/config" >}}) for more
+details.
+
+
+#### SPK Indexer
+
+The SPK Indexer is meant to be run continuously as a service to
+monitor one repository and update that repository's index. If you have
+multiple repositories, and you want to automatically update all their
+indexes, you will need to config and run multiple SPK Indexers - each
+with their own config name and section.
+
+It is up to each site to deploy the SPK Indexer(s) as a service in the
+most appropriate way for that site.
+
+The SPK Indexer will make an index from scratch if one does not exist
+for the repository it is monitoring. This allows an Indexer to be used
+to bootstrap an index for a repository, and recover an index if it is
+removed or another problem occurs.
+
+The special admin "generate a full index" package update message can
+be sent to make a SPK Indexer regenerate a repository's index from
+scratch, even if one exists already.
+
+See the [SPK messaging docs]({{< ref "./messaging" >}}) and the [SPK
+config file reference docs]({{< ref "../admin/config" >}}) for more
+details.
+
+
+#### SPK update commands and index status messages
+
+These SPK commands send package update messages (to a topic/queue)
+when they run:
+- `spk publish`
+- `spk deprecate`
+- `spk undeprecate`
+- `spk remove`
+
+They also listen to index status messages (from a topic/queue), and
+wait for their repository's index to update before the commands
+finish. Messages about other repositories' indexes are ignored.
+
+However, because these commands are typically run by users, the cannot
+wait forever. The first thing they do is check the latest message (in
+the topic/queue) and to see if it is recent enough, e.g. within the
+last minute or so. A recent enough index status message means that a
+SPK Indexer is active and sending messages. In this case the commands
+will continue to listen and wait for index updates. If that message is
+too old, the command assumes the indexer is down, that the index is
+not going to be updated soon, and it exits immediately rather than
+wait.
+
+Provided they get recent enough messages, the commands will check the
+`index_start_time` field of the messages. They are looking for times
+that are after the command finished its updates (e.g. `spk publish`
+has published all its packages). Those index updates will include the
+package changes made by the command. When the command gets an 'Index
+completed' message with a late enough index start time, it knows the
+index contains its changes and it will stop listening and can exit
+successfully.
 
 
 ## Index Details
+
+SPK supports file-based flatbuffer formatted indexes.
 
 ### Index File Location
 
@@ -154,21 +271,23 @@ in the 'spk-schema' crate:
 `SPK` uses flatbuffers for the index data format on disk. This is fast
 to read and use, but slow to generate. Updates to an existing index
 require an index to be read in completely and written out again with
-the updated data. It does not support updating complex structures
-in-place.
+the updated data. It does not support updating complex structures in
+an index in-place
 
 The `spk-proto` crate contains SPK's flatbuffers schema for an
 index. It requires `flatc` to be installed to generate the rust code
 for the index schema.
 
 The schema is versioned internally, and the index file name contains
-the index schema version number as well.
+the index schema version number as well. This is checked on load
+against the index version SPK is compatible with to schema and SPK
+version mismatches.
 
 The index structure does not match the rust object structures
 one-to-one. This is partially due to only keeping things needed for
-solves, and partially due to what flatbuffers require, support, and
-recommend (lists not sets or mappings, removing duplication and
-intermediate structures).
+solves and solver operations, and partially due to what flatbuffers
+require, support, and recommend for speed (lists not sets or mappings,
+removing duplication and intermediate structures).
 
 The broad top-level schema structure is (capital letters indicate a schema table name):
 ```
@@ -188,7 +307,7 @@ RepositoryIndex
 
 The structure is quite deep to cover the data for options,
 requirements, compat rules, version numbers, build ids, and
-components. See the schema itself for more detailed information,
+components. See the schema file itself for more detailed information,
 including which fields of rust objects are being ignored, omitted from
 an index.
 

--- a/docs/ref/messaging.md
+++ b/docs/ref/messaging.md
@@ -4,46 +4,159 @@ summary: Messaging from SPK
 weight: 120
 ---
 
-This explains SPK'S support for sending messages to external messaging systems
+This documents SPK's support for sending event messages to external messaging systems.
 
 ## Messaging from SPK
 
-`SPK` supports sending messages to configured messaging systems after certain events.
+`SPK` supports sending messages to configured, external, messaging
+systems after certain events.
 
-These events are when packages are:
+It can send package update messages for package events, when packages are:
 - published
-- modified
-- deleted
+- modified (deprecated or undeprecated)
+- removed
+
+It can send index status messages for index events, when:
+- An index update is started
+- An index update is in-progress (periodically as the update is happening)
+- An index update is complete
+- A SPK Indexer is running (a heartbeat message)
+
+The external messaging system must be set up separately to SPK by the
+site. SPK's config file must have a messaging channel configuration
+added to it for the messaging system.
 
 
 ### Supported messaging systems
 
 SPK only supports sending messages for events to kafka systems.
 
+To send messages, SPK must be configured for each messaging system the
+sites wants it to send to. Multiple messaging channels can be
+configured. Each must be configured as a separate SPK message channel.
 
-### SPK messaging configuration
+Currently, kafka is the only supported kind of messaging channel.
 
-To send messages, SPK must be configured for each messaging system it
-will send to. Multiple backend messaging systems can be specified.
+### Message channel configuration
 
-See [here]({{< ref "../admin/config" >}}) for the kafka configuration.
+A kafka message channel must be configured with:
+- a `name`
+- a list of `brokers`
+- a `package_updates_topic_name`, for package update events
+- a `index_updates_topic_name`, for index status update events
+- a set of `repo_names` that SPK is allowed to send messages about
+
+There are several other optional configuration settings for a kafka
+message channel. See [SPK config file]({{< ref "../admin/config" >}})
+for more details.
+
+### Index message channel configuration
+
+An index (for a repository) can be configured so that index update
+messages are sent to a particular message channel. Each SPK repository
+has an index configuration section and the `update_message_channel`
+property can be set to the `name` of the message channel SPK will use
+for sending index status updates. 
+
+Index status update messages are sent when an index is being generated
+or updated. This is usually done by an Indexer, but can be done with
+`spk repo ...` command lines.
+
+How often index status messages are sent can be configured via the
+`update_event_send_freq_ms` setting in the index's configuration.
+
+See [SPK config file]({{< ref "../admin/config" >}}) for more details.
 
 
-### SPK message format
+### Indexer messaging configuration
 
-SPK sends messages in json format. They contain these fields and data:
+An Indexer (index updating service) has to be configured to use a
+named messaging channel before it can be used to monitor package
+updates for a repository and run index updates.
+
+The these settings must be configured:
+- `message_channel_name` of the messaging channel system to use
+- `repo_name` of the repository to monitor and index
+
+A messaging channel must exist with that name, and the repository name
+must be present in that messaging channel's list of repo names that it
+allows. Otherwise the Indexer will not be able to send or receive
+messages about the repository it is interested in.
+
+See [SPK config file]({{< ref "../admin/config" >}}) for more details.
+
+
+## SPK message formats
+
+SPK sends messages in json format. There are two kinds of messages:
+1. Package update messages
+2. Index status messages
+
+ Each goes to a different topic/queue in a configured messaging system.
+
+
+### Package update messages
+
+Package update messages contain these fields and data:
 ```
 {
   "event": "generating event"
-  "repo": "repository name"
+  "repo": "repository address"
+  "repo_name": "repository name"
   "package": "package/version/build identifier"
 }
 ```
 For example:
 ```
 {
-  "event": "package published"
-  "repo": "origin"
+  "event": "package published",
+  "repo": "file:/on/a/file/system/some/where",
+  "repo_name": "origin",
   "package": "mypkg/1.2.3/ABCDEF"
 }
 ```
+There are four valid package event values:
+- "package published"
+- "package modified"
+- "package removed"
+- and the special: "generate index", see [SPK Indexer]({{< ref "./indexes" >}}).
+
+
+### Index status messages
+
+Index status message come in two broad kinds: index status messages,
+and Indexer heartbeat messages. Both use the same message format and
+structure, but the heartbeat messages contain placeholder data in some
+fields.
+
+```
+{
+  "event": "index status",
+  "repo": "repository address",
+  "name": "repository name",
+  "start": "the timestamp of when the index started to change"
+}
+```
+
+The `start` timestamp will be the same for all index status messages
+related to the same index update processing. They will all be when
+that index update first started. This lets message consumers both:
+group related index status changes, and detect which ones are recent
+enough to be relevant to them.
+
+For example:
+```
+{
+  "event": "index in-progress",
+  "repo": "file:/on/a/file/system/some/where",
+  "name": "origin",
+  "start": 1777941742
+}
+``
+
+There are four valid index event values:
+- "index started"
+- "index in-progress"
+- "index completed"
+- "indexer heartbeat"
+


### PR DESCRIPTION
This adds an index update listening step to spk commands that update packages: `publish`, `deprecate`, `undeprecate`, and `remove`. After finishing their current processing, these comands will wait and listen to messages on an index updates topic to verify their changes have made it into the repository's index before finishing.

This also adds the `spk repo indexer ...` command to start an index updating process (an Indexer) that will listen for package update messages for a given repo, and kick off index updates for that repo's index as packages are changed.  The Indexer will send index status event messages to the index updates topic for other spk commands to listen to. The  `publish`, `deprecate`, `undeprecate`, and `remove` commands will use those messages to determine when the index the care about has been updated.

This also extends the spk configuration for messaging channels, indexes, and indexers to include the index status topic, naming channels and indexers, and various new timeouts and settings.

The idea is to support automatic updating of an index when packages change. A site would need an external messaging system set up. But then the site could configure a message channel and an indexer, and run an indexer as a service (e.g. for the origin repo). Then all the spk commands that modify packages in that repo, would send messages, via the message channel, to the indexer for it to update the index automatically, and the indexer would send messages back to the commands to let them know the index now contains their changes. 

This is another PR in the chain for adding indexes to spk solves:
1. #1336
2. #1337
3. #1338
4. #1339
5. #1340
6. #1344
7. #1354
8. #1355
9. #1356
10. this PR
11. #1364
12. #1368
13. #1374