### PR TITLE
Fix resolvo build-env option propagation

### DIFF
--- a/crates/spk-solve/src/solvers/resolvo/mod.rs
+++ b/crates/spk-solve/src/solvers/resolvo/mod.rs
@@ -232,6 +232,11 @@ impl Solver {
         .map_err(|err| Error::String(format!("Tokio panicked? {err}")))??;
 
         let mut solution_options = OptionMap::default();
+        for request in &self.requests {
+            if let RequestWithOptions::Var(var_req) = request {
+                solution_options.insert(var_req.var.clone(), var_req.value.to_string());
+            }
+        }
         let mut solution_adds = Vec::with_capacity(solvables.len());
         // Keep track of the index of each package added to `solution_adds` in
         // order to merge components. Components of a package come out of the

--- a/crates/spk-solve/src/solvers/solver_test.rs
+++ b/crates/spk-solve/src/solvers/solver_test.rs
@@ -3529,3 +3529,28 @@ async fn install_requirement_vars_found_in_solution(
         solution.options()
     );
 }
+
+/// Build-environment var options with assigned values should appear in the
+/// resulting Solution options.
+#[rstest]
+#[case::step(step_solver())]
+#[case::resolvo(resolvo_solver())]
+#[tokio::test]
+async fn build_environment_var_options_found_in_solution(#[case] mut solver: SolverImpl) {
+    let recipe = recipe!({
+        "pkg": "simple/1.2.3",
+        "api": "v0/package",
+        "build": {
+            "options": [{"var": "my_var/true"}],
+        },
+    });
+
+    solver.configure_for_build_environment(&recipe).unwrap();
+
+    let solution = run_and_print_resolve_for_tests(&mut solver).await.unwrap();
+    assert!(
+        solution.options().get(opt_name!("my_var")) == Some(&"true".to_string()),
+        "expected my_var/true to be in solution options, got: {:#?}",
+        solution.options()
+    );
+}


### PR DESCRIPTION
Add a cross-solver regression test for build-environment var options in Solution. The new test uses a simple recipe with my_var/true and asserts both solver flavors populate the option.

Resolvo only collected options from solved packages and global-var solvables, which missed top-level var requests produced by configure_for_build_environment. Seed solution options from those requests before processing solved records to match step behavior.