### PR TITLE
Add env mode to spk export

### DIFF
--- a/crates/spk-cli/group3/Cargo.toml
+++ b/crates/spk-cli/group3/Cargo.toml
@@ -20,6 +20,7 @@ colored = { workspace = true }
 futures = { workspace = true }
 spfs = { workspace = true }
 spk-cli-common = { workspace = true }
+spk-solve = { workspace = true }
 spk-storage = { workspace = true }
 spk-schema = { workspace = true }
 spfs-cli-common = { workspace = true }

--- a/crates/spk-cli/group3/src/cmd_export.rs
+++ b/crates/spk-cli/group3/src/cmd_export.rs
@@ -7,7 +7,9 @@ use std::sync::Arc;
 use clap::{Args, ValueHint};
 use colored::Colorize;
 use miette::{Result, bail};
-use spk_cli_common::{CommandArgs, Run, flags};
+use spk_cli_common::{CommandArgs, Run, build_required_packages, flags};
+use spk_schema::Package;
+use spk_solve::{Solver, SolverMut};
 use spk_storage as storage;
 
 #[cfg(test)]
@@ -18,7 +20,7 @@ mod cmd_export_test;
 #[derive(Args)]
 pub struct Export {
     #[clap(flatten)]
-    pub repos: flags::Repositories,
+    pub solver: flags::Solver,
     #[clap(flatten)]
     pub options: flags::Options,
     #[clap(flatten)]
@@ -27,28 +29,59 @@ pub struct Export {
     #[clap(short, long, global = true, action = clap::ArgAction::Count)]
     pub verbose: u8,
 
-    /// The package to export
-    #[clap(name = "PKG")]
-    pub package: String,
+    /// Resolve one or more requests and export all solved packages
+    ///
+    /// Because this flag accepts a variable number of requests, the output
+    /// path cannot be given as a positional argument in this mode; use
+    /// --file/-f to specify a custom output filename.
+    #[clap(
+        long = "env",
+        value_name = "REQUEST",
+        num_args = 1..,
+        action = clap::ArgAction::Append
+    )]
+    pub env_requests: Vec<String>,
 
-    /// The file to export into (Defaults to the name and version of the package)
+    /// The package to export (single-package mode)
+    #[clap(name = "PKG", required_unless_present = "env_requests")]
+    pub package: Option<String>,
+
+    // The output path can be given two ways: as a positional FILE (the
+    // long-standing single-package spelling) or via --file/-f. clap cannot
+    // back both spellings with a single field, since a positional argument
+    // cannot also carry a long/short flag, so each spelling needs its own
+    // field. --env mode is variadic and would swallow a trailing positional,
+    // so only --file works there. The two are resolved into one effective
+    // path in `run`, where supplying both at once is rejected.
+    /// The file to export into (single-package mode)
+    ///
+    /// A convenience spelling for single-package exports. The same path can
+    /// be given with --file/-f instead; the two cannot be combined. This
+    /// positional form is not available in --env mode.
     #[arg(value_hint = ValueHint::FilePath, value_name = "FILE")]
-    pub filename: Option<std::path::PathBuf>,
+    pub positional_file: Option<std::path::PathBuf>,
+
+    /// The file to export into
+    ///
+    /// Works in both single-package and --env mode. In single-package mode
+    /// it is an alternative to the positional FILE. In --env mode it is the
+    /// only way to set a custom output path, since the path cannot be given
+    /// as a positional argument there; if omitted in --env mode a filename
+    /// is derived from the requests.
+    #[arg(
+        long = "file",
+        short = 'f',
+        value_hint = ValueHint::FilePath,
+        value_name = "FILE"
+    )]
+    pub output_file: Option<std::path::PathBuf>,
 }
 
-#[async_trait::async_trait]
-impl Run for Export {
-    type Output = i32;
-
-    async fn run(&mut self) -> Result<Self::Output> {
-        let options = self.options.get_options()?;
-
-        let names_and_repos = self.repos.get_repos_for_non_destructive_operation().await?;
-        let repo_handles = names_and_repos
-            .into_iter()
-            .map(|(_, r)| Arc::new(r))
-            .collect::<Vec<_>>();
-        let repos = repo_handles
+impl Export {
+    fn get_source_spfs_repos_from_handles(
+        repo_handles: &[Arc<storage::RepositoryHandle>],
+    ) -> Result<Vec<&storage::SpfsRepository>> {
+        repo_handles
             .iter()
             .map(|repo| match &**repo {
                 storage::RepositoryHandle::SPFS(repo) => Ok(repo),
@@ -58,32 +91,155 @@ impl Run for Export {
                     bail!("Only spfs repositories are supported")
                 }
             })
-            .collect::<Result<Vec<_>>>()?;
+            .collect::<Result<Vec<_>>>()
+    }
 
-        let pkg = self
-            .requests
-            .parse_idents(&options, [self.package.as_str()], repo_handles.as_slice())
-            .await?
-            .pop()
-            .unwrap();
-
+    fn derive_single_package_filename(pkg: &spk_schema::AnyIdent) -> std::path::PathBuf {
         let mut build = String::new();
         if let Some(b) = pkg.build() {
             build = format!("_{b}");
         }
-        let filename = self.filename.clone().unwrap_or_else(|| {
-            std::path::PathBuf::from(format!("{}_{}{build}.spk", pkg.name(), pkg.version()))
-        });
-        let res = storage::export_package(repos.as_slice(), &pkg, &filename).await;
-        if let Err(spk_storage::Error::PackageNotFound(_)) = res {
+        std::path::PathBuf::from(format!("{}_{}{build}.spk", pkg.name(), pkg.version()))
+    }
+
+    fn sanitize_filename_base(input: &str) -> String {
+        let mut out = String::new();
+        let mut last_was_dash = false;
+        for ch in input.chars() {
+            let mapped = if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.') {
+                ch.to_ascii_lowercase()
+            } else {
+                '-'
+            };
+            if mapped == '-' {
+                if last_was_dash {
+                    continue;
+                }
+                last_was_dash = true;
+            } else {
+                last_was_dash = false;
+            }
+            out.push(mapped);
+        }
+        let trimmed = out.trim_matches('-');
+        if trimmed.is_empty() {
+            "solution".to_string()
+        } else {
+            trimmed.to_string()
+        }
+    }
+
+    fn derive_env_filename(requests: &[String]) -> std::path::PathBuf {
+        let base = requests
+            .first()
+            .map(|req| Self::sanitize_filename_base(req))
+            .unwrap_or_else(|| "solution".to_string());
+        if requests.len() > 1 {
+            std::path::PathBuf::from(format!("{base}-plus-{}.spk", requests.len() - 1))
+        } else {
+            std::path::PathBuf::from(format!("{base}.spk"))
+        }
+    }
+
+    fn warn_and_cleanup_failed_archive(
+        filename: &std::path::Path,
+        res: &std::result::Result<(), spk_storage::Error>,
+        warn_for_package_not_found: bool,
+    ) {
+        if warn_for_package_not_found && let Err(spk_storage::Error::PackageNotFound(_)) = res {
             tracing::warn!("Ensure that you are specifying at least a package and");
             tracing::warn!("version number when exporting from the local repository");
         }
         if res.is_err()
-            && let Err(err) = std::fs::remove_file(&filename)
+            && let Err(err) = std::fs::remove_file(filename)
         {
             tracing::warn!(?err, path=?filename, "failed to clean up incomplete archive");
         }
+    }
+}
+
+#[async_trait::async_trait]
+impl Run for Export {
+    type Output = i32;
+
+    async fn run(&mut self) -> Result<Self::Output> {
+        if self.positional_file.is_some() && self.output_file.is_some() {
+            bail!("Specify either a positional FILE or --file, not both");
+        }
+        if !self.env_requests.is_empty()
+            && (self.package.is_some() || self.positional_file.is_some())
+        {
+            bail!("--env mode does not accept positional PKG/FILE arguments");
+        }
+
+        if self.env_requests.is_empty() {
+            let options = self.options.get_options()?;
+            let names_and_repos = self
+                .solver
+                .repos
+                .get_repos_for_non_destructive_operation()
+                .await?;
+            let repo_handles = names_and_repos
+                .into_iter()
+                .map(|(_, r)| Arc::new(r))
+                .collect::<Vec<_>>();
+            let repos = Self::get_source_spfs_repos_from_handles(repo_handles.as_slice())?;
+
+            let package = self
+                .package
+                .as_ref()
+                .expect("clap should require PKG when --env is not provided");
+            let pkg = self
+                .requests
+                .parse_idents(&options, [package.as_str()], repo_handles.as_slice())
+                .await?
+                .pop()
+                .unwrap();
+
+            let filename = self
+                .output_file
+                .clone()
+                .or_else(|| self.positional_file.clone())
+                .unwrap_or_else(|| Self::derive_single_package_filename(&pkg));
+            let res = storage::export_package(repos.as_slice(), &pkg, &filename).await;
+            Self::warn_and_cleanup_failed_archive(&filename, &res, true);
+            res?;
+            println!("{}: {:?}", "Created".green(), filename);
+            return Ok(0);
+        }
+
+        let mut solver = self.solver.get_solver(&self.options).await?;
+        let (requests, extra_options) = self
+            .requests
+            .parse_requests(&self.env_requests, &self.options, solver.repositories())
+            .await?;
+        solver.update_options(extra_options);
+        for request in requests {
+            solver.add_request(request);
+        }
+
+        let formatter = self
+            .solver
+            .decision_formatter_settings
+            .get_formatter(self.verbose)?;
+        let solution = solver.run_and_print_resolve(&formatter).await?;
+        let compiled_solution = build_required_packages(&solution, solver.clone()).await?;
+
+        let repo_handles = compiled_solution.repositories();
+        let repos = Self::get_source_spfs_repos_from_handles(repo_handles.as_slice())?;
+        let solved_packages = compiled_solution
+            .items()
+            .map(|item| item.spec.ident().to_any_ident())
+            .collect::<std::collections::BTreeSet<_>>();
+
+        let filename = self
+            .output_file
+            .clone()
+            .unwrap_or_else(|| Self::derive_env_filename(&self.env_requests));
+        let res =
+            storage::export_packages(repos.as_slice(), solved_packages.into_iter(), &filename)
+                .await;
+        Self::warn_and_cleanup_failed_archive(&filename, &res, false);
         res?;
         println!("{}: {:?}", "Created".green(), filename);
         Ok(0)
@@ -93,6 +249,9 @@ impl Run for Export {
 impl CommandArgs for Export {
     fn get_positional_args(&self) -> Vec<String> {
         // The important positional args for an export are the packages
-        vec![self.package.clone()]
+        if !self.env_requests.is_empty() {
+            return self.env_requests.clone();
+        }
+        self.package.clone().into_iter().collect()
     }
 }

--- a/crates/spk-cli/group3/src/cmd_export_test.rs
+++ b/crates/spk-cli/group3/src/cmd_export_test.rs
@@ -2,14 +2,23 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/spkenv/spk
 
+use clap::Parser;
+use futures::TryStreamExt;
 use rstest::rstest;
 use spfs::prelude::*;
 use spfstest::spfstest;
 use spk_build::{BinaryPackageBuilder, BuildSource};
+use spk_cli_common::Run;
 use spk_schema::foundation::option_map;
 use spk_schema::{Package, recipe};
 use spk_solve::SolverImpl;
 use spk_storage::fixtures::*;
+
+#[derive(Parser)]
+struct Opt {
+    #[clap(flatten)]
+    export: super::Export,
+}
 
 fn step_solver() -> SolverImpl {
     SolverImpl::Step(spk_solve::StepSolver::default())
@@ -133,5 +142,325 @@ async fn test_export_works_with_missing_builds(#[case] solver: SolverImpl) {
                 red_spec.ident().build()
             ),
         ]
+    );
+}
+
+#[tokio::test]
+async fn test_export_rejects_positional_file_and_file_flag_together() {
+    // In single-package mode the output path may be given either as a
+    // positional FILE or via --file/-f, but supplying both at once is
+    // ambiguous and must be rejected.
+    let mut opt = Opt::try_parse_from([
+        "export",
+        "spk-export-test/1.0.0",
+        "positional.spk",
+        "--file",
+        "flag.spk",
+    ])
+    .unwrap();
+    let result = opt.export.run().await;
+    let err = result.expect_err("supplying both a positional FILE and --file should error");
+    assert!(
+        err.to_string().contains("not both"),
+        "unexpected error message: {err}"
+    );
+}
+
+#[test]
+fn test_derive_env_filename_from_requests() {
+    assert_eq!(
+        super::Export::derive_env_filename(&[
+            "spk-solve-export-top/1.0.0".to_string(),
+            "spk-solve-export-dep/1.0.0".to_string(),
+        ]),
+        std::path::PathBuf::from("spk-solve-export-top-1.0.0-plus-1.spk")
+    );
+}
+
+#[spfstest]
+#[rstest]
+#[case::step(step_solver())]
+#[case::resolvo(resolvo_solver())]
+#[tokio::test]
+async fn test_export_solve_mode_only_exports_selected_builds(#[case] solver: SolverImpl) {
+    let rt = spfs_runtime().await;
+
+    let dep_spec = recipe!(
+        {
+            "pkg": "spk-solve-export-selected-build/1.0.0",
+            "build": {
+                "options": [
+                    {"var": "color"},
+                ],
+                "script": "touch /spfs/dep-file.txt",
+            },
+        }
+    );
+    let top_spec = recipe!(
+        {
+            "pkg": "spk-solve-export-selected-build-top/1.0.0",
+            "build": {"script": "touch /spfs/top-file.txt"},
+            "install": {
+                "requirements": [{"pkg": "spk-solve-export-selected-build/1.0.0"}]
+            },
+        }
+    );
+    rt.tmprepo.publish_recipe(&dep_spec).await.unwrap();
+    let (blue_dep, _) =
+        BinaryPackageBuilder::from_recipe_with_solver(dep_spec.clone(), solver.clone())
+            .with_source(BuildSource::LocalPath(".".into()))
+            .build_and_publish(option_map! {"color" => "blue"}, &*rt.tmprepo)
+            .await
+            .unwrap();
+    let (red_dep, _) = BinaryPackageBuilder::from_recipe_with_solver(dep_spec, solver.clone())
+        .with_source(BuildSource::LocalPath(".".into()))
+        .build_and_publish(option_map! {"color" => "red"}, &*rt.tmprepo)
+        .await
+        .unwrap();
+    rt.tmprepo.publish_recipe(&top_spec).await.unwrap();
+    BinaryPackageBuilder::from_recipe_with_solver(top_spec, solver)
+        .with_source(BuildSource::LocalPath(".".into()))
+        .build_and_publish(option_map! {}, &*rt.tmprepo)
+        .await
+        .unwrap();
+
+    let filename = rt.tmpdir.path().join("selected-build-export.spk");
+    let mut opt = Opt::try_parse_from([
+        "export",
+        "--local-repo-only",
+        "--index-use",
+        "disabled",
+        "--opt",
+        "color=red",
+        "--env",
+        "spk-solve-export-selected-build-top/1.0.0",
+        "--file",
+        &filename.to_string_lossy(),
+    ])
+    .unwrap();
+    let result = opt.export.run().await;
+    assert!(matches!(result, Ok(0)), "solve export should not fail");
+
+    let mut entries = Vec::new();
+    let mut tarfile = tar::Archive::new(std::fs::File::open(&filename).unwrap());
+    for entry in tarfile.entries().unwrap() {
+        entries.push(entry.unwrap().path().unwrap().to_string_lossy().to_string());
+    }
+
+    let red_build_tag = format!(
+        "tags/spk/pkg/spk-solve-export-selected-build/1.0.0/{}",
+        red_dep.ident().build()
+    );
+    let blue_build_tag = format!(
+        "tags/spk/pkg/spk-solve-export-selected-build/1.0.0/{}",
+        blue_dep.ident().build()
+    );
+    let red_build_spec_tag = format!(
+        "tags/spk/spec/spk-solve-export-selected-build/1.0.0/{}.tag",
+        red_dep.ident().build()
+    );
+    let blue_build_spec_tag = format!(
+        "tags/spk/spec/spk-solve-export-selected-build/1.0.0/{}.tag",
+        blue_dep.ident().build()
+    );
+
+    assert!(
+        entries.iter().any(|entry| entry == &red_build_tag),
+        "archive should include the selected dependency build"
+    );
+    assert!(
+        entries.iter().any(|entry| entry == &red_build_spec_tag),
+        "archive should include the selected dependency build spec"
+    );
+    assert!(
+        entries.iter().all(|entry| entry != &blue_build_tag),
+        "archive should not include an unselected dependency build"
+    );
+    assert!(
+        entries.iter().all(|entry| entry != &blue_build_spec_tag),
+        "archive should not include an unselected dependency build spec"
+    );
+}
+
+#[spfstest]
+#[rstest]
+#[case::step(step_solver())]
+#[case::resolvo(resolvo_solver())]
+#[tokio::test]
+async fn test_export_solve_mode_exports_whole_solution(#[case] solver: SolverImpl) {
+    let rt = spfs_runtime().await;
+
+    let dep_spec = recipe!(
+        {
+            "pkg": "spk-solve-export-dep/1.0.0",
+            "build": {"script": "touch /spfs/dep-file.txt"},
+        }
+    );
+    let top_spec = recipe!(
+        {
+            "pkg": "spk-solve-export-top/1.0.0",
+            "build": {"script": "touch /spfs/top-file.txt"},
+            "install": {"requirements": [{"pkg": "spk-solve-export-dep/1.0.0"}]},
+        }
+    );
+    rt.tmprepo.publish_recipe(&dep_spec).await.unwrap();
+    BinaryPackageBuilder::from_recipe_with_solver(dep_spec, solver.clone())
+        .with_source(BuildSource::LocalPath(".".into()))
+        .build_and_publish(option_map! {}, &*rt.tmprepo)
+        .await
+        .unwrap();
+    rt.tmprepo.publish_recipe(&top_spec).await.unwrap();
+    BinaryPackageBuilder::from_recipe_with_solver(top_spec, solver)
+        .with_source(BuildSource::LocalPath(".".into()))
+        .build_and_publish(option_map! {}, &*rt.tmprepo)
+        .await
+        .unwrap();
+
+    let filename = rt.tmpdir.path().join("solution-export.spk");
+    let mut opt = Opt::try_parse_from([
+        "export",
+        "--local-repo-only",
+        "--index-use",
+        "disabled",
+        "--env",
+        "spk-solve-export-top/1.0.0",
+        "--file",
+        &filename.to_string_lossy(),
+    ])
+    .unwrap();
+    let result = opt.export.run().await;
+    assert!(matches!(result, Ok(0)), "solve export should not fail");
+
+    let mut entries = Vec::new();
+    let mut tarfile = tar::Archive::new(std::fs::File::open(&filename).unwrap());
+    for entry in tarfile.entries().unwrap() {
+        entries.push(entry.unwrap().path().unwrap().to_string_lossy().to_string());
+    }
+    entries.sort();
+    assert!(
+        entries
+            .iter()
+            .any(|entry| entry == "tags/spk/pkg/spk-solve-export-top/1.0.0"),
+        "archive should include top package tag directory"
+    );
+    assert!(
+        entries
+            .iter()
+            .any(|entry| entry == "tags/spk/pkg/spk-solve-export-dep/1.0.0"),
+        "archive should include dependency package tag directory"
+    );
+
+    let local_repo = spk_storage::local_repository().await.unwrap();
+    let tar_repo = spfs::storage::tar::TarRepository::open(&filename)
+        .await
+        .unwrap();
+    let tar_repo: spfs::storage::RepositoryHandle = tar_repo.into();
+    let env_spec = tar_repo
+        .iter_tags()
+        .map_ok(|(spec, _)| spec)
+        .try_collect()
+        .await
+        .unwrap();
+    let syncer = spfs_cli_common::Sync {
+        sync: false,
+        resync: true,
+        check: false,
+        max_concurrent_manifests: 10,
+        max_concurrent_payloads: 10,
+        progress: None,
+    }
+    .get_syncer(&local_repo, &local_repo);
+    let sync_result = syncer.clone_with_source(&tar_repo).sync_env(env_spec).await;
+    assert!(
+        sync_result.is_ok(),
+        "import-equivalent sync should not fail"
+    );
+}
+
+#[spfstest]
+#[rstest]
+#[case::step(step_solver())]
+#[case::resolvo(resolvo_solver())]
+#[tokio::test]
+async fn test_export_env_mode_multiple_requests_with_custom_filename(#[case] solver: SolverImpl) {
+    let rt = spfs_runtime().await;
+
+    // Two independent packages so we can request both at once and confirm
+    // that --env accepts multiple requests alongside a custom output file.
+    let first_spec = recipe!(
+        {
+            "pkg": "spk-env-export-first/1.0.0",
+            "build": {"script": "touch /spfs/first-file.txt"},
+        }
+    );
+    let second_spec = recipe!(
+        {
+            "pkg": "spk-env-export-second/1.0.0",
+            "build": {"script": "touch /spfs/second-file.txt"},
+        }
+    );
+    rt.tmprepo.publish_recipe(&first_spec).await.unwrap();
+    BinaryPackageBuilder::from_recipe_with_solver(first_spec, solver.clone())
+        .with_source(BuildSource::LocalPath(".".into()))
+        .build_and_publish(option_map! {}, &*rt.tmprepo)
+        .await
+        .unwrap();
+    rt.tmprepo.publish_recipe(&second_spec).await.unwrap();
+    BinaryPackageBuilder::from_recipe_with_solver(second_spec, solver)
+        .with_source(BuildSource::LocalPath(".".into()))
+        .build_and_publish(option_map! {}, &*rt.tmprepo)
+        .await
+        .unwrap();
+
+    let filename = rt.tmpdir.path().join("custom-multi-export.spk");
+    let mut opt = Opt::try_parse_from([
+        "export",
+        "--local-repo-only",
+        "--index-use",
+        "disabled",
+        "--env",
+        "spk-env-export-first/1.0.0",
+        "spk-env-export-second/1.0.0",
+        "--file",
+        &filename.to_string_lossy(),
+    ])
+    .unwrap();
+
+    // Both requests should be parsed into env_requests, leaving the custom
+    // --file to be used verbatim as the output path.
+    assert_eq!(
+        opt.export.env_requests,
+        vec![
+            "spk-env-export-first/1.0.0".to_string(),
+            "spk-env-export-second/1.0.0".to_string(),
+        ],
+    );
+    assert_eq!(opt.export.output_file.as_deref(), Some(filename.as_path()));
+
+    let result = opt.export.run().await;
+    assert!(matches!(result, Ok(0)), "env export should not fail");
+
+    // The custom filename must be honored rather than a derived name.
+    assert!(
+        filename.exists(),
+        "archive should be written to the custom --file path"
+    );
+
+    let mut entries = Vec::new();
+    let mut tarfile = tar::Archive::new(std::fs::File::open(&filename).unwrap());
+    for entry in tarfile.entries().unwrap() {
+        entries.push(entry.unwrap().path().unwrap().to_string_lossy().to_string());
+    }
+    assert!(
+        entries
+            .iter()
+            .any(|entry| entry == "tags/spk/pkg/spk-env-export-first/1.0.0"),
+        "archive should include the first requested package"
+    );
+    assert!(
+        entries
+            .iter()
+            .any(|entry| entry == "tags/spk/pkg/spk-env-export-second/1.0.0"),
+        "archive should include the second requested package"
     );
 }

--- a/crates/spk-storage/src/lib.rs
+++ b/crates/spk-storage/src/lib.rs
@@ -36,6 +36,7 @@ pub use storage::{
     SpfsRepository,
     Storage,
     export_package,
+    export_packages,
     find_path_providers,
     inject_path_repo_into_spfs_config,
     local_repository,

--- a/crates/spk-storage/src/storage/archive.rs
+++ b/crates/spk-storage/src/storage/archive.rs
@@ -13,12 +13,39 @@ use variantly::Variantly;
 use super::{Repository, SpfsRepository};
 use crate::{Error, NameAndRepository, Result};
 
+/// Export a single package ident into a `.spk` tar repository archive.
+///
+/// If a version ident is provided, all available builds for that version are
+/// included. If a build ident is provided, the matching build and its recipe
+/// are exported.
 pub async fn export_package(
     source_repos: &[&SpfsRepository],
     pkg: impl AsRef<AnyIdent>,
     filename: impl AsRef<Path>,
 ) -> Result<()> {
-    let pkg = pkg.as_ref();
+    export_packages(source_repos, [pkg.as_ref().clone()], filename).await
+}
+
+/// Export multiple packages into a single `.spk` tar repository archive.
+///
+/// Each requested ident is copied from the first source repository that can
+/// satisfy it. Version idents include all available builds for that version,
+/// while build idents include the matching build and its recipe.
+pub async fn export_packages<I>(
+    source_repos: &[&SpfsRepository],
+    pkgs: I,
+    filename: impl AsRef<Path>,
+) -> Result<()>
+where
+    I: IntoIterator<Item = AnyIdent>,
+{
+    let requested_packages = pkgs.into_iter().collect_vec();
+    if requested_packages.is_empty() {
+        return Err(Error::String(
+            "No packages were requested for export".to_string(),
+        ));
+    }
+
     // Make filename absolute as spfs::runtime::makedirs_with_perms does not handle
     // relative paths properly.
     let filename = std::env::current_dir()
@@ -55,86 +82,95 @@ pub async fn export_package(
         spfs::storage::RepositoryHandle::from(tar_repo),
     ))?;
 
-    // these are sorted to ensure that the recipe is published
-    // before any build - it's only an error in testing, but still best practice
-    let mut to_transfer = std::collections::BTreeSet::new();
-    to_transfer.insert(pkg.clone());
-    if pkg.build().is_none() {
-        for repo in source_repos {
-            to_transfer.extend(
-                repo.list_package_builds(pkg.as_version_ident())
-                    .await?
-                    .into_iter()
-                    .map(|pkg| pkg.into_any_ident()),
-            );
-        }
-    } else {
-        to_transfer.insert(pkg.with_build(None));
-    }
+    // Keep track of what we have already copied so multiple requests that
+    // overlap don't repeatedly transfer the same package/spec data.
+    let mut copied = std::collections::BTreeSet::<AnyIdent>::new();
 
-    'pkg: for transfer_pkg in to_transfer.into_iter() {
-        if transfer_pkg.is_embedded() {
-            // Don't attempt to export an embedded package; the stub
-            // will be recreated if exporting its provider.
-            continue;
+    for pkg in requested_packages {
+        // These are sorted to ensure that the recipe is published before any
+        // build. It's only an error in testing, but still best practice.
+        let mut to_transfer = std::collections::BTreeSet::new();
+        to_transfer.insert(pkg.clone());
+        if pkg.build().is_none() {
+            for repo in source_repos {
+                to_transfer.extend(
+                    repo.list_package_builds(pkg.as_version_ident())
+                        .await?
+                        .into_iter()
+                        .map(|pkg| pkg.into_any_ident()),
+                );
+            }
+        } else {
+            to_transfer.insert(pkg.with_build(None));
         }
 
-        #[derive(Variantly)]
-        enum CopyResult {
-            VersionNotFound,
-            BuildNotFound,
-            Err(Error),
-        }
-
-        let mut first_error = None;
-        let mut all_errors_are_build_not_found = true;
-
-        for (position, repo) in source_repos.iter().with_position() {
-            let err = match copy_any(transfer_pkg.clone(), repo, &target_repo).await {
-                Ok(_) => continue 'pkg,
-                Err(Error::PackageNotFound(ident)) => {
-                    if ident.build().is_some() {
-                        CopyResult::BuildNotFound
-                    } else {
-                        CopyResult::VersionNotFound
-                    }
-                }
-                Err(err) => CopyResult::Err(err),
-            };
-
-            // `list_package_builds` can return builds that only exist as spfs tags
-            // under `spk/spec`, meaning the build doesn't really exist. Ignore
-            // `PackageNotFound` about these ... unless the build was
-            // explicitly named to be archived.
-            //
-            // Consider changing `list_package_builds` so it doesn't do that
-            // anymore, although it has a comment that it is doing so
-            // intentionally. Maybe it should return a richer type that describes
-            // if only the "spec build" exists and that info could be used here.
-            all_errors_are_build_not_found = all_errors_are_build_not_found
-                && matches!(err, CopyResult::BuildNotFound)
-                && pkg.build().is_none();
-
-            // We'll report the error from the first repo that failed, under the
-            // assumption that the repo(s) listed first are more likely to be
-            // where the problem is fixable (e.g., the local repo).
-            if first_error.is_none() {
-                first_error = Some(err);
+        'transfer: for transfer_pkg in to_transfer.into_iter() {
+            if transfer_pkg.is_embedded() || copied.contains(&transfer_pkg) {
+                // Don't attempt to export an embedded package; the stub
+                // will be recreated if exporting its provider.
+                continue;
             }
 
-            match position {
-                Position::Last | Position::Only if all_errors_are_build_not_found => {
-                    continue 'pkg;
+            #[derive(Variantly)]
+            enum CopyResult {
+                VersionNotFound,
+                BuildNotFound,
+                Err(Error),
+            }
+
+            let mut first_error = None;
+            let mut all_errors_are_build_not_found = true;
+
+            for (position, repo) in source_repos.iter().with_position() {
+                let err = match copy_any(transfer_pkg.clone(), repo, &target_repo).await {
+                    Ok(_) => {
+                        copied.insert(transfer_pkg.clone());
+                        continue 'transfer;
+                    }
+                    Err(Error::PackageNotFound(ident)) => {
+                        if ident.build().is_some() {
+                            CopyResult::BuildNotFound
+                        } else {
+                            CopyResult::VersionNotFound
+                        }
+                    }
+                    Err(err) => CopyResult::Err(err),
+                };
+
+                // `list_package_builds` can return builds that only exist as spfs tags
+                // under `spk/spec`, meaning the build doesn't really exist. Ignore
+                // `PackageNotFound` about these ... unless the build was
+                // explicitly named to be archived.
+                //
+                // Consider changing `list_package_builds` so it doesn't do that
+                // anymore, although it has a comment that it is doing so
+                // intentionally. Maybe it should return a richer type that describes
+                // if only the "spec build" exists and that info could be used here.
+                all_errors_are_build_not_found = all_errors_are_build_not_found
+                    && matches!(err, CopyResult::BuildNotFound)
+                    && pkg.build().is_none();
+
+                // We'll report the error from the first repo that failed, under the
+                // assumption that the repo(s) listed first are more likely to be
+                // where the problem is fixable (e.g., the local repo).
+                if first_error.is_none() {
+                    first_error = Some(err);
                 }
-                Position::Last | Position::Only => {
-                    return Err(first_error
-                        .unwrap()
-                        .err()
-                        .unwrap_or_else(|| Error::PackageNotFound(Box::new(transfer_pkg))));
-                }
-                _ => {
-                    // Try the next repo
-                    continue;
+
+                match position {
+                    Position::Last | Position::Only if all_errors_are_build_not_found => {
+                        continue 'transfer;
+                    }
+                    Position::Last | Position::Only => {
+                        return Err(first_error
+                            .unwrap()
+                            .err()
+                            .unwrap_or_else(|| Error::PackageNotFound(Box::new(transfer_pkg))));
+                    }
+                    _ => {
+                        // Try the next repo
+                        continue;
+                    }
                 }
             }
         }

--- a/crates/spk-storage/src/storage/mod.rs
+++ b/crates/spk-storage/src/storage/mod.rs
@@ -13,7 +13,7 @@ mod repository_index;
 mod runtime;
 mod spfs;
 
-pub use archive::export_package;
+pub use archive::{export_package, export_packages};
 pub use flatbuffer_index::FlatBufferRepoIndex;
 pub use handle::RepositoryHandle;
 pub use indexed::IndexedRepository;


### PR DESCRIPTION
I had a need to export a package and all its dependencies and found that I had to export them one by one, and tediously figure out each dependency and version needed. And since I was lazy I also ended up exporting all the builds of these packages when I really only needed the one build necessary for the solve to succeed. So I had this idea to extend the `spk export` command to accept a list of requests and have it figure this all out automatically, and produce a single output file with all the packages.

## Summary
- add an `--env` mode to `spk export` that writes a complete solved archive
- preserve the existing direct package export flow
- because `--env` accepts a variable number of requests, a custom output filename is provided via `--file`/`-f` rather than a positional argument
- cover env-mode filename derivation, whole-solution export, and multiple-requests-with-custom-filename behavior

## Testing
- make nextest lint
