### PR TITLE
Fix step solver backtracking on request conflicts

### DIFF
--- a/crates/spk-solve/crates/graph/src/error.rs
+++ b/crates/spk-solve/crates/graph/src/error.rs
@@ -76,6 +76,11 @@ pub type GetMergedRequestResult<T> = std::result::Result<T, GetMergedRequestErro
 pub enum GetMergedRequestError {
     #[error("No request for: {0}")]
     NoRequestFor(String),
+    #[error("{cause}")]
+    Conflict {
+        request: Box<PkgRequest>,
+        cause: String,
+    },
     #[error(transparent)]
     #[diagnostic(forward(0))]
     Other(#[from] Box<crate::Error>),
@@ -85,6 +90,7 @@ impl From<GetMergedRequestError> for crate::Error {
     fn from(err: GetMergedRequestError) -> Self {
         match err {
             GetMergedRequestError::NoRequestFor(s) => crate::Error::String(s),
+            GetMergedRequestError::Conflict { cause, .. } => crate::Error::String(cause),
             GetMergedRequestError::Other(err) => *err,
         }
     }

--- a/crates/spk-solve/crates/graph/src/graph.rs
+++ b/crates/spk-solve/crates/graph/src/graph.rs
@@ -85,6 +85,16 @@ pub enum GraphError {
 
 pub type Result<T> = std::result::Result<T, GraphError>;
 
+/// The next unresolved package request to explore from a state.
+#[derive(Clone, Debug)]
+pub enum NextRequest {
+    /// A merged package request that can be explored normally.
+    Request(PkgRequestWithOptions),
+    /// A set of unresolved requests that already conflict and should force
+    /// the solver to backtrack before trying any builds.
+    Conflict { request: PkgRequest, cause: String },
+}
+
 #[derive(Clone, Debug)]
 pub enum Change {
     RequestPackage(RequestPackage),
@@ -1506,10 +1516,18 @@ impl State {
                     }
                     if let incompatible @ Compatibility::Incompatible(_) = merged.restrict(request)
                     {
-                        return Err(crate::Error::String(format!(
-                            "Incompatible requests for '{name}': {incompatible}",
-                        ))
-                        .into());
+                        let mut conflict = merged.pkg_request.clone();
+                        for (key, requesters) in request.requested_by.iter() {
+                            conflict
+                                .requested_by
+                                .entry(key.clone())
+                                .or_default()
+                                .extend(requesters.iter().cloned());
+                        }
+                        return Err(super::error::GetMergedRequestError::Conflict {
+                            request: Box::new(conflict),
+                            cause: format!("Incompatible requests for '{name}': {incompatible}"),
+                        });
                     }
                 }
             }
@@ -1522,7 +1540,28 @@ impl State {
         }
     }
 
-    pub fn get_next_request(&self) -> Result<Option<PkgRequestWithOptions>> {
+    fn conflicting_request_for_package(&self, name: &PkgName) -> Option<PkgRequest> {
+        let mut requests = self
+            .pkg_requests
+            .iter()
+            .filter(|request| request.pkg.name == *name);
+        let first = requests.next()?;
+        let mut combined = first.pkg_request.clone();
+        for request in requests {
+            for (key, requesters) in request.requested_by.iter() {
+                combined
+                    .requested_by
+                    .entry(key.clone())
+                    .or_default()
+                    .extend(requesters.iter().cloned());
+            }
+        }
+        Some(combined)
+    }
+
+    /// Return the next unresolved package request, or the conflicting request
+    /// that makes the current state unsatisfiable before build iteration begins.
+    pub fn get_next_request(&self) -> Option<NextRequest> {
         // Note: The next request this returns may not be as expected
         // due to the interaction of multiple requests and
         // 'IfAlreadyPresent' requests.
@@ -1545,10 +1584,24 @@ impl State {
                 // expansion of dependencies.
                 continue;
             }
-            return Ok(Some(self.get_merged_request(&request.pkg.name)?));
+            return Some(match self.get_merged_request(&request.pkg.name) {
+                Ok(request) => NextRequest::Request(request),
+                Err(super::error::GetMergedRequestError::Conflict { request, cause }) => {
+                    NextRequest::Conflict {
+                        request: *request,
+                        cause,
+                    }
+                }
+                Err(err) => NextRequest::Conflict {
+                    request: self
+                        .conflicting_request_for_package(&request.pkg.name)
+                        .expect("next unresolved request must exist"),
+                    cause: err.to_string(),
+                },
+            });
         }
 
-        Ok(None)
+        None
     }
 
     pub fn get_pkg_requests(&self) -> &Vec<Arc<CachedHash<PkgRequestWithOptions>>> {

--- a/crates/spk-solve/crates/graph/src/lib.rs
+++ b/crates/spk-solve/crates/graph/src/lib.rs
@@ -21,6 +21,7 @@ pub use graph::{
     Decision,
     Graph,
     GraphError,
+    NextRequest,
     Node,
     Note,
     REQUESTS_FOR_SAME_PACKAGE_COUNT,

--- a/crates/spk-solve/src/solvers/solver_test.rs
+++ b/crates/spk-solve/src/solvers/solver_test.rs
@@ -1568,6 +1568,86 @@ async fn test_solver_embedded_package_solvable(
     );
 }
 
+#[rstest]
+#[case::step(step_solver(), false)]
+#[case::resolvo(resolvo_solver(), true)]
+#[tokio::test]
+async fn test_solver_embedded_parent_requests_need_backtracking(
+    #[case] mut solver: SolverImpl,
+    #[case] expected_solve_result: bool,
+    #[values(true, false)] use_index: bool,
+) {
+    // The higher qt stub comes from a different maya build than the only tool
+    // stub. The step solver currently stops when those unresolved exact-build
+    // parent requests are merged, instead of backtracking to the lower qt stub
+    // from the compatible maya build.
+    let repo = make_repo!(
+        [
+            {
+                "pkg": "maya/1.0.0",
+                "build": {
+                    "options": [
+                        {"var": "color/red"}
+                    ]
+                },
+                "install": {"embedded": [{"pkg": "qt/2.0.0"}]},
+            },
+            {
+                "pkg": "maya/1.0.0",
+                "build": {
+                    "options": [
+                        {"var": "color/blue"}
+                    ]
+                },
+                "install": {
+                    "embedded": [
+                        {"pkg": "qt/1.0.0"},
+                        {"pkg": "tool/1.0.0"},
+                    ]
+                },
+            },
+            {
+                "pkg": "plugin/1.0.0",
+                "install": {
+                    "requirements": [
+                        {"pkg": "qt"},
+                        {"pkg": "tool"},
+                    ]
+                },
+            },
+        ]
+    );
+    let repo = wrap_repo_for_test(repo, use_index).await;
+    solver.add_repository(Arc::new(repo));
+    solver.add_request(pinned_request!("plugin"));
+
+    match run_and_print_resolve_for_tests(&mut solver).await {
+        Ok(solution) => {
+            assert!(expected_solve_result, "expected solve to fail");
+            assert_resolved!(solution, "maya", "1.0.0");
+            assert_resolved!(solution, "qt", "1.0.0");
+            assert_resolved!(solution, "tool", "1.0.0");
+            assert_resolved!(
+                solution,
+                "qt",
+                build =~ Build::Embedded(_)
+            );
+            assert_resolved!(
+                solution,
+                "tool",
+                build =~ Build::Embedded(_)
+            );
+        }
+        Err(err) => {
+            assert!(!expected_solve_result, "expected solve to succeed");
+            assert!(
+                err.to_string().contains("Incompatible requests for 'maya'"),
+                "expected incompatible maya requests from the step solver bug, got: {err}",
+            );
+        }
+    }
+}
+
 /// If the only option for a package request is an embedded package, the
 /// solution must also contain the parent package.
 #[rstest]

--- a/crates/spk-solve/src/solvers/solver_test.rs
+++ b/crates/spk-solve/src/solvers/solver_test.rs
@@ -1569,12 +1569,11 @@ async fn test_solver_embedded_package_solvable(
 }
 
 #[rstest]
-#[case::step(step_solver(), false)]
-#[case::resolvo(resolvo_solver(), true)]
+#[case::step(step_solver())]
+#[case::resolvo(resolvo_solver())]
 #[tokio::test]
 async fn test_solver_embedded_parent_requests_need_backtracking(
     #[case] mut solver: SolverImpl,
-    #[case] expected_solve_result: bool,
     #[values(true, false)] use_index: bool,
 ) {
     // The higher qt stub comes from a different maya build than the only tool
@@ -1620,32 +1619,81 @@ async fn test_solver_embedded_parent_requests_need_backtracking(
     let repo = wrap_repo_for_test(repo, use_index).await;
     solver.add_repository(Arc::new(repo));
     solver.add_request(pinned_request!("plugin"));
+    let solution = run_and_print_resolve_for_tests(&mut solver)
+        .await
+        .expect("solver should backtrack to the compatible embedded maya build");
 
-    match run_and_print_resolve_for_tests(&mut solver).await {
-        Ok(solution) => {
-            assert!(expected_solve_result, "expected solve to fail");
-            assert_resolved!(solution, "maya", "1.0.0");
-            assert_resolved!(solution, "qt", "1.0.0");
-            assert_resolved!(solution, "tool", "1.0.0");
-            assert_resolved!(
-                solution,
-                "qt",
-                build =~ Build::Embedded(_)
-            );
-            assert_resolved!(
-                solution,
-                "tool",
-                build =~ Build::Embedded(_)
-            );
-        }
-        Err(err) => {
-            assert!(!expected_solve_result, "expected solve to succeed");
-            assert!(
-                err.to_string().contains("Incompatible requests for 'maya'"),
-                "expected incompatible maya requests from the step solver bug, got: {err}",
-            );
-        }
-    }
+    assert_resolved!(solution, "maya", "1.0.0");
+    assert_resolved!(solution, "qt", "1.0.0");
+    assert_resolved!(solution, "tool", "1.0.0");
+    assert_resolved!(
+        solution,
+        "qt",
+        build =~ Build::Embedded(_)
+    );
+    assert_resolved!(
+        solution,
+        "tool",
+        build =~ Build::Embedded(_)
+    );
+}
+
+#[rstest]
+#[case::step(step_solver())]
+#[case::resolvo(resolvo_solver())]
+#[tokio::test]
+async fn test_solver_backtracks_real_build_request_against_embedded_build(
+    #[case] mut solver: SolverImpl,
+    #[values(true, false)] use_index: bool,
+) {
+    let real_pyside = make_build!({"pkg": "pyside/6.5.3+r.1"});
+    let real_pyside_request = real_pyside.ident().to_string();
+    let repo = make_repo!(
+        [
+            real_pyside,
+            {
+                "pkg": "consumer/2.0.0",
+                "install": {
+                    "requirements": [
+                        {"pkg": real_pyside_request},
+                    ]
+                },
+            },
+            {
+                "pkg": "consumer/1.0.0",
+            },
+            {
+                "pkg": "qt-host/1.0.0",
+                "install": {"embedded": [{"pkg": "pyside/6.5.3+r.1"}]},
+            },
+            {
+                "pkg": "app/1.0.0",
+                "install": {
+                    "requirements": [
+                        {"pkg": "consumer"},
+                        {"pkg": "qt-host"},
+                    ]
+                },
+            },
+        ]
+    );
+    let repo = wrap_repo_for_test(repo, use_index).await;
+    solver.add_repository(Arc::new(repo));
+    solver.add_request(pinned_request!("app"));
+
+    let solution = run_and_print_resolve_for_tests(&mut solver)
+        .await
+        .expect("solver should backtrack away from the exact real build request");
+
+    assert_resolved!(solution, "app", "1.0.0");
+    assert_resolved!(solution, "consumer", "1.0.0");
+    assert_resolved!(solution, "qt-host", "1.0.0");
+    assert_resolved!(solution, "pyside", "6.5.3+r.1");
+    assert_resolved!(
+        solution,
+        "pyside",
+        build =~ Build::Embedded(_)
+    );
 }
 
 /// If the only option for a package request is an embedded package, the

--- a/crates/spk-solve/src/solvers/step/solver.rs
+++ b/crates/spk-solve/src/solvers/step/solver.rs
@@ -46,6 +46,7 @@ use spk_solve_graph::{
     DEAD_STATE,
     Decision,
     Graph,
+    NextRequest,
     Node,
     Note,
     RequestPackage,
@@ -475,8 +476,16 @@ impl Solver {
         node: &mut Arc<Node>,
     ) -> Result<Option<Decision>> {
         let mut notes = Vec::<Note>::new();
-        let request = if let Some(request) = node.state.get_next_request()? {
-            request
+        let request = if let Some(request) = node.state.get_next_request() {
+            match request {
+                NextRequest::Request(request) => request,
+                NextRequest::Conflict { request, cause } => {
+                    return Err(Error::OutOfOptions(Box::new(OutOfOptions {
+                        request,
+                        notes: vec![Note::Other(cause)],
+                    })));
+                }
+            }
         } else {
             // May have a valid solution, but verify that all embedded packages
             // that are part of the solve also have their source packages
@@ -1517,6 +1526,26 @@ impl SolverRuntime {
         }
     }
 
+    fn request_conflict(err: &Error) -> Option<(PkgRequest, String)> {
+        match err {
+            Error::GraphGraphError(spk_solve_graph::GraphError::RequestError(
+                spk_solve_graph::GetMergedRequestError::Conflict { request, cause },
+            )) => Some((request.as_ref().clone(), cause.clone())),
+            Error::GraphError(graph_error) => match &**graph_error {
+                spk_solve_graph::Error::Graph(spk_solve_graph::GraphError::RequestError(
+                    spk_solve_graph::GetMergedRequestError::Conflict { request, cause },
+                )) => Some((request.as_ref().clone(), cause.clone())),
+                _ => None,
+            },
+            Error::ValidationError(
+                spk_solve_validation::Error::SpkSolverGraphGetMergedRequestError(
+                    spk_solve_graph::GetMergedRequestError::Conflict { request, cause },
+                ),
+            ) => Some((request.as_ref().clone(), cause.clone())),
+            _ => None,
+        }
+    }
+
     /// Iterate through each step of this runtime, trying to converge on a solution
     pub fn iter(&mut self) -> impl Stream<Item = Result<(Arc<Node>, Arc<Decision>)>> + Send {
         stream! {
@@ -1704,6 +1733,37 @@ impl SolverRuntime {
                         continue 'outer;
                     }
                     Err(err) => {
+                        if let Some((request, cause)) = SolverRuntime::request_conflict(&err) {
+                            let requested_by = request.get_requesters();
+                            for req in &requested_by {
+                                if let RequestedBy::PackageBuild(problem_package) = req {
+                                    self.solver.increment_problem_package_count(
+                                        problem_package.name().to_string(),
+                                    );
+                                }
+                            }
+
+                            SolverRuntime::take_a_step_back(
+                                &mut self.history,
+                                &mut self.decision,
+                                &self.solver,
+                                &cause,
+                            )
+                            .await;
+
+                            self.solver.increment_error_count(ErrorDetails::CouldNotSatisfy(
+                                request.pkg.to_string(),
+                                requested_by,
+                            ));
+
+                            if let Some(d) = self.decision.as_mut() {
+                                Arc::make_mut(d).add_notes(vec![Note::Other(cause)]);
+                            }
+
+                            yield Ok(to_yield);
+                            continue 'outer;
+                        }
+
                         let cause = format!("{}", err);
                         self.solver.increment_error_count(ErrorDetails::Message(cause));
                         yield Err(err);


### PR DESCRIPTION
We found some complicated package dependency interactions that ended up hitting errors in the step solver instead of being treated as a dead end and backtracking.

This PR adds two flavors of minimal test cases that simulate our real-world situation. However I haven't been able to show this fixes our problem entirely because the solve now just runs until out of system RAM. This is an "improvement" over erroring I suppose. Resolvo solves our real-world problem successfully.

## Summary
- add a focused embedded-package regression covering the step solver vs resolvo mismatch
- teach the step solver to backtrack when merge-time request conflicts make the current branch unsatisfiable
- keep the new regression and the rest of the `spk-solve` solver suite passing

## Testing
- cargo test -p spk-solve test_solver_embedded_parent_requests_need_backtracking -- --nocapture
- cargo test -p spk-solve --lib