### PR TITLE
Indexes 12: implements get_build_requirements() for IndexedPackage

### DIFF
--- a/crates/spk-schema/src/v0/indexed_package.rs
+++ b/crates/spk-schema/src/v0/indexed_package.rs
@@ -16,7 +16,6 @@ use spk_schema_foundation::ident::{
     PinnedValue,
     PkgRequestWithOptions,
     RequestWithOptions,
-    RequestedBy,
 };
 use spk_schema_foundation::ident_build::Build;
 use spk_schema_foundation::ident_component::Component;
@@ -26,6 +25,7 @@ use spk_schema_foundation::spec_ops::HasBuildIdent;
 use spk_schema_foundation::version::{IncompatibleReason, VarOptionProblem};
 
 use super::check_package_spec_satisfies_pkg_request;
+use super::package_spec::build_requirements_from_build_options;
 use crate::fb_converter::fb_requirements_to_requirements;
 use crate::foundation::name::PkgName;
 use crate::foundation::spec_ops::prelude::*;
@@ -497,34 +497,8 @@ impl Package for IndexedPackage {
     }
 
     fn get_build_requirements(&self) -> crate::Result<Cow<'_, RequirementsList<PinnedRequest>>> {
-        let mut requests = RequirementsList::default();
-        // A duplicated of get_build_requirements() from
-        // v0/package_spec with this line changed to call a method.
-        for opt in self.get_build_options().iter() {
-            match opt {
-                Opt::Pkg(opt) => {
-                    let mut req =
-                        opt.to_request(None, RequestedBy::BinaryBuild(self.ident().clone()))?;
-                    if req.pkg.components.is_empty() {
-                        // inject the default component for this context if needed
-                        req.pkg.components.insert(Component::default_for_build());
-                    }
-                    requests.insert_or_merge_pinned(PinnedRequest::Pkg(req))?;
-                }
-                Opt::Var(opt) => {
-                    // If no value was specified in the spec, there's
-                    // no need to turn that into a requirement to
-                    // find a var with an empty value.
-                    if let Some(value) = opt.get_value(None)
-                        && !value.is_empty()
-                    {
-                        requests.insert_or_merge_pinned(PinnedRequest::Var(
-                            opt.to_request(Some(value.as_str())),
-                        ))?;
-                    }
-                }
-            }
-        }
+        let requests =
+            build_requirements_from_build_options(self.ident(), &self.get_build_options())?;
         Ok(Cow::Owned(requests))
     }
 

--- a/crates/spk-schema/src/v0/indexed_package.rs
+++ b/crates/spk-schema/src/v0/indexed_package.rs
@@ -16,6 +16,7 @@ use spk_schema_foundation::ident::{
     PinnedValue,
     PkgRequestWithOptions,
     RequestWithOptions,
+    RequestedBy,
 };
 use spk_schema_foundation::ident_build::Build;
 use spk_schema_foundation::ident_component::Component;
@@ -496,10 +497,35 @@ impl Package for IndexedPackage {
     }
 
     fn get_build_requirements(&self) -> crate::Result<Cow<'_, RequirementsList<PinnedRequest>>> {
-        Err(Error::SpkIndexedPackageDoesNotImplement(
-            "Package".to_string(),
-            "get_build_requirements".to_string(),
-        ))
+        let mut requests = RequirementsList::default();
+        // A duplicated of get_build_requirements() from
+        // v0/package_spec with this line changed to call a method.
+        for opt in self.get_build_options().iter() {
+            match opt {
+                Opt::Pkg(opt) => {
+                    let mut req =
+                        opt.to_request(None, RequestedBy::BinaryBuild(self.ident().clone()))?;
+                    if req.pkg.components.is_empty() {
+                        // inject the default component for this context if needed
+                        req.pkg.components.insert(Component::default_for_build());
+                    }
+                    requests.insert_or_merge_pinned(PinnedRequest::Pkg(req))?;
+                }
+                Opt::Var(opt) => {
+                    // If no value was specified in the spec, there's
+                    // no need to turn that into a requirement to
+                    // find a var with an empty value.
+                    if let Some(value) = opt.get_value(None)
+                        && !value.is_empty()
+                    {
+                        requests.insert_or_merge_pinned(PinnedRequest::Var(
+                            opt.to_request(Some(value.as_str())),
+                        ))?;
+                    }
+                }
+            }
+        }
+        Ok(Cow::Owned(requests))
     }
 
     fn runtime_requirements(&self) -> Cow<'_, RequirementsList<RequestWithOptions>> {

--- a/crates/spk-schema/src/v0/package_spec.rs
+++ b/crates/spk-schema/src/v0/package_spec.rs
@@ -367,6 +367,40 @@ impl OptionValues for PackageSpec {
     }
 }
 
+/// Helper method for gathering build requirements from the a list of
+/// build options. This used by (both) v0 package implementations.
+pub fn build_requirements_from_build_options(
+    ident: &BuildIdent,
+    build_options: &[Opt],
+) -> crate::Result<RequirementsList<PinnedRequest>> {
+    let mut requests = RequirementsList::default();
+    for opt in build_options.iter() {
+        match opt {
+            Opt::Pkg(opt) => {
+                let mut req = opt.to_request(None, RequestedBy::BinaryBuild(ident.clone()))?;
+                if req.pkg.components.is_empty() {
+                    // inject the default component for this context if needed
+                    req.pkg.components.insert(Component::default_for_build());
+                }
+                requests.insert_or_merge_pinned(PinnedRequest::Pkg(req))?;
+            }
+            Opt::Var(opt) => {
+                // If no value was specified in the spec, there's
+                // no need to turn that into a requirement to
+                // find a var with an empty value.
+                if let Some(value) = opt.get_value(None)
+                    && !value.is_empty()
+                {
+                    requests.insert_or_merge_pinned(PinnedRequest::Var(
+                        opt.to_request(Some(value.as_str())),
+                    ))?;
+                }
+            }
+        }
+    }
+    Ok(requests)
+}
+
 impl Package for PackageSpec {
     type Package = Self;
     type EmbeddedPackage = EmbeddedPackageSpec;
@@ -427,32 +461,8 @@ impl Package for PackageSpec {
     }
 
     fn get_build_requirements(&self) -> crate::Result<Cow<'_, RequirementsList<PinnedRequest>>> {
-        let mut requests = RequirementsList::default();
-        for opt in self.build.options.iter() {
-            match opt {
-                Opt::Pkg(opt) => {
-                    let mut req =
-                        opt.to_request(None, RequestedBy::BinaryBuild(self.ident().clone()))?;
-                    if req.pkg.components.is_empty() {
-                        // inject the default component for this context if needed
-                        req.pkg.components.insert(Component::default_for_build());
-                    }
-                    requests.insert_or_merge_pinned(PinnedRequest::Pkg(req))?;
-                }
-                Opt::Var(opt) => {
-                    // If no value was specified in the spec, there's
-                    // no need to turn that into a requirement to
-                    // find a var with an empty value.
-                    if let Some(value) = opt.get_value(None)
-                        && !value.is_empty()
-                    {
-                        requests.insert_or_merge_pinned(PinnedRequest::Var(
-                            opt.to_request(Some(value.as_str())),
-                        ))?;
-                    }
-                }
-            }
-        }
+        let requests =
+            build_requirements_from_build_options(self.ident(), &self.get_build_options())?;
         Ok(Cow::Owned(requests))
     }
 

--- a/crates/spk-storage/src/storage/flatbuffer_index_test.rs
+++ b/crates/spk-storage/src/storage/flatbuffer_index_test.rs
@@ -253,7 +253,15 @@ fn assert_packages_are_equivalent(build_from_repo: Arc<Spec>, build_from_index: 
         "get_build_options() don't match [{pkg}]",
     );
 
-    // get_build_requirements(&self) -> crate::Result<Cow<'_, RequirementsList<PinnedRequest>>> - not implemented by SolverPackageSpec
+    assert_eq!(
+        build_from_repo
+            .get_build_requirements()
+            .expect("should have valid build requirements from repo package"),
+        build_from_index
+            .get_build_requirements()
+            .expect("should have gotten valid build requirements from index package"),
+        "get_build_requirements() don't match [{pkg}]",
+    );
 
     assert_eq!(
         build_from_repo.runtime_requirements(),


### PR DESCRIPTION
This implements the `get_build_requirements()` method for the `IndexedPackage` type using existing data in the index. The method will no longer error as unimplemented.

This is an indexes related PR, previous indexes PRs include:

9. #1356
10. #1363
11. #1364
12. This PR.
13. #1374