### PR TITLE
Fix resolvo build component constraints

### DIFF
--- a/crates/spk-solve/src/solvers/resolvo/spk_provider.rs
+++ b/crates/spk-solve/src/solvers/resolvo/spk_provider.rs
@@ -719,19 +719,6 @@ impl SpkProvider {
             .collect()
     }
 
-    /// Return a list of requirements for all the package requests found in the
-    /// given requests.
-    fn dep_pkg_requirements(&self, requests: &[RequestWithOptions]) -> Vec<Requirement> {
-        requests
-            .iter()
-            .filter_map(|req| match req {
-                RequestWithOptions::Pkg(pkg) => Some(pkg),
-                _ => None,
-            })
-            .flat_map(|req| self.pkg_request_to_known_dependencies(req).requirements)
-            .collect()
-    }
-
     pub fn is_canceled(&self) -> bool {
         self.cancel_solving.borrow().is_some()
     }
@@ -819,6 +806,27 @@ impl SpkProvider {
             }
         }
         known_deps
+    }
+
+    /// Return known dependencies for a requirement as interpreted from the
+    /// given component context.
+    fn request_to_known_dependencies_in_component_context(
+        &self,
+        requirement: &RequestWithOptions,
+        component: &Component,
+    ) -> KnownDependencies {
+        let mut requirement = requirement.clone();
+        if *component == Component::Build
+            && let RequestWithOptions::Pkg(pkg_request) = &mut requirement
+            && pkg_request.pkg.components.is_empty()
+            && !pkg_request.pkg.is_source()
+        {
+            pkg_request
+                .pkg
+                .components
+                .insert(Component::default_for_build());
+        }
+        self.request_to_known_dependencies(&requirement)
     }
 
     /// Return a new provider to restart the solve, preserving what was learned
@@ -1437,9 +1445,14 @@ impl DependencyProvider for SpkProvider {
                                     .into(),
                             );
                         });
-                        known_deps.requirements.extend(
-                            self.dep_pkg_requirements(component_spec.requirements_with_options()),
-                        );
+                        for requirement in component_spec.requirements_with_options().iter() {
+                            let kd = self.request_to_known_dependencies_in_component_context(
+                                requirement,
+                                actual_component,
+                            );
+                            known_deps.requirements.extend(kd.requirements);
+                            known_deps.constrains.extend(kd.constrains);
+                        }
                     }
                 }
                 // Also add dependencies on any packages embedded in this
@@ -1557,8 +1570,10 @@ impl DependencyProvider for SpkProvider {
                                 embedded_component.requirements_with_options().iter()
                             })
                         {
-                            let kd =
-                                self.request_to_known_dependencies(embedded_component_requirement);
+                            let kd = self.request_to_known_dependencies_in_component_context(
+                                embedded_component_requirement,
+                                actual_component,
+                            );
                             known_deps.requirements.extend(kd.requirements);
                             known_deps.constrains.extend(kd.constrains);
                         }

--- a/crates/spk-solve/src/solvers/solver_test.rs
+++ b/crates/spk-solve/src/solvers/solver_test.rs
@@ -292,9 +292,9 @@ async fn test_solver_package_with_no_recipe_from_cmd_line(
     .into_iter()
     .collect();
     repo.publish_package(&spec, &components).await.unwrap();
-    let repo = wrap_repo_for_test(repo, use_index).await;
+    let repo = Arc::new(wrap_repo_for_test(repo, use_index).await);
 
-    solver.add_repository(Arc::new(repo));
+    solver.add_repository(repo.clone());
     // Create this one as requested by the command line, rather than the tests
     let req = PinnedRequest::Pkg(PkgRequest::new(
         parse_ident_range("my-pkg").unwrap(),
@@ -463,9 +463,9 @@ async fn test_solver_dependency_incompatible(
             },
         ]
     );
-    let repo = wrap_repo_for_test(repo, use_index).await;
+    let repo = Arc::new(wrap_repo_for_test(repo, use_index).await);
 
-    solver.add_repository(Arc::new(repo));
+    solver.add_repository(repo.clone());
     solver.add_request(pinned_request!("my-plugin/1"));
     // this one is incompatible with requirements of my-plugin but the solver doesn't know it yet
     solver.add_request(pinned_request!("maya/2019"));
@@ -501,9 +501,9 @@ async fn test_solver_dependency_incompatible_stepback(
             },
         ]
     );
-    let repo = wrap_repo_for_test(repo, use_index).await;
+    let repo = Arc::new(wrap_repo_for_test(repo, use_index).await);
 
-    solver.add_repository(Arc::new(repo));
+    solver.add_repository(repo.clone());
     solver.add_request(pinned_request!("my-plugin/1"));
     // this one is incompatible with requirements of my-plugin/1.1.0 but not my-plugin/1.0
     solver.add_request(pinned_request!("maya/2019"));
@@ -2791,6 +2791,59 @@ async fn test_solver_component_availability(
         "should resolve the only version with all the components we need actually published"
     );
     assert_resolved!(solution, "python", components = ["bin", "lib"]);
+}
+
+#[rstest]
+#[case::step(step_solver())]
+#[case::resolvo(resolvo_solver())]
+#[tokio::test]
+async fn test_solver_build_component_ifalreadypresent_uses_build_context(
+    #[case] mut solver: SolverImpl,
+    #[values(true, false)] use_index: bool,
+) {
+    let repo = make_repo!(
+        [
+            {"pkg": "dep/1.0.0"},
+            {"pkg": "dep/1.0.1"},
+            {
+                "pkg": "dep-carrier/1.0.0",
+                "install": {
+                    "components": [
+                        {
+                            "name": "build",
+                            "requirements": [
+                                {"pkg": "dep/=1.0.0", "include": "IfAlreadyPresent"}
+                            ]
+                        },
+                        {
+                            "name": "run",
+                            "requirements": [
+                                {"pkg": "dep/Binary:1.0.0", "include": "IfAlreadyPresent"}
+                            ]
+                        }
+                    ]
+                }
+            }
+        ]
+    );
+    let repo = Arc::new(wrap_repo_for_test(repo, use_index).await);
+
+    solver.add_repository(repo.clone());
+    solver.add_request(pinned_request!("dep-carrier:build"));
+    solver.add_request(pinned_request!("dep:build"));
+
+    let solution = run_and_print_resolve_for_tests(&mut solver).await.unwrap();
+
+    assert_resolved!(solution, "dep", "1.0.0");
+
+    solver.reset();
+    solver.add_repository(repo);
+    solver.add_request(pinned_request!("dep-carrier"));
+    solver.add_request(pinned_request!("dep/=1.0.1"));
+
+    let solution = run_and_print_resolve_for_tests(&mut solver).await.unwrap();
+
+    assert_resolved!(solution, "dep", "1.0.1");
 }
 
 #[rstest]


### PR DESCRIPTION
This PR isolates the underlying resolvo issue that showed up in the later `v1/platform` work. Instead of depending on the full platform flow, it uses a focused solver regression to demonstrate that build-component `IfAlreadyPresent` requirements need to be preserved and interpreted in build context. That gives the rest of the stack a small, reviewable base PR to depend on.

## Summary
- preserve component-scoped `IfAlreadyPresent` constraints in resolvo
- interpret unqualified package requirements from build components in build context
- add a solver regression that isolates the bug without relying on `v1/platform`

## Testing
- make format
- cargo test -p spk-solve test_solver_build_component_ifalreadypresent_uses_build_context -- --nocapture
- cargo test -p spk-solve test_solver_constraint_and_request -- --nocapture