### PR TITLE
Add v1/platform integration regression

### DIFF
--- a/crates/spk-build/src/build/binary_test.rs
+++ b/crates/spk-build/src/build/binary_test.rs
@@ -11,6 +11,7 @@ use spfstest::spfstest;
 use spk_schema::foundation::env::data_path;
 use spk_schema::foundation::fixtures::*;
 use spk_schema::foundation::ident_component::Component;
+use spk_schema::foundation::spec_ops::HasVersion;
 use spk_schema::foundation::{opt_name, option_map, version_ident};
 use spk_schema::ident::{PkgRequest, PkgRequestWithOptions, RangeIdent, RequestWithOptions};
 use spk_schema::{
@@ -24,8 +25,8 @@ use spk_schema::{
     SpecRecipe,
     recipe,
 };
-use spk_solve::{Solution, SolverImpl};
-use spk_solve_macros::make_repo;
+use spk_solve::{Solution, SolverExt, SolverImpl, SolverMut};
+use spk_solve_macros::{make_repo, pinned_request};
 use spk_storage::fixtures::*;
 use spk_storage::{self as storage, Repository};
 
@@ -272,6 +273,122 @@ async fn test_build_package_pinning(
         }
         _ => panic!("expected a package request"),
     }
+}
+
+#[spfstest]
+#[rstest]
+#[case::step(step_solver())]
+#[case::resolvo(resolvo_solver())]
+#[tokio::test]
+async fn test_build_package_with_v1_platform_pins_frombuildenv_and_solves_binary_compatible_runtime(
+    #[case] solver: SolverImpl,
+) {
+    let rt = spfs_runtime().await;
+    let dep_1_0_0 = recipe!(
+        {
+            "pkg": "dep/1.0.0",
+            "build": {"script": "touch /spfs/dep-file"},
+        }
+    );
+    let dep_1_0_1 = recipe!(
+        {
+            "pkg": "dep/1.0.1",
+            "build": {"script": "touch /spfs/dep-file"},
+        }
+    );
+    let platform = SpecRecipe::from_yaml(
+        r#"{
+            api: "v1/platform",
+            platform: "dep-platform/1.0.0",
+            requirements: [
+                {
+                    pkg: "dep",
+                    atBuild: "=1.0.0",
+                    atRuntime: "Binary:1.0.0",
+                }
+            ],
+        }"#,
+    )
+    .unwrap();
+    let downstream = recipe!(
+        {
+            "pkg": "consumer/1.0.0",
+            "build": {
+                "script": ["touch /spfs/consumer-file"],
+                "options": [
+                    {"pkg": "dep"},
+                    {"pkg": "dep-platform/1.0.0"},
+                ],
+            },
+            "install": {
+                "requirements": [
+                    {"pkg": "dep", "fromBuildEnv": true},
+                ]
+            },
+        }
+    );
+
+    for recipe in [&dep_1_0_0, &dep_1_0_1] {
+        rt.tmprepo.publish_recipe(recipe).await.unwrap();
+
+        BinaryPackageBuilder::from_recipe_with_solver(recipe.clone(), solver.clone())
+            .with_source(BuildSource::LocalPath(".".into()))
+            .with_repository(rt.tmprepo.clone())
+            .build_and_publish(option_map! {}, &*rt.tmprepo)
+            .await
+            .unwrap();
+    }
+
+    rt.tmprepo.publish_recipe(&platform).await.unwrap();
+    let (_platform, _) = BinaryPackageBuilder::from_recipe_with_solver(platform, solver.clone())
+        .with_source(BuildSource::LocalPath(".".into()))
+        .with_repository(rt.tmprepo.clone())
+        .build_and_publish(option_map! {}, &*rt.tmprepo)
+        .await
+        .unwrap();
+
+    rt.tmprepo.publish_recipe(&downstream).await.unwrap();
+    let (downstream, _) =
+        BinaryPackageBuilder::from_recipe_with_solver(downstream.clone(), solver.clone())
+            .with_source(BuildSource::LocalPath(".".into()))
+            .with_repository(rt.tmprepo.clone())
+            .build_and_publish(option_map! {}, &*rt.tmprepo)
+            .await
+            .unwrap();
+
+    let downstream = rt.tmprepo.read_package(downstream.ident()).await.unwrap();
+    let req = downstream.runtime_requirements().first().unwrap().clone();
+    match req {
+        RequestWithOptions::Pkg(req) => {
+            assert_eq!(req.pkg.to_string(), "dep/Binary:1.0.0");
+        }
+        _ => panic!("expected a package request"),
+    }
+
+    let mut solver = solver;
+    solver.add_repository(rt.tmprepo.clone());
+    solver.add_request(pinned_request!("dep/=1.0.1"));
+    solver.add_request(pinned_request!("dep-platform"));
+    solver.add_request(pinned_request!("consumer"));
+
+    let solution = solver.solve().await.unwrap();
+    assert_eq!(
+        solution.get("dep").unwrap().spec.version().to_string(),
+        "1.0.1"
+    );
+    assert_eq!(
+        solution
+            .get("dep-platform")
+            .unwrap()
+            .spec
+            .version()
+            .to_string(),
+        "1.0.0"
+    );
+    assert_eq!(
+        solution.get("consumer").unwrap().spec.version().to_string(),
+        "1.0.0"
+    );
 }
 
 #[spfstest]

--- a/crates/spk-cli/cmd-make-binary/src/cmd_make_binary_test.rs
+++ b/crates/spk-cli/cmd-make-binary/src/cmd_make_binary_test.rs
@@ -83,3 +83,52 @@ build:
         .await
         .expect("With override, build script should succeed.");
 }
+
+#[spfstest]
+#[rstest]
+#[case::v0("v0/platform", true)]
+#[case::v1("v1/platform", true)]
+#[tokio::test]
+async fn build_a_platform(
+    tmpdir: tempfile::TempDir,
+    #[case] api: &str,
+    #[case] should_succeed: bool,
+) {
+    let _rt = spfs_runtime().await;
+
+    let filename = tmpdir.path().join("simple.spk.yaml");
+    {
+        let mut file = File::create(&filename).unwrap();
+        file.write_all(
+            format!(
+                r#"
+platform: demo-platform/1.0.0
+api: {api}
+requirements: []
+"#
+            )
+            .as_bytes(),
+        )
+        .unwrap();
+    }
+
+    let filename_str = filename.as_os_str().to_str().unwrap();
+
+    let mut opt = Opt::try_parse_from([
+        "make-binary",
+        // Don't exec a new process to move into a new runtime, this confuses
+        // coverage testing.
+        "--no-runtime",
+        "--disable-repo=origin",
+        "--here",
+        filename_str,
+    ])
+    .unwrap();
+    let res = opt.mkb.run().await;
+
+    if should_succeed {
+        res.expect("Build should succeed.");
+    } else {
+        assert!(res.is_err(), "Build should fail, got {res:?}.");
+    }
+}

--- a/crates/spk-schema/src/spec.rs
+++ b/crates/spk-schema/src/spec.rs
@@ -481,6 +481,11 @@ impl FromYaml for SpecRecipe {
                     .map_err(|err| SerdeError::new(yaml, SerdeYamlError(err)))?;
                 Ok(Self::V0Platform(inner))
             }
+            ApiVersion::V1Platform => {
+                let inner = serde_yaml::from_str(&yaml)
+                    .map_err(|err| SerdeError::new(yaml, SerdeYamlError(err)))?;
+                Ok(Self::V1Platform(inner))
+            }
             ApiVersion::V0Requirements => {
                 // Reading a list of requests/requirements file is not
                 // supported here. But it might be in future.
@@ -566,6 +571,11 @@ impl SpecFileData {
                 let inner = serde_yaml::from_value(value)
                     .map_err(|err| SerdeError::new(yaml, SerdeYamlError(err)))?;
                 SpecFileData::Recipe(Arc::new(SpecRecipe::V0Platform(inner)))
+            }
+            ApiVersion::V1Platform => {
+                let inner = serde_yaml::from_value(value)
+                    .map_err(|err| SerdeError::new(yaml, SerdeYamlError(err)))?;
+                SpecFileData::Recipe(Arc::new(SpecRecipe::V1Platform(inner)))
             }
             ApiVersion::V0Requirements => {
                 let requests: v0::Requirements = serde_yaml::from_value(value)
@@ -885,6 +895,11 @@ impl FromYaml for Spec {
                     .map_err(|err| SerdeError::new(yaml, SerdeYamlError(err)))?;
                 Ok(Self::V0Package(inner))
             }
+            ApiVersion::V1Platform => {
+                let inner = serde_yaml::from_str(&yaml)
+                    .map_err(|err| SerdeError::new(yaml, SerdeYamlError(err)))?;
+                Ok(Self::V0Package(inner))
+            }
             ApiVersion::V0Requirements => {
                 // Reading a list of requests/requirement file is not
                 // supported here. But it might be in future.
@@ -925,6 +940,8 @@ pub enum ApiVersion {
     V0Package,
     #[serde(rename = "v0/platform")]
     V0Platform,
+    #[serde(rename = "v1/platform")]
+    V1Platform,
     #[serde(rename = "v0/requirements")]
     V0Requirements,
 }

--- a/crates/spk-schema/src/spec_test.rs
+++ b/crates/spk-schema/src/spec_test.rs
@@ -358,3 +358,27 @@ fn test_template_namespace_options() {
     let recipe = rendered_data.into_recipe().unwrap();
     assert_eq!(recipe.version().to_string(), "1.0.0");
 }
+
+#[rstest]
+fn test_template_render_supports_v1_platform_recipes() {
+    static SPEC: &str = r#"
+api: v1/platform
+platform: my-platform/{{ opt.version }}
+requirements: []
+"#;
+
+    let tpl = SpecTemplate {
+        name: Some(PkgName::new("my-platform").unwrap().to_owned()),
+        file_path: "my-platform.spk.yaml".into(),
+        versions: Default::default(),
+        template: SPEC.into(),
+    };
+    let options = option_map! {"version" => "1.0.0"};
+    let rendered_data = tpl
+        .render(&options)
+        .expect("template should render a v1/platform recipe");
+    let recipe = rendered_data.into_recipe().unwrap();
+
+    assert!(matches!(recipe.as_ref(), crate::SpecRecipe::V1Platform(_)));
+    assert_eq!(recipe.ident().to_string(), "my-platform/1.0.0");
+}


### PR DESCRIPTION
This PR is the top layer of the stack and keeps the `v1/platform` integration scenario separate from the lower-level parser and solver fixes. It adds an end-to-end regression for the downstream build/runtime pinning case so we keep coverage on the platform-specific workflow without mixing that test into the more general base PRs.

## Summary
- add a `spk-build` regression for downstream `v1/platform` build/runtime pinning
- verify `fromBuildEnv: true` inherits `dep/Binary:1.0.0` from the platform-constrained build
- keep the platform-specific integration coverage separate from the lower-level solver fix

## Testing
- make format
- spfs run - -- cargo test -p spk-build test_build_package_with_v1_platform_pins_frombuildenv_and_solves_binary_compatible_runtime -- --nocapture