### PR TITLE
Fix build-component requirement handling for resolved and embedded packages

### DIFF
--- a/crates/spk-solve/crates/graph/src/graph.rs
+++ b/crates/spk-solve/crates/graph/src/graph.rs
@@ -471,9 +471,24 @@ impl<'state> DecisionBuilder<'state, '_> {
                 // is buggy now
                 continue;
             }
-            changes.extend(
-                self.requirements_to_changes(component.requirements_with_options(), &requested_by),
-            );
+            changes.extend(component.requirements_with_options().iter().flat_map(
+                |req| match req {
+                    RequestWithOptions::Pkg(req) => {
+                        let mut req = req.clone();
+                        req.add_requester(requested_by.clone());
+                        if component.name == Component::Build
+                            && req.pkg.components.is_empty()
+                            && !req.pkg.is_source()
+                        {
+                            req.pkg.components.insert(Component::default_for_build());
+                        }
+                        self.pkg_request_to_changes(&req)
+                    }
+                    RequestWithOptions::Var(req) => {
+                        vec![Change::RequestVar(RequestVar::new(req.clone()))]
+                    }
+                },
+            ));
         }
         changes
     }

--- a/crates/spk-solve/src/solvers/resolvo/spk_provider.rs
+++ b/crates/spk-solve/src/solvers/resolvo/spk_provider.rs
@@ -682,16 +682,40 @@ impl SpkProvider {
                     Some(PreReleasePolicy::IncludeAll);
             }
             pkg_request_with_component.pkg.components = BTreeSet::from_iter([component]);
-            let dep_vs = self.pool.intern_version_set(
-                dep_name,
-                RequestVS::SpkRequest(RequestWithOptions::Pkg(pkg_request_with_component)),
-            );
             match pkg_request.inclusion_policy {
                 spk_schema::ident::InclusionPolicy::Always => {
+                    let dep_vs = self.pool.intern_version_set(
+                        dep_name,
+                        RequestVS::SpkRequest(RequestWithOptions::Pkg(pkg_request_with_component)),
+                    );
                     known_deps.requirements.push(dep_vs.into());
                 }
                 spk_schema::ident::InclusionPolicy::IfAlreadyPresent => {
-                    known_deps.constrains.push(dep_vs);
+                    // "If already present" constrains the version whenever the
+                    // package is in the solution, regardless of which component
+                    // pulled it in. Constraining a specific actual component
+                    // (e.g. the build component implied by a build-context
+                    // requirement) would miss a package that is only present
+                    // under a different component, such as one provided as an
+                    // embedded build that has no separate build component.
+                    //
+                    // Every actual component shares a version with the
+                    // synthetic Base component, so constrain Base with a
+                    // component-agnostic request to bind the version to the
+                    // package's presence.
+                    let base_name =
+                        self.pool
+                            .intern_package_name(ResolvoPackageName::PkgNameBufWithComponent(
+                                PkgNameBufWithComponent {
+                                    name: pkg_request.pkg.name().to_owned(),
+                                    component: SyntheticComponent::Base,
+                                },
+                            ));
+                    pkg_request_with_component.pkg.components = BTreeSet::new();
+                    known_deps.constrains.push(self.pool.intern_version_set(
+                        base_name,
+                        RequestVS::SpkRequest(RequestWithOptions::Pkg(pkg_request_with_component)),
+                    ));
                 }
             }
         }

--- a/crates/spk-solve/src/solvers/solver_test.rs
+++ b/crates/spk-solve/src/solvers/solver_test.rs
@@ -2833,7 +2833,6 @@ async fn test_solver_build_component_ifalreadypresent_uses_build_context(
     solver.add_request(pinned_request!("dep:build"));
 
     let solution = run_and_print_resolve_for_tests(&mut solver).await.unwrap();
-
     assert_resolved!(solution, "dep", "1.0.0");
 
     solver.reset();
@@ -2844,6 +2843,142 @@ async fn test_solver_build_component_ifalreadypresent_uses_build_context(
     let solution = run_and_print_resolve_for_tests(&mut solver).await.unwrap();
 
     assert_resolved!(solution, "dep", "1.0.1");
+}
+
+#[rstest]
+#[case::step(step_solver())]
+#[case::resolvo(resolvo_solver())]
+#[tokio::test]
+async fn test_solver_build_component_ifalreadypresent_reconsiders_existing_build_request(
+    #[case] mut solver: SolverImpl,
+    #[values(true, false)] use_index: bool,
+) {
+    let repo = make_repo!(
+        [
+            {"pkg": "dep/1.0.0"},
+            {"pkg": "dep/1.0.1"},
+            {
+                "pkg": "dep-carrier/1.0.0",
+                "install": {
+                    "components": [
+                        {
+                            "name": "build",
+                            "requirements": [
+                                {"pkg": "dep/=1.0.0", "include": "IfAlreadyPresent"}
+                            ]
+                        }
+                    ]
+                }
+            }
+        ]
+    );
+    let repo = Arc::new(wrap_repo_for_test(repo, use_index).await);
+
+    solver.add_repository(repo);
+    solver.add_request(pinned_request!("dep:build"));
+    solver.add_request(pinned_request!("dep-carrier:build"));
+
+    let solution = run_and_print_resolve_for_tests(&mut solver).await.unwrap();
+    assert_resolved!(solution, "dep", "1.0.0");
+}
+
+#[rstest]
+#[case::step(step_solver())]
+#[case::resolvo(resolvo_solver())]
+#[tokio::test]
+async fn test_solver_build_component_ifalreadypresent_reconsiders_dependent_package(
+    #[case] mut solver: SolverImpl,
+    #[values(true, false)] use_index: bool,
+) {
+    let repo = make_repo!(
+        [
+            {"pkg": "dep/1.0.0"},
+            {"pkg": "dep/1.0.1"},
+            {
+                "pkg": "consumer/1.0.0",
+                "install": {"requirements": [{"pkg": "dep/=1.0.0"}]},
+            },
+            {
+                "pkg": "consumer/1.0.1",
+                "install": {"requirements": [{"pkg": "dep/=1.0.1"}]},
+            },
+            {
+                "pkg": "dep-carrier/1.0.0",
+                "install": {
+                    "components": [
+                        {
+                            "name": "build",
+                            "requirements": [
+                                {"pkg": "dep/=1.0.0", "include": "IfAlreadyPresent"}
+                            ]
+                        }
+                    ]
+                }
+            }
+        ]
+    );
+    let repo = Arc::new(wrap_repo_for_test(repo, use_index).await);
+
+    solver.add_repository(repo);
+    solver.add_request(pinned_request!("consumer"));
+    solver.add_request(pinned_request!("dep:build"));
+    solver.add_request(pinned_request!("dep-carrier:build"));
+
+    let solution = run_and_print_resolve_for_tests(&mut solver).await.unwrap();
+    assert_resolved!(solution, "consumer", "1.0.0");
+    assert_resolved!(solution, "dep", "1.0.0");
+}
+
+/// A build-component `IfAlreadyPresent` requirement must also be honored
+/// against an *embedded* package that was resolved earlier. The embedded
+/// version is dictated by its provider, so satisfying the tightened request
+/// requires reconsidering the provider rather than the embedded package.
+#[rstest]
+#[case::step(step_solver())]
+#[case::resolvo(resolvo_solver())]
+#[tokio::test]
+async fn test_solver_build_component_ifalreadypresent_reconsiders_embedded_package(
+    #[case] mut solver: SolverImpl,
+    #[values(true, false)] use_index: bool,
+) {
+    let repo = make_repo!(
+        [
+            {
+                "pkg": "embedder/1.0.0",
+                "install": {"embedded": [{"pkg": "embedded/1.0.0"}]},
+            },
+            {
+                "pkg": "embedder/2.0.0",
+                "install": {"embedded": [{"pkg": "embedded/2.0.0"}]},
+            },
+            {
+                "pkg": "dep-carrier/1.0.0",
+                "install": {
+                    "components": [
+                        {
+                            "name": "build",
+                            "requirements": [
+                                {"pkg": "embedded/=1.0.0", "include": "IfAlreadyPresent"}
+                            ]
+                        }
+                    ]
+                }
+            }
+        ]
+    );
+    let repo = Arc::new(wrap_repo_for_test(repo, use_index).await);
+
+    solver.add_repository(repo);
+    // `embedder` resolves to its highest version (2.0.0) first, providing the
+    // embedded `embedded/2.0.0`. The `dep-carrier` build component then pins
+    // `embedded` to `=1.0.0`, which the resolved embedded build cannot
+    // satisfy, so the solver must reconsider `embedder` at `1.0.0`.
+    solver.add_request(pinned_request!("embedder"));
+    solver.add_request(pinned_request!("dep-carrier:build"));
+
+    let solution = run_and_print_resolve_for_tests(&mut solver).await.unwrap();
+    assert_resolved!(solution, "embedder", "1.0.0");
+    assert_resolved!(solution, "embedded", "1.0.0");
 }
 
 #[rstest]

--- a/crates/spk-solve/src/solvers/step/solver.rs
+++ b/crates/spk-solve/src/solvers/step/solver.rs
@@ -934,6 +934,13 @@ impl Solver {
                         }
                     };
 
+                    if let Some(reconsider) = self
+                        .reconsider_invalidated_resolve(graph, &node.state, &decision)
+                        .await?
+                    {
+                        decision = reconsider;
+                    }
+
                     decision.add_notes(notes.iter().cloned());
                     return Ok(Some(decision));
                 }
@@ -944,6 +951,106 @@ impl Solver {
             request: request.pkg_request,
             notes,
         })))
+    }
+
+    /// Detect when applying `decision` would tighten the request for an
+    /// already-resolved package such that the resolved build no longer
+    /// satisfies it.
+    ///
+    /// This happens when, for example, a build-component
+    /// `IfAlreadyPresent` requirement is introduced by a package that is
+    /// resolved after the package it constrains. Rather than committing an
+    /// invalid state and re-proving resolved packages on every step, repair
+    /// the branch at the point the offending decision is made:
+    ///
+    /// - If the package is a plain repository build whose request merely
+    ///   needs tightening, step back to before it was resolved and
+    ///   re-request it carrying the tightened constraint so it is
+    ///   reconsidered with the new information (mirroring the handling of
+    ///   `ConflictingEmbeddedPackage`).
+    /// - Otherwise the branch cannot be repaired by reconsidering this one
+    ///   package: either the requests themselves conflict (e.g. a dependent
+    ///   pinned a different version), or the stale package is embedded and so
+    ///   governed by its provider rather than its own request. In those cases
+    ///   abandon the branch and let the solver backtrack through the earlier
+    ///   decisions, which can reconsider the dependent or the provider.
+    async fn reconsider_invalidated_resolve(
+        &self,
+        graph: &Arc<tokio::sync::RwLock<Graph>>,
+        state: &State,
+        decision: &Decision,
+    ) -> Result<Option<Decision>> {
+        for change in decision.changes.iter() {
+            let Change::RequestPackage(request_package) = change else {
+                continue;
+            };
+            let request = &request_package.request;
+
+            // Only an already-resolved package can be invalidated by a newly
+            // added request.
+            let (resolved, _source, state_id) = match state.get_current_resolve(&request.pkg.name) {
+                Ok(resolve) => resolve,
+                Err(_) => continue,
+            };
+
+            // Tighten the existing merged request with the new request and
+            // check whether the resolved build still satisfies the result.
+            let mut merged = match state.get_merged_request(&request.pkg.name) {
+                Ok(merged) => merged,
+                Err(_) => continue,
+            };
+            let (requests_conflict, stale_reason) = match merged.restrict(request) {
+                Compatibility::Incompatible(reason) => (true, Some(reason)),
+                // Only the version is checked here: a request that merely
+                // tightens the version is what an `IfAlreadyPresent`
+                // build-component requirement does, and checking the full
+                // request would spuriously reject the embedded build id of an
+                // embedded stub. Request-level conflicts are caught above.
+                Compatibility::Compatible => {
+                    match merged.is_version_applicable(resolved.ident().version()) {
+                        Compatibility::Compatible => (false, None),
+                        Compatibility::Incompatible(reason) => (false, Some(reason)),
+                    }
+                }
+            };
+            let Some(reason) = stale_reason else {
+                continue;
+            };
+
+            // The resolved build no longer fits the tightened request. If the
+            // requests themselves conflict, or the stale package is embedded,
+            // this branch cannot be repaired by reconsidering this one package
+            // alone, so abandon it and let the solver backtrack.
+            if requests_conflict || resolved.ident().build().is_embedded() {
+                return Err(Error::OutOfOptions(Box::new(OutOfOptions {
+                    request: request.pkg_request.clone(),
+                    notes: vec![Note::Other(format!(
+                        "request for {} conflicts with the existing resolve: {reason}",
+                        request.pkg.name
+                    ))],
+                })));
+            }
+
+            // Step back to the state from before this package was resolved and
+            // re-request it with the tightened constraint prioritized.
+            let graph_lock = graph.read().await;
+            let target_state_node = graph_lock
+                .nodes
+                .get(&state_id.id())
+                .ok_or_else(|| Error::String("state not found".into()))?
+                .read()
+                .await;
+
+            return Ok(Some(
+                Decision::builder(&target_state_node.state).reconsider_package(
+                    request.clone(),
+                    request.pkg.name.as_ref(),
+                    Arc::clone(&self.number_of_steps_back),
+                ),
+            ));
+        }
+
+        Ok(None)
     }
 
     fn validate_recipe<R: Recipe>(&self, state: &State, recipe: &R) -> Result<Compatibility> {


### PR DESCRIPTION
## Summary

Build-component requirements (for example an `IfAlreadyPresent` constraint declared on a package's `build` component) were not represented in the build context. As a result a later requirement could tighten the merged request for an **already-resolved** package without the solver noticing, and the resolved package would silently violate the tightened request. This PR makes both solver flavors honor those constraints, including when the constrained package is provided as an embedded build.

## Step solver

- Keep build-component requests in the build context.
- Validate each decision **before it is committed** (in `reconsider_invalidated_resolve`) instead of re-proving every resolved package on every step, so states stay valid by construction. When a decision would tighten the request for an already-resolved package such that its resolved build no longer satisfies the version:
  - if the package is a plain repository build whose request merely needs tightening, step back to before it was resolved and re-request it with the tightened constraint (mirroring the existing `ConflictingEmbeddedPackage` handling);
  - otherwise abandon the branch and let the solver backtrack — this covers both the **dependent-package** case (a different resolved package pinned a conflicting version) and the **embedded** case (the stale package is provided by, and so governed by, its parent).

## Resolvo solver

- An `IfAlreadyPresent` requirement constrained the specific (build) component package, which misses a package that is only present under a different component — such as one provided as an embedded build with no separate build component. Constrain the synthetic `Base` component instead, so the version binds whenever the package is in the solution regardless of which component pulled it in.

## Tests

New regressions across both solver flavors (and both index modes):

- `..._reconsiders_existing_build_request` — a broad build request tightened by a later build-component `IfAlreadyPresent` constraint.
- `..._reconsiders_dependent_package` — a dependent package that must be reconsidered when the dependency is re-pinned.
- `..._reconsiders_embedded_package` — an embedded package whose **provider** must be reconsidered to satisfy the tightened constraint.

## Testing

- `cargo test -p spk-solve`
- `cargo clippy -p spk-solve --all-targets`
- `make format`
