### PR TITLE
Indexes 13: Bugfix for missing package sizes in solution summary from an index

### DIFF
--- a/crates/spk-storage/src/disk_usage.rs
+++ b/crates/spk-storage/src/disk_usage.rs
@@ -703,6 +703,15 @@ pub async fn get_components_disk_usage(
         .with_continue_on_error(true)
         .build();
 
+    // This level knows about spk repo handles, including indexed
+    // ones, and needs to ensure a non-indexed repo handle is used for
+    // the components' disk usage walking.
+    let files_repo = if let RepositoryHandle::Indexed(ref indexed_repo) = *repo {
+        indexed_repo.underlying_repo()
+    } else {
+        repo.clone()
+    };
+
     // Add the size of each components to the grouped disk usage size
     // to get a total.
     for (component, digest) in components {
@@ -714,7 +723,7 @@ pub async fn get_components_disk_usage(
             name: component.clone(),
             digest: Arc::new(*digest),
         };
-        let mut traversal = repo_walker.file_stream(&repo, walked_component);
+        let mut traversal = repo_walker.file_stream(&files_repo, walked_component);
 
         while let Some(file) = traversal.try_next().await? {
             let entry_size = if visited_digests.insert(file.entry.object) || count_links {

--- a/crates/spk-storage/src/storage/indexed.rs
+++ b/crates/spk-storage/src/storage/indexed.rs
@@ -18,6 +18,7 @@ use spk_schema::ident_build::EmbeddedSource;
 use spk_schema::name::OptNameBuf;
 use spk_schema::{BuildIdent, Spec, SpecRecipe};
 
+use super::RepositoryHandle;
 use super::repository::{PublishPolicy, Repository, Storage};
 use crate::storage::{FlatBufferRepoIndex, RepoIndex, RepositoryIndex};
 use crate::{Error, Result};
@@ -66,6 +67,11 @@ impl IndexedRepository {
     /// repository, which may create it if needed.
     pub async fn wrapped_repo_index_location_path(&self) -> Result<PathBuf> {
         self.wrapped_repo.index_location_path().await
+    }
+
+    /// Get the underlying repo handle this index wraps.
+    pub fn underlying_repo(&self) -> Arc<RepositoryHandle> {
+        self.wrapped_repo.clone()
     }
 
     /// Set whether to update the internal index after any publish or


### PR DESCRIPTION
This fixes a bug introduced by using an index that meant all the packages would be shown as zero size in the solution summary output. This restores the package component disk usage sizes by exposing the underlying repo in the index, and using that when calculating sizes at the end of a solve.

This is an indexes related PR, previous indexes PRs include:

9. #1356
10. #1363
11. #1364
12. #1368
13. This PR.

