### PR TITLE
Fix flaky range intersect proptest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,7 +326,7 @@ version = "0.68.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -366,11 +366,11 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.4"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -843,7 +843,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "crossterm_winapi",
  "mio",
  "parking_lot",
@@ -1150,7 +1150,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1240,7 +1240,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1324,7 +1324,7 @@ version = "25.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1045398c1bfd89168b5fd3f1fc11f6e70b34f6f66300c87d44d3de849463abf1"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "rustc_version",
 ]
 
@@ -1577,7 +1577,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "ignore",
  "walkdir",
 ]
@@ -2030,7 +2030,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "cfg-if",
  "libc",
 ]
@@ -2149,7 +2149,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.3",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2164,7 +2164,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "libc",
  "redox_syscall",
 ]
@@ -2373,7 +2373,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2385,7 +2385,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2432,7 +2432,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2551,7 +2551,7 @@ version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2968,7 +2968,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "chrono",
  "flate2",
  "hex",
@@ -2983,7 +2983,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "chrono",
  "hex",
 ]
@@ -3000,14 +3000,13 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.7.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.9.4",
- "lazy_static",
+ "bitflags 2.11.1",
  "num-traits",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
@@ -3246,7 +3245,7 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -3399,7 +3398,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
  "base64 0.21.7",
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "serde",
  "serde_derive",
 ]
@@ -3471,7 +3470,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -3484,11 +3483,11 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3569,7 +3568,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3699,10 +3698,11 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -3717,10 +3717,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.219"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5315,7 +5324,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.8",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5662,7 +5671,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
@@ -6228,7 +6237,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ paste = "1.0"
 pin-project-lite = "0.2.0"
 procfs = "0.16.0"
 progress_bar_derive_macro = { path = "crates/progress_bar_derive_macro" }
-proptest = "1.0.0"
+proptest = "1.11.0"
 prost = "0.13"
 rand = "0.8.5"
 rdkafka = { version = "0.39.0", features = ["cmake-build"] }

--- a/crates/spk-schema/Cargo.toml
+++ b/crates/spk-schema/Cargo.toml
@@ -53,5 +53,5 @@ tracing = { workspace = true }
 variantly = { workspace = true }
 
 [dev-dependencies]
-proptest = "1.0.0"
+proptest = "1.11.0"
 rstest = { workspace = true }

--- a/crates/spk-schema/src/version_range_test.rs
+++ b/crates/spk-schema/src/version_range_test.rs
@@ -344,10 +344,10 @@ fn arb_semver_range_from_version(version: Version) -> impl Strategy<Value = Vers
                             .take(parts_to_generate)
                             .zip(values_to_use.iter())
                             .map(|(actual_number, proposed_number)| {
-                                if !found_non_zero && *actual_number == 0 {
-                                    found_non_zero = true;
-                                    *actual_number
-                                } else if !found_non_zero {
+                                if !found_non_zero {
+                                    if *actual_number != 0 {
+                                        found_non_zero = true;
+                                    }
                                     *actual_number
                                 } else {
                                     *proposed_number
@@ -390,6 +390,40 @@ fn arb_wildcard_range_from_version(version: Version) -> impl Strategy<Value = Ve
     })
 }
 
+fn arb_different_version_from(version: Version) -> impl Strategy<Value = Version> {
+    Just({
+        let mut version = version;
+        let last = version.parts.len() - 1;
+        version.parts[last] = match version.parts[last] {
+            0 => 1,
+            num => num - 1,
+        };
+        version
+    })
+}
+
+fn version_strictly_smaller(mut version: Version) -> Version {
+    if let Some(index) = version.parts.iter().rposition(|part| *part > 0) {
+        version.parts[index] -= 1;
+        for part in version.parts.iter_mut().skip(index + 1) {
+            *part = 0;
+        }
+        version
+    } else {
+        version.minus_epsilon()
+    }
+}
+
+fn version_strictly_larger(mut version: Version) -> Version {
+    let last = version.parts.len() - 1;
+    if version.parts[last] == u32::MAX {
+        version.parts.push(1);
+    } else {
+        version.parts[last] += 1;
+    }
+    version
+}
+
 fn arb_range_that_includes_version(version: Version) -> impl Strategy<Value = VersionRange> {
     prop_oneof![
         // Compat: the same version
@@ -400,71 +434,43 @@ fn arb_range_that_includes_version(version: Version) -> impl Strategy<Value = Ve
         Just(VersionRange::DoubleEquals(DoubleEqualsVersion::new(
             version.clone()
         ))),
-        // DoubleNotEquals: an arbitrary version that isn't equal
-        (arb_version(), Just(version.clone()))
-            .prop_filter(
-                "not the same version",
-                |(other_version, version)| other_version != version
-            )
-            .prop_map(|(other_version, _)| {
-                VersionRange::DoubleNotEquals(DoubleNotEqualsVersion::new(
-                    other_version.parts.len(),
-                    other_version,
-                ))
-            }),
+        // DoubleNotEquals: a version deterministically different from the
+        // witness version, to avoid reject-heavy filtering.
+        arb_different_version_from(version.clone()).prop_map(|other_version| {
+            VersionRange::DoubleNotEquals(DoubleNotEqualsVersion::new(
+                other_version.parts.len(),
+                other_version,
+            ))
+        }),
         // Equals: the same version
         Just(VersionRange::Equals(EqualsVersion::new(version.clone()))),
         // Filter: skipping for now
-        // GreaterThan: an arbitrary version that is <=
-        (arb_version(), Just(version.clone()))
-            .prop_filter(
-                "a less than or equal version",
-                |(other_version, version)| other_version <= version
-            )
-            .prop_map(|(other_version, _)| {
-                VersionRange::GreaterThan(GreaterThanRange::new(other_version))
-            }),
-        // GreaterThanOrEqualTo: an arbitrary version that is <
-        (arb_version(), Just(version.clone()))
-            .prop_filter(
-                "a less than version",
-                |(other_version, version)| other_version < version
-            )
-            .prop_map(|(other_version, _)| {
-                VersionRange::GreaterThanOrEqualTo(GreaterThanOrEqualToRange::new(other_version))
-            }),
-        // LesserThan: an arbitrary version that is >=
-        (arb_version(), Just(version.clone()))
-            .prop_filter(
-                "a greater than or equal version",
-                |(other_version, version)| other_version >= version
-            )
-            .prop_map(|(other_version, _)| {
-                VersionRange::LessThan(LessThanRange::new(other_version))
-            }),
-        // LessThanOrEqualTo: an arbitrary version that is >
-        (arb_version(), Just(version.clone()))
-            .prop_filter(
-                "a greater than version",
-                |(other_version, version)| other_version > version
-            )
-            .prop_map(|(other_version, _)| {
-                VersionRange::LessThanOrEqualTo(LessThanOrEqualToRange::new(other_version))
-            }),
+        // GreaterThan: a boundary just below the witness version.
+        Just(VersionRange::GreaterThan(GreaterThanRange::new(
+            version_strictly_smaller(version.clone()),
+        ))),
+        // GreaterThanOrEqualTo: the witness version itself.
+        Just(VersionRange::GreaterThanOrEqualTo(
+            GreaterThanOrEqualToRange::new(version.clone()),
+        )),
+        // LessThan: a boundary just above the witness version.
+        Just(VersionRange::LessThan(LessThanRange::new(
+            version_strictly_larger(version.clone()),
+        ))),
+        // LessThanOrEqualTo: the witness version itself.
+        Just(VersionRange::LessThanOrEqualTo(
+            LessThanOrEqualToRange::new(version.clone()),
+        )),
         // LowestSpecified: transform version digits
         arb_lowest_specified_range_from_version(version.clone()),
-        // NotEquals: an arbitrary version that isn't equal
-        (arb_version(), Just(version.clone()))
-            .prop_filter(
-                "not the same version",
-                |(other_version, version)| other_version != version
-            )
-            .prop_map(|(other_version, _)| {
-                VersionRange::NotEquals(NotEqualsVersion::new(
-                    other_version.parts.len(),
-                    other_version,
-                ))
-            }),
+        // NotEquals: a version deterministically different from the witness
+        // version, to avoid reject-heavy filtering.
+        arb_different_version_from(version.clone()).prop_map(|other_version| {
+            VersionRange::NotEquals(NotEqualsVersion::new(
+                other_version.parts.len(),
+                other_version,
+            ))
+        }),
         // Semver: transform version digits
         arb_semver_range_from_version(version.clone()),
         // Wildcard: turn one of the version digits into a wildcard


### PR DESCRIPTION
This fixes the flaky `prop_test_range_intersect` property test in `spk-schema` by replacing reject-heavy generators with constructive intersecting ranges and correcting the zero-major semver generator. It also updates `proptest` to 1.11.0 as part of the change.

## Summary
- construct ordered range bounds directly instead of relying on `prop_filter` rejection loops
- fix the zero-major caret/semver generator so generated ranges actually include the witness version
- update `proptest` to 1.11.0

## Testing
- cargo test -p spk-schema prop_test_range_intersect -- --nocapture
- make nextest lint