### PR TITLE
Verify payload contents in spfs check

### DIFF
--- a/crates/spfs-cli/main/src/cmd_check.rs
+++ b/crates/spfs-cli/main/src/cmd_check.rs
@@ -23,6 +23,12 @@ pub struct CmdCheck {
     #[clap(long, default_value_t = spfs::Checker::DEFAULT_MAX_OBJECT_CONCURRENCY)]
     max_object_concurrency: usize,
 
+    /// Read every payload and verify that its contents match its digest.
+    ///
+    /// This is slower than checking for payload file existence alone.
+    #[clap(long)]
+    verify_payload_contents: bool,
+
     /// Attempt to fix problems by pulling from another repository. Defaults to "origin".
     #[clap(long)]
     pull: Option<Option<String>>,
@@ -61,8 +67,11 @@ impl CmdCheck {
             None => None,
         };
 
-        let mut checker =
-            spfs::Checker::new(&repo).with_reporter(spfs::check::ConsoleCheckReporter::default());
+        let mut checker = spfs::Checker::new(&repo)
+            .with_reporter(spfs::check::ConsoleCheckReporter::default())
+            .with_max_tag_stream_concurrency(self.max_tag_stream_concurrency)
+            .with_max_object_concurrency(self.max_object_concurrency)
+            .with_payload_contents_verification(self.verify_payload_contents);
         if let Some(pull_from) = &pull_from {
             checker = checker.with_repair_source(pull_from);
         }
@@ -96,21 +105,24 @@ impl CmdCheck {
             checked_objects,
             missing_payloads,
             repaired_payloads,
+            invalid_payloads,
             checked_payloads,
             checked_payload_bytes,
         } = summary;
         let missing_objects = missing_objects.len();
         let missing_payloads = missing_payloads.len();
+        let invalid_payloads = invalid_payloads.len();
 
         println!("{} after {duration:.0?}:", "Finished".bold());
         let missing = "missing".red().italic();
+        let invalid = "invalid".red().italic();
         let repaired = "repaired".cyan().italic();
         println!("{checked_tags:>12} tags visited     ({missing_tags} {missing})");
         println!(
             "{checked_objects:>12} objects visited  ({missing_objects} {missing}, {repaired_objects} {repaired})",
         );
         println!(
-            "{checked_payloads:>12} payloads visited ({missing_payloads} {missing}, {repaired_payloads} {repaired})",
+            "{checked_payloads:>12} payloads visited ({missing_payloads} {missing}, {invalid_payloads} {invalid}, {repaired_payloads} {repaired})",
         );
         let human_bytes = match NumberPrefix::binary(checked_payload_bytes as f64) {
             NumberPrefix::Standalone(amt) => format!("{amt} bytes"),
@@ -118,7 +130,7 @@ impl CmdCheck {
         };
         println!("{human_bytes:>12} total payload footprint");
 
-        if missing_objects + missing_payloads != 0 {
+        if missing_objects + missing_payloads + invalid_payloads != 0 {
             if pull_from.is_none() {
                 tracing::info!("running with `--pull` may be able to resolve these issues")
             }

--- a/crates/spfs/src/check.rs
+++ b/crates/spfs/src/check.rs
@@ -27,11 +27,12 @@ mod check_test;
 /// The checker can be cloned efficiently
 pub struct Checker<'repo, 'sync, Reporter: CheckReporter = SilentCheckReporter> {
     repo: &'repo storage::RepositoryHandle,
-    repair_with: Option<super::Syncer<'sync, 'repo>>,
+    repair_with: Option<&'sync storage::RepositoryHandle>,
     reporter: Arc<Reporter>,
     processed_digests: Arc<dashmap::DashMap<encoding::Digest, CheckProgress>>,
     tag_stream_semaphore: Semaphore,
     object_semaphore: Semaphore,
+    verify_payload_contents: bool,
 }
 
 impl<'repo> Checker<'repo, 'static> {
@@ -48,6 +49,7 @@ impl<'repo> Checker<'repo, 'static> {
             processed_digests: Arc::new(Default::default()),
             tag_stream_semaphore: Semaphore::new(Self::DEFAULT_MAX_TAG_STREAM_CONCURRENCY),
             object_semaphore: Semaphore::new(Self::DEFAULT_MAX_OBJECT_CONCURRENCY),
+            verify_payload_contents: false,
         }
     }
 }
@@ -69,6 +71,7 @@ where
             processed_digests: self.processed_digests,
             tag_stream_semaphore: self.tag_stream_semaphore,
             object_semaphore: self.object_semaphore,
+            verify_payload_contents: self.verify_payload_contents,
         }
     }
 
@@ -84,13 +87,11 @@ where
         Checker {
             repo: self.repo,
             reporter: self.reporter,
-            repair_with: Some(
-                crate::Syncer::new(source, self.repo)
-                    .with_policy(SyncPolicy::LatestTagsAndResyncObjects),
-            ),
+            repair_with: Some(source),
             processed_digests: self.processed_digests,
             tag_stream_semaphore: self.tag_stream_semaphore,
             object_semaphore: self.object_semaphore,
+            verify_payload_contents: self.verify_payload_contents,
         }
     }
 
@@ -103,6 +104,15 @@ where
     /// The maximum number of objects that can be validated at once
     pub fn with_max_object_concurrency(mut self, max_object_concurrency: usize) -> Self {
         self.object_semaphore = Semaphore::new(max_object_concurrency);
+        self
+    }
+
+    /// Read every payload and verify that its contents hash to the expected digest.
+    ///
+    /// This is slower than checking payload existence alone because every payload
+    /// must be streamed and hashed.
+    pub fn with_payload_contents_verification(mut self, verify_payload_contents: bool) -> Self {
+        self.verify_payload_contents = verify_payload_contents;
         self
     }
 
@@ -498,19 +508,63 @@ where
         perms: Option<u32>,
     ) -> Result<CheckPayloadResult> {
         self.reporter.visit_payload(digest);
-        let mut result = CheckPayloadResult::Missing(digest);
-        if self.repo.has_payload(digest).await {
-            result = CheckPayloadResult::Ok;
-        } else if let Some(syncer) = &self.repair_with {
-            // Safety: this sync is unsafe unless the blob is also created
-            // or exists. We pass this rule up to the caller.
-            if let Ok(r) = unsafe { syncer.sync_payload_with_perms_opt(digest, perms).await } {
-                self.reporter.repaired_payload(&r);
-                result = CheckPayloadResult::Repaired;
+        let mut result = self.check_existing_payload(digest).await?;
+        match result {
+            CheckPayloadResult::Missing(_) => {
+                if let Some(syncer) = self.repair_syncer(SyncPolicy::LatestTagsAndResyncObjects) {
+                    // Safety: this sync is unsafe unless the blob is also created
+                    // or exists. We pass this rule up to the caller.
+                    if let Ok(r) =
+                        unsafe { syncer.sync_payload_with_perms_opt(digest, perms).await }
+                    {
+                        self.reporter.repaired_payload(&r);
+                        result = CheckPayloadResult::Repaired;
+                    }
+                }
             }
+            CheckPayloadResult::Invalid { .. } => {
+                if let Some(syncer) = self.repair_syncer(SyncPolicy::ResyncEverything) {
+                    // Safety: this sync is unsafe unless the blob is also created
+                    // or exists. We pass this rule up to the caller.
+                    if let Ok(r) =
+                        unsafe { syncer.sync_payload_with_perms_opt(digest, perms).await }
+                    {
+                        self.reporter.repaired_payload(&r);
+                        result = CheckPayloadResult::Repaired;
+                    }
+                }
+            }
+            CheckPayloadResult::Repaired | CheckPayloadResult::Ok => {}
         }
         self.reporter.checked_payload(&result);
         Ok(result)
+    }
+
+    async fn check_existing_payload(&self, digest: encoding::Digest) -> Result<CheckPayloadResult> {
+        if !self.verify_payload_contents {
+            return Ok(if self.repo.has_payload(digest).await {
+                CheckPayloadResult::Ok
+            } else {
+                CheckPayloadResult::Missing(digest)
+            });
+        }
+
+        let (payload, _) = match self.repo.open_payload(digest).await {
+            Ok(payload) => payload,
+            Err(Error::UnknownObject(_) | Error::ObjectMissingPayload(_, _)) => {
+                return Ok(CheckPayloadResult::Missing(digest));
+            }
+            Err(err) => return Err(err),
+        };
+        let actual = encoding::Hasher::hash_async_reader(payload).await?;
+        Ok(if actual == digest {
+            CheckPayloadResult::Ok
+        } else {
+            CheckPayloadResult::Invalid {
+                expected: digest,
+                actual,
+            }
+        })
     }
 
     /// Returns the object, and whether or not it was repaired
@@ -524,7 +578,8 @@ where
                 let Error::UnknownObject(digest) = err else {
                     return Err(err);
                 };
-                let Some(syncer) = &self.repair_with else {
+                let Some(syncer) = self.repair_syncer(SyncPolicy::LatestTagsAndResyncObjects)
+                else {
                     return Err(err);
                 };
                 if let Ok(result) = syncer.sync_digest(digest).await {
@@ -539,6 +594,11 @@ where
             }
             res => res.map(|o| (o, Fallback::None)),
         }
+    }
+
+    fn repair_syncer(&self, policy: SyncPolicy) -> Option<crate::Syncer<'sync, 'repo>> {
+        self.repair_with
+            .map(|source| crate::Syncer::new(source, self.repo).with_policy(policy))
     }
 }
 
@@ -656,10 +716,18 @@ impl CheckReporter for ConsoleCheckReporter {
 
     fn checked_payload(&self, result: &CheckPayloadResult) {
         let bars = self.get_bars();
-        if let CheckPayloadResult::Missing(digest) = result {
-            bars.missing
-                .println(format!("{}: {digest}", "Missing".red()));
-            bars.missing.inc_length(1);
+        match result {
+            CheckPayloadResult::Missing(digest) => {
+                bars.missing
+                    .println(format!("{}: {digest}", "Missing".red()));
+                bars.missing.inc_length(1);
+            }
+            CheckPayloadResult::Invalid { expected, actual } => {
+                bars.missing
+                    .println(format!("{}: {expected} (got {actual})", "Invalid".red()));
+                bars.missing.inc_length(1);
+            }
+            CheckPayloadResult::Repaired | CheckPayloadResult::Ok => {}
         }
     }
 
@@ -706,6 +774,8 @@ pub struct CheckSummary {
     pub missing_payloads: HashSet<encoding::Digest>,
     /// The number of missing payloads that were repaired
     pub repaired_payloads: usize,
+    /// The payloads whose contents did not match their digest
+    pub invalid_payloads: HashSet<encoding::Digest>,
     /// The number of payloads checked and found to be okay
     pub checked_payloads: usize,
     /// The total number of payload bytes checked
@@ -735,6 +805,7 @@ impl std::ops::AddAssign for CheckSummary {
             checked_payload_bytes,
             repaired_objects,
             repaired_payloads,
+            invalid_payloads,
         } = rhs;
         self.missing_tags += missing_tags;
         self.checked_tags += checked_tags;
@@ -745,6 +816,7 @@ impl std::ops::AddAssign for CheckSummary {
         self.checked_payload_bytes += checked_payload_bytes;
         self.repaired_objects += repaired_objects;
         self.repaired_payloads += repaired_payloads;
+        self.invalid_payloads.extend(invalid_payloads);
     }
 }
 
@@ -1073,6 +1145,11 @@ impl TryFrom<CheckObjectResult> for CheckBlobResult {
 pub enum CheckPayloadResult {
     /// The payload is missing from this repository
     Missing(encoding::Digest),
+    /// The payload exists but its contents do not hash to the expected digest
+    Invalid {
+        expected: encoding::Digest,
+        actual: encoding::Digest,
+    },
     /// The payload was missing from this repository but was repaired
     Repaired,
     /// The payload was checked and is present
@@ -1084,6 +1161,10 @@ impl CheckPayloadResult {
         match self {
             Self::Missing(digest) => CheckSummary {
                 missing_payloads: Some(*digest).into_iter().collect(),
+                ..Default::default()
+            },
+            Self::Invalid { expected, .. } => CheckSummary {
+                invalid_payloads: Some(*expected).into_iter().collect(),
                 ..Default::default()
             },
             Self::Repaired => CheckSummary {

--- a/crates/spfs/src/check_test.rs
+++ b/crates/spfs/src/check_test.rs
@@ -13,6 +13,33 @@ use crate::fixtures::*;
 use crate::graph::{Database, DatabaseExt};
 use crate::storage::{PayloadStorage, RepositoryExt};
 
+fn check_summary(results: &[super::CheckObjectResult]) -> CheckSummary {
+    results.iter().map(|r| r.summary()).sum()
+}
+
+async fn corrupt_payload(repo: &crate::storage::RepositoryHandle, digest: crate::encoding::Digest) {
+    let (payload, path) = repo.open_payload(digest).await.unwrap();
+    drop(payload);
+
+    #[cfg(unix)]
+    let permissions = {
+        use std::os::unix::fs::PermissionsExt;
+
+        let metadata = std::fs::metadata(&path).unwrap();
+        let mut permissions = metadata.permissions();
+        permissions.set_mode(permissions.mode() | 0o200);
+        permissions
+    };
+    #[cfg(not(unix))]
+    let permissions = {
+        let mut permissions = std::fs::metadata(&path).unwrap().permissions();
+        permissions.set_readonly(false);
+        permissions
+    };
+    std::fs::set_permissions(&path, permissions).unwrap();
+    std::fs::write(path, b"corrupted payload bytes").unwrap();
+}
+
 #[rstest]
 #[tokio::test]
 async fn test_check_missing_payload(#[future] tmprepo: TempRepo) {
@@ -42,7 +69,7 @@ async fn test_check_missing_payload(#[future] tmprepo: TempRepo) {
         .await
         .unwrap();
 
-    let summary: CheckSummary = results.iter().map(|r| r.summary()).sum();
+    let summary = check_summary(&results);
     tracing::info!("{summary:#?}");
     assert_eq!(
         summary.checked_objects, total_objects,
@@ -93,7 +120,7 @@ async fn test_check_missing_object(#[future] tmprepo: TempRepo) {
         .await
         .unwrap();
 
-    let summary: CheckSummary = results.iter().map(|r| r.summary()).sum();
+    let summary = check_summary(&results);
     tracing::info!("{summary:#?}");
     assert_eq!(
         summary.checked_objects,
@@ -152,7 +179,7 @@ async fn test_check_missing_payload_recover(#[future] tmprepo: TempRepo) {
         .await
         .unwrap();
 
-    let summary: CheckSummary = results.iter().map(|r| r.summary()).sum();
+    let summary = check_summary(&results);
     tracing::info!("{summary:#?}");
     assert_eq!(
         summary.checked_objects, total_objects,
@@ -213,7 +240,7 @@ async fn test_check_missing_object_recover(#[future] tmprepo: TempRepo) {
         .await
         .unwrap();
 
-    let summary: CheckSummary = results.iter().map(|r| r.summary()).sum();
+    let summary = check_summary(&results);
     tracing::info!("{summary:#?}");
     assert_eq!(
         summary.checked_objects, total_objects,
@@ -278,7 +305,7 @@ async fn check_missing_annotation_blob(#[future] tmprepo: TempRepo) {
             .await
             .unwrap();
 
-        let summary: CheckSummary = results.iter().map(|r| r.summary()).sum();
+        let summary = check_summary(&results);
         tracing::info!("{summary:#?}");
         assert_eq!(summary.checked_objects, 2);
         assert_eq!(summary.checked_payloads, 1);
@@ -295,7 +322,7 @@ async fn check_missing_annotation_blob(#[future] tmprepo: TempRepo) {
         .await
         .expect("checker should succeed when an annotation blob is missing");
 
-    let summary: CheckSummary = results.iter().map(|r| r.summary()).sum();
+    let summary = check_summary(&results);
     tracing::info!("{summary:#?}");
     assert_eq!(summary.checked_objects, 2);
     assert_eq!(summary.checked_payloads, 0);
@@ -312,4 +339,102 @@ async fn check_missing_annotation_blob(#[future] tmprepo: TempRepo) {
             .iter()
             .any(|r| matches!(r, super::CheckObjectResult::Missing(digest) if *digest == blob))
     );
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_check_invalid_payload_contents(#[future] tmprepo: TempRepo) {
+    init_logging();
+    let tmprepo = tmprepo.await;
+
+    let manifest = generate_tree(&tmprepo).await.to_graph_manifest();
+    let file = manifest
+        .iter_entries()
+        .find(|entry| entry.is_regular_file())
+        .expect("at least one regular file");
+
+    corrupt_payload(&tmprepo.repo(), *file.object()).await;
+
+    let total_blobs = manifest
+        .iter_entries()
+        .filter(|e| e.is_regular_file())
+        .count();
+    let total_objects = total_blobs + 1; // the manifest
+
+    let results = Checker::new(&tmprepo.repo())
+        .with_payload_contents_verification(true)
+        .check_all_objects()
+        .await
+        .unwrap();
+
+    let summary = check_summary(&results);
+    tracing::info!("{summary:#?}");
+    assert_eq!(
+        summary.checked_objects, total_objects,
+        "expected all items to be visited"
+    );
+    assert_eq!(
+        summary.checked_payloads,
+        total_blobs - 1,
+        "expected the corrupted payload to fail verification"
+    );
+    assert!(
+        summary.invalid_payloads.contains(file.object()),
+        "should find one invalid payload"
+    );
+    assert!(
+        summary.missing_payloads.is_empty(),
+        "should not report the corrupted payload as missing"
+    );
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_check_invalid_payload_recover(#[future] tmprepo: TempRepo) {
+    init_logging();
+    let tmprepo = tmprepo.await;
+    let repo2 = crate::fixtures::tmprepo("fs").await;
+
+    let manifest = generate_tree(&tmprepo).await.to_graph_manifest();
+    let digest = manifest.digest().unwrap();
+    crate::Syncer::new(&tmprepo.repo(), &repo2.repo())
+        .sync_digest(digest)
+        .await
+        .expect("Failed to sync repos");
+
+    let file = manifest
+        .iter_entries()
+        .find(|entry| entry.is_regular_file())
+        .expect("at least one regular file");
+
+    corrupt_payload(&tmprepo.repo(), *file.object()).await;
+
+    let total_blobs = manifest
+        .iter_entries()
+        .filter(|e| e.is_regular_file())
+        .count();
+    let total_objects = total_blobs + 1; // the manifest
+
+    let results = Checker::new(&tmprepo.repo())
+        .with_repair_source(&repo2.repo())
+        .with_payload_contents_verification(true)
+        .check_all_objects()
+        .await
+        .unwrap();
+
+    let summary = check_summary(&results);
+    tracing::info!("{summary:#?}");
+    assert_eq!(
+        summary.checked_objects, total_objects,
+        "expected all items to be visited"
+    );
+    assert_eq!(
+        summary.checked_payloads, total_blobs,
+        "expected all payloads to be valid after repair"
+    );
+    assert!(
+        summary.invalid_payloads.is_empty(),
+        "should repair the invalid payload"
+    );
+    assert_eq!(summary.repaired_payloads, 1, "should repair one payload");
 }


### PR DESCRIPTION
## Summary
- add a `--verify-payload-contents` flag to `spfs check`
- re-hash payload files to detect on-disk corruption, not just missing payloads
- report invalid payloads separately and repair them with `--pull`

## Testing
- cargo test -p spfs check_test -- --nocapture
- make nextest lint