### PR TITLE
Fix spk-proto rebuild fingerprint

### DIFF
--- a/crates/spk-proto/build.rs
+++ b/crates/spk-proto/build.rs
@@ -22,10 +22,4 @@ fn main() {
         ..Default::default()
     })
     .expect("schema compiler command");
-
-    let generated_file = PathBuf::from(out_dir).join("spk_generated.rs");
-    println!(
-        "cargo:rerun-if-changed=schema/spk.fbs generated file: {}",
-        generated_file.display()
-    );
 }


### PR DESCRIPTION
## Summary
- remove the malformed `cargo:rerun-if-changed` line from `crates/spk-proto/build.rs`
- stop Cargo from tracking a non-existent path that kept the build script fingerprint stale
- avoid needless recompilation when repeatedly running `cargo run --release --bin spk -- explain ...`

## Testing
- spk env nodejs -- node "/net/homedirs/jrray/.local/share/nvim/mason/bin/cspell" lint --config cspell.json crates/spk-proto/build.rs
- make nextest lint