### PR TITLE
Bugfix for ignoring compat values of embedded package specs in an index

### DIFF
--- a/crates/spk-schema/src/fb_converter.rs
+++ b/crates/spk-schema/src/fb_converter.rs
@@ -379,6 +379,8 @@ pub fn fb_embedded_package_specs_to_embedded_package_specs(
         let build_ident = BuildIdent::from_str(fb_emb_spec.ident()).unwrap_or_else(|_| unreachable!("An Embedded package spec in flatbuffer data should have a valid ident: '{}' is not valid", fb_emb_spec.ident()));
 
         let build_options = fb_opts_to_opts(fb_emb_spec.build_options());
+        let compat = fb_compat_to_compat(fb_emb_spec.compat());
+
         let options: OptionMap = build_options
             .iter()
             .map(|opt| (opt.full_name().to_owned(), opt.get_value(None)))
@@ -395,6 +397,7 @@ pub fn fb_embedded_package_specs_to_embedded_package_specs(
         let embedded_spec = unsafe {
             EmbeddedPackageSpec::new_unchecked(
                 build_ident,
+                compat,
                 EmbeddedBuildSpec {
                     options: build_options,
                 },

--- a/crates/spk-schema/src/v0/embedded_package_spec.rs
+++ b/crates/spk-schema/src/v0/embedded_package_spec.rs
@@ -113,6 +113,7 @@ impl EmbeddedPackageSpec {
     /// EmbeddedPackageSpec.
     pub unsafe fn new_unchecked(
         ident: BuildIdent,
+        compat: Compat,
         build: EmbeddedBuildSpec,
         requirements_with_options: RequirementsList<RequestWithOptions>,
         install: EmbeddedInstallSpec,
@@ -120,7 +121,7 @@ impl EmbeddedPackageSpec {
         EmbeddedPackageSpec {
             pkg: ident,
             meta: Meta::default(),
-            compat: Compat::default(),
+            compat,
             deprecated: bool::default(),
             sources: Vec::new(),
             build,

--- a/crates/spk-storage/src/storage/flatbuffer_index_test.rs
+++ b/crates/spk-storage/src/storage/flatbuffer_index_test.rs
@@ -528,4 +528,22 @@ async fn test_flatbuffer_deprecated_version() {
     assert_repo_and_index_have_same_packages(repo, indexed_repo).await;
 }
 
+#[rstest]
+#[tokio::test]
+async fn test_flatbuffer_embedded_package_with_compat() {
+    // Make a package with an embedded package that has a non-default compat value.
+    let repo = make_repo!(
+      [
+          {
+              "pkg": "maya/2019.2",
+              "build": {"script": "echo BUILD"},
+              "install": {"embedded": [{"pkg": "qt/5.12.6", "compat": "x.x.a.b" }]},
+          },
+      ]
+    );
+    let indexed_repo = index_for_test(repo.clone()).await;
+
+    assert_repo_and_index_have_same_packages(repo, indexed_repo).await;
+}
+
 // TODO: add rest of solves sample repos to this as tests


### PR DESCRIPTION
This fixes a bug where the stored compat values of embedded package specs in an index were being ignored. The default compat value was being used instead.
