### PR TITLE
Pin overlayfs index/metacopy options instead of relying on kernel defaults

### DIFF
--- a/crates/spfs/src/env.rs
+++ b/crates/spfs/src/env.rs
@@ -998,8 +998,10 @@ fn have_required_join_capabilities() -> Result<bool> {
 const OVERLAY_ARGS_RO_PREFIX: &str = "ro";
 const OVERLAY_ARGS_INDEX: &str = "index";
 const OVERLAY_ARGS_INDEX_ON: &str = "index=on";
+const OVERLAY_ARGS_INDEX_OFF: &str = "index=off";
 const OVERLAY_ARGS_METACOPY: &str = "metacopy";
 const OVERLAY_ARGS_METACOPY_ON: &str = "metacopy=on";
+const OVERLAY_ARGS_METACOPY_OFF: &str = "metacopy=off";
 pub(crate) const OVERLAY_ARGS_LOWERDIR_APPEND: &str = "lowerdir+";
 const OVERLAY_ARGS_LOWERDIR_APPEND_ASSIGN: &str = "lowerdir+=";
 const OVERLAY_ARGS_LOWERDIR_ASSIGN: &str = "lowerdir=";
@@ -1043,17 +1045,32 @@ impl OverlayMountOptions {
         if self.read_only {
             opts.push(OVERLAY_ARGS_RO_PREFIX);
         }
-        if !self.global_options.break_hardlinks
-            && params.contains(OVERLAY_ARGS_INDEX)
-            && self.global_options.redirect_dir.allow_break_hardlinks()
-        {
-            opts.push(OVERLAY_ARGS_INDEX_ON);
+        // Emit `index` explicitly rather than relying on the kernel's default
+        // for the overlay module. Some kernels build/configure overlayfs with
+        // `index=on` by default (e.g. CONFIG_OVERLAY_FS_INDEX=y), and an
+        // unexpected `index=on` causes overlayfs to record and then verify a
+        // `trusted.overlay.origin` file handle for the upper root against the
+        // lower root. spfs re-renders the lower layers across a remount, so the
+        // lower root changes and that verification fails with a "stale file
+        // handle" error, breaking the remount of /spfs.
+        if params.contains(OVERLAY_ARGS_INDEX) {
+            if !self.global_options.break_hardlinks
+                && self.global_options.redirect_dir.allow_break_hardlinks()
+            {
+                opts.push(OVERLAY_ARGS_INDEX_ON);
+            } else {
+                opts.push(OVERLAY_ARGS_INDEX_OFF);
+            }
         }
-        if self.global_options.metadata_copy_up
-            && params.contains(OVERLAY_ARGS_METACOPY)
-            && self.global_options.redirect_dir.allow_metadata_copy_up()
-        {
-            opts.push(OVERLAY_ARGS_METACOPY_ON);
+        // Likewise pin metacopy rather than inheriting the kernel default.
+        if params.contains(OVERLAY_ARGS_METACOPY) {
+            if self.global_options.metadata_copy_up
+                && self.global_options.redirect_dir.allow_metadata_copy_up()
+            {
+                opts.push(OVERLAY_ARGS_METACOPY_ON);
+            } else {
+                opts.push(OVERLAY_ARGS_METACOPY_OFF);
+            }
         }
         opts.push(self.global_options.redirect_dir.into());
         opts


### PR DESCRIPTION
## Problem

On hosts whose kernel defaults the overlay module to `index=on`
(`CONFIG_OVERLAY_FS_INDEX=y` / `overlay.index=Y`), `make nextest`/`make test`
fail for every case that builds and commits a package, e.g.:

```
mount: /spfs: fsconfig() failed: Stale file handle.
× Failed to mount overlayfs
Failed to re-mount runtime filesystem: spfs-enter --remount failed with code Some(1)
```

`OverlayMountOptions::to_options()` emitted no `index=` option in the default
`redirect_dir=follow` case, so the mount inherited the kernel module default.
With `index=on`, overlayfs records and verifies a `trusted.overlay.origin`
handle for the upper root against the lower root. spfs re-renders the lower
layers across a remount, so the lower root changes and verification fails with
ESTALE, breaking the remount of `/spfs`. Kernels that default to `index=off`
never hit this, which is why it only reproduces on some hosts.

## Fix

Emit `index` and `metacopy` explicitly (`on`/`off`) so overlay mounts are
deterministic regardless of the kernel module defaults.

## Testing

`make nextest` → 1594 passed, 0 failed on a host with `overlay.index=Y`
(previously many spk-build failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)