### PR TITLE
Fix 'package not found' from spk info in build scripts

### DIFF
--- a/crates/spk-storage/src/storage/runtime.rs
+++ b/crates/spk-storage/src/storage/runtime.rs
@@ -23,6 +23,10 @@ use super::Repository;
 use super::repository::{PublishPolicy, Storage};
 use crate::{Error, InvalidPackageSpec, Result};
 
+#[cfg(test)]
+#[path = "./runtime_test.rs"]
+mod runtime_test;
+
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct RuntimeRepository {
     address: url::Url,
@@ -176,31 +180,7 @@ impl RuntimeRepository {
             })
             .collect_vec();
 
-        let digests = find_layers_by_filenames(&filenames_to_resolve_flattened)
-            .await
-            .map_err(|err| {
-                if let Error::SPFS(spfs::Error::UnknownReference(path)) = &err {
-                    // In order to return a `PackageNotFound` we need to look
-                    // for what package owned the path in this `UnknownReference`
-                    // error.
-                    filenames_to_resolve
-                        .iter()
-                        .find(|component_filenames| {
-                            component_filenames
-                                .filenames
-                                .iter()
-                                .any(|(_, p)| *p == *path)
-                        })
-                        .map(|component_filenames| {
-                            Error::PackageNotFound(Box::new(
-                                (pkgs[component_filenames.index]).to_any_ident(),
-                            ))
-                        })
-                        .unwrap_or(err)
-                } else {
-                    err
-                }
-            })?;
+        let digests = find_layers_by_filenames(&filenames_to_resolve_flattened).await?;
 
         // Now all the results can be collected via that same order.
 
@@ -220,6 +200,16 @@ impl RuntimeRepository {
             })
             .zip(digests.into_iter())
         {
+            // A component marker that isn't present in any committed layer of
+            // the runtime stack belongs to a package whose files live in the
+            // runtime's active changes rather than a committed layer. This
+            // happens for the package currently being built: its spec and
+            // component markers are written into /spfs before the build script
+            // runs, but its contents have not been committed to a layer yet.
+            // Treat that as the empty digest (no committed content) rather than
+            // reporting the package as not found, so that, for example, running
+            // `spk info` from inside a build script does not fail.
+            let digest = digest.unwrap_or_else(|| spfs::encoding::EMPTY_DIGEST.into());
             match component_mode {
                 ComponentMode::RealComponent(comp) => {
                     results[component_filenames_index].insert(comp, digest);
@@ -521,10 +511,15 @@ async fn find_layer_by_filename<S: AsRef<str>>(path: S) -> Result<spfs::encoding
 /// It is more efficient to perform this lookup on multiple paths
 /// simultaneously than to do one path at a time.
 ///
-/// The digests are returned in the same order as the elements in `paths`.
+/// The results are returned in the same order as the elements in `paths`. A
+/// path that does not belong to any committed layer of the runtime stack
+/// resolves to `None` rather than an error: a marker file can be absent from
+/// every committed layer when its package is currently being built, in which
+/// case its files live in the runtime's active changes (the overlayfs upper
+/// dir) and not in a committed layer.
 async fn find_layers_by_filenames<S: AsRef<str>>(
     paths: &[S],
-) -> Result<Vec<spfs::encoding::Digest>> {
+) -> Result<Vec<Option<spfs::encoding::Digest>>> {
     if paths.is_empty() {
         return Ok(Vec::new());
     }
@@ -534,8 +529,7 @@ async fn find_layers_by_filenames<S: AsRef<str>>(
 
     let mut paths = paths.iter().map(Some).enumerate().collect::<Vec<_>>();
 
-    let mut results = Vec::new();
-    results.resize_with(paths.len(), Default::default);
+    let mut results: Vec<Option<spfs::encoding::Digest>> = vec![None; paths.len()];
 
     let layers = spfs::resolve_stack_to_layers(&runtime.status.stack, Some(&repo)).await?;
     for layer in layers.iter().rev() {
@@ -553,7 +547,7 @@ async fn find_layers_by_filenames<S: AsRef<str>>(
         for (index, path_opt) in paths.iter_mut() {
             if let Some(path) = path_opt {
                 if manifest.get_path(path).is_some() {
-                    results[*index] = layer.digest()?;
+                    results[*index] = Some(layer.digest()?);
                     *path_opt = None;
                 } else {
                     paths_remaining = true;
@@ -566,16 +560,8 @@ async fn find_layers_by_filenames<S: AsRef<str>>(
         }
     }
 
-    // Some path(s) were not resolved.
-    for (_, path_opt) in paths {
-        if let Some(path) = path_opt {
-            return Err(spfs::Error::UnknownReference(path.as_ref().into()).into());
-        }
-    }
-
-    Err(Error::String(
-        "Internal bug; not all paths resolved but unknown which".to_owned(),
-    ))
+    // Any paths still unresolved are left as `None`; see the doc comment.
+    Ok(results)
 }
 
 /// Return a list of spfs object lists that lead to the given

--- a/crates/spk-storage/src/storage/runtime_test.rs
+++ b/crates/spk-storage/src/storage/runtime_test.rs
@@ -1,0 +1,53 @@
+// Copyright (c) Contributors to the SPK project.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/spkenv/spk
+
+use spfs::encoding::EMPTY_DIGEST;
+use spfstest::spfstest;
+use spk_schema::BuildIdent;
+use spk_schema::foundation::ident_component::Component;
+
+use super::RuntimeRepository;
+use crate::fixtures::spfs_runtime;
+
+/// Regression test: `read_components_bulk` must not fail with
+/// `PackageNotFound` for a package whose component markers exist in the
+/// runtime's active changes but not in any committed layer.
+///
+/// This is the state of the package currently being built: `spk` writes its
+/// spec and component marker files into /spfs before running the build
+/// script, but the package's contents have not been committed to a layer yet.
+/// Previously this caused `current_env` (and therefore `spk info` run from
+/// inside a build script with no arguments) to fail with a "Package not found"
+/// error about the package being built.
+#[spfstest]
+#[tokio::test]
+async fn read_components_bulk_tolerates_package_being_built() {
+    // Provides a clean, editable, isolated runtime with an empty layer stack.
+    let _rt = spfs_runtime().await;
+
+    let ident: BuildIdent = "being-built/1.0.0/3I42H3S6".parse().unwrap();
+
+    // Lay out the package's component marker the way a build does, writing
+    // directly into the live /spfs (the runtime's active changes) without
+    // committing a layer for it.
+    let pkg_dir = std::path::Path::new("/spfs/spk/pkg").join(ident.to_string());
+    spfs::runtime::makedirs_with_perms(&pkg_dir, 0o777)
+        .expect("should be able to create the package metadata dir under /spfs");
+    std::fs::File::create(pkg_dir.join(format!("{}.cmpt", Component::Run)))
+        .expect("should be able to create the run component marker");
+
+    let repo = RuntimeRepository::default();
+    let results = repo
+        .read_components_bulk(&[&ident])
+        .await
+        .expect("reading components for a package being built must not error");
+
+    let empty: spfs::encoding::Digest = EMPTY_DIGEST.into();
+    assert_eq!(
+        results[0].get(&Component::Run),
+        Some(&empty),
+        "the run component of a package being built (not yet committed to a \
+         layer) should resolve to the empty digest rather than erroring"
+    );
+}


### PR DESCRIPTION
## Problem

Running `spk info` with **no arguments** from inside a package's build script fails with a `Package not found` error about the package being built.

This is a **regression** of #385 (fixed in 2022 by #403), which has resurfaced through a different code path — `spk info` was later reworked to a no-solve `print_current_env` flow that the original fix did not cover.

## Root cause

`spk info` (no args) goes through `print_current_env` → `current_env` (`crates/spk-cli/common/src/env.rs`), which scans the runtime repository (`/spfs/spk/pkg`). During a build, spk writes the in-progress package's `spec.yaml` and component marker (`.cmpt`) files there **before** running the build script, so `current_env` picks up the package being built.

It then calls `RuntimeRepository::read_components_bulk`, which resolves each component marker to the committed spfs layer that contains it via `find_layers_by_filenames`. The package being built has **no committed layer yet** — its files live only in the runtime's active changes (the overlayfs upper dir). So `find_layers_by_filenames` returned `UnknownReference`, which `read_components_bulk` mapped to `PackageNotFound(<package being built>)`, and `current_env` propagated it — failing the whole command.

## Fix

- `find_layers_by_filenames` now returns `Vec<Option<Digest>>`, resolving a marker that isn't in any committed layer to `None` instead of erroring.
- `read_components_bulk` treats `None` as the empty digest (no committed content) and the obsolete `UnknownReference → PackageNotFound` mapping is removed.

`read_components_bulk` is only called by `current_env`, so the behavior change is scoped to exactly this case.

## Test

New `#[spfstest]` regression test `read_components_bulk_tolerates_package_being_built` sets up an isolated editable runtime, writes a component marker into the live `/spfs` (uncommitted — exactly the mid-build state), and asserts `read_components_bulk` returns the empty digest rather than erroring. Verified that it **fails without the fix** (`UnknownReference`, formerly surfaced as `PackageNotFound`) and **passes with it**. Existing `walker` runtime tests still pass.

Fixes #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)