### PR TITLE
Fix spk operations on indexed repositories

### DIFF
--- a/crates/spk-cli/cmd-debug/src/cmd_debug.rs
+++ b/crates/spk-cli/cmd-debug/src/cmd_debug.rs
@@ -92,7 +92,7 @@ impl Run for Debug {
 
         for (layer, repo) in source_layers {
             if !local_repo.has_object(layer).await
-                && let storage::RepositoryHandle::SPFS(repo) = repo
+                && let Some(repo) = repo.try_as_spfs()
             {
                 let syncer = spfs::Syncer::new(repo, &local_repo)
                     .with_reporter(spfs::sync::reporter::SyncReporters::console());

--- a/crates/spk-cli/cmd-render/src/cmd_render.rs
+++ b/crates/spk-cli/cmd-render/src/cmd_render.rs
@@ -79,12 +79,18 @@ impl Run for Render {
 
         // Find possible fallback repositories among the solver's repositories.
         let mut fallback_repository_handles = Vec::with_capacity(solver.repositories().len());
-        for repo in solver.repositories().iter().filter(|repo| {
-            repo.is_spfs() && {
-                // XXX: is there a better way to identify the local repo?
-                repo.name() != "local"
+        for repo in solver.repositories().iter() {
+            // Unwrap any wrapper repositories (e.g. indexed ones) so that a
+            // repository is not skipped just because indexes are enabled.
+            // Indexed repositories report the address of the repository they
+            // wrap, so the handle's address is still the spfs one.
+            if repo.try_as_spfs().is_none() {
+                continue;
             }
-        }) {
+            // XXX: is there a better way to identify the local repo?
+            if repo.name() == "local" {
+                continue;
+            }
             // XXX: Can't find a better way to get an owned RepositoryHandle
             // from the &Arc<RepositoryHandle> inside the Solver.
             if let Ok(handle) = spfs::open_repository(repo.address()).await {

--- a/crates/spk-cli/group3/src/cmd_export.rs
+++ b/crates/spk-cli/group3/src/cmd_export.rs
@@ -50,13 +50,9 @@ impl Run for Export {
             .collect::<Vec<_>>();
         let repos = repo_handles
             .iter()
-            .map(|repo| match &**repo {
-                storage::RepositoryHandle::SPFS(repo) => Ok(repo),
-                storage::RepositoryHandle::Mem(_)
-                | storage::RepositoryHandle::Runtime(_)
-                | storage::RepositoryHandle::Indexed(_) => {
-                    bail!("Only spfs repositories are supported")
-                }
+            .map(|repo| match repo.try_as_spfs() {
+                Some(repo) => Ok(repo),
+                None => bail!("Only spfs repositories are supported"),
             })
             .collect::<Result<Vec<_>>>()?;
 

--- a/crates/spk-cli/group3/src/cmd_export_test.rs
+++ b/crates/spk-cli/group3/src/cmd_export_test.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/spkenv/spk
 
+use clap::Parser;
 use rstest::rstest;
 use spfs::prelude::*;
 use spfstest::spfstest;
@@ -10,6 +11,15 @@ use spk_schema::foundation::option_map;
 use spk_schema::{Package, recipe};
 use spk_solve::SolverImpl;
 use spk_storage::fixtures::*;
+use spk_storage::{FlatBufferRepoIndex, RepositoryIndexMut};
+
+use super::{Export, Run};
+
+#[derive(Parser)]
+struct Opt {
+    #[clap(flatten)]
+    export: Export,
+}
 
 fn step_solver() -> SolverImpl {
     SolverImpl::Step(spk_solve::StepSolver::default())
@@ -133,5 +143,89 @@ async fn test_export_works_with_missing_builds(#[case] solver: SolverImpl) {
                 red_spec.ident().build()
             ),
         ]
+    );
+}
+
+#[spfstest]
+#[rstest]
+#[case::step(step_solver())]
+#[case::resolvo(resolvo_solver())]
+#[tokio::test]
+async fn test_export_works_with_an_indexed_repo(#[case] solver: SolverImpl) {
+    // When index use is enabled, the repositories handed to the command are
+    // indexed repositories that wrap the underlying spfs storage. Export must
+    // still find that storage rather than rejecting the repository outright.
+    let rt = spfs_runtime().await;
+
+    let spec = recipe!(
+        {
+            "pkg": "spk-export-index-test/0.0.1",
+            "build": {
+                "auto_host_vars": "None",
+                "script": "touch /spfs/file.txt",
+            },
+        }
+    );
+    rt.tmprepo.publish_recipe(&spec).await.unwrap();
+    let (built_spec, _) = BinaryPackageBuilder::from_recipe_with_solver(spec, solver)
+        .with_source(BuildSource::LocalPath(".".into()))
+        .with_repository(rt.tmprepo.clone())
+        .build_and_publish(&option_map! {}, &*rt.tmprepo)
+        .await
+        .unwrap();
+
+    // Write out an index so that `--index-use enabled` produces an indexed
+    // repository instead of falling back to the plain spfs one.
+    let local_repo = spk_storage::local_repository().await.unwrap();
+    FlatBufferRepoIndex::index_repo(&vec![("local".to_string(), local_repo.into())])
+        .await
+        .unwrap();
+
+    let filename = rt.tmpdir.path().join("indexed-archive.spk");
+    // `--enable-repo local` is needed as well; the local repository is
+    // otherwise added ahead of the code that applies index use.
+    let mut opt = Opt::try_parse_from([
+        "export",
+        "--enable-repo",
+        "local",
+        "--index-use",
+        "enabled",
+        &format!("{}", built_spec.ident().clone().to_version_ident()),
+        filename.to_str().unwrap(),
+    ])
+    .unwrap();
+
+    // Loading an index can quietly fall back to the plain spfs repository, so
+    // check that this test is really exercising the wrapped case.
+    let repos = opt
+        .export
+        .repos
+        .get_repos_for_non_destructive_operation()
+        .await
+        .unwrap();
+    assert!(
+        repos
+            .iter()
+            .any(|(_, repo)| matches!(repo, spk_storage::RepositoryHandle::Indexed(_))),
+        "the export command should have been given an indexed repository"
+    );
+
+    opt.export
+        .run()
+        .await
+        .expect("export should succeed against an indexed repository");
+
+    let mut tags = Vec::new();
+    let mut tarfile = tar::Archive::new(std::fs::File::open(&filename).unwrap());
+    for entry in tarfile.entries().unwrap() {
+        let name = entry.unwrap().path().unwrap().to_string_lossy().to_string();
+        if name.ends_with(".tag") {
+            tags.push(name);
+        }
+    }
+    assert!(
+        tags.iter()
+            .any(|tag| tag.contains("spk/pkg/spk-export-index-test/0.0.1")),
+        "the exported archive should contain the package's build tags, got: {tags:?}"
     );
 }

--- a/crates/spk-exec/src/exec.rs
+++ b/crates/spk-exec/src/exec.rs
@@ -55,8 +55,8 @@ impl ResolvedLayers {
         use spfs::graph::object::Enum;
         try_stream! {
             for resolved_layer in self.0.iter() {
-                let manifest = match &*resolved_layer.repo {
-                    RepositoryHandle::SPFS(repo) => {
+                let manifest = match resolved_layer.repo.try_as_spfs() {
+                    Some(repo) => {
                         let object = repo.read_object(resolved_layer.digest).await?;
                         match object.into_enum() {
                             Enum::Layer(obj) => {
@@ -73,7 +73,7 @@ impl ResolvedLayers {
                             _ => continue,
                         }
                     }
-                    _ => Err(Error::NonSpfsLayerInResolvedLayers)?,
+                    None => Err(Error::NonSpfsLayerInResolvedLayers)?,
                 };
                 let unlock = manifest.to_tracking_manifest();
                 let walker = unlock.walk();
@@ -310,7 +310,7 @@ where
 
     let to_sync_count = to_sync.len();
     for (i, (spec, repo, digest)) in to_sync.into_iter().enumerate() {
-        if let storage::RepositoryHandle::SPFS(repo) = &*repo {
+        if let Some(repo) = repo.try_as_spfs() {
             tracing::info!(
                 "collecting {} of {} {}",
                 i + 1,
@@ -319,6 +319,12 @@ where
             );
             let syncer = spfs::Syncer::new(repo, &local_repo).with_reporter(reporter());
             syncer.sync_digest(digest).await?;
+        } else {
+            tracing::warn!(
+                "cannot localize {} from the {} repository because it has no spfs storage",
+                spec.ident().format_ident(),
+                repo.name(),
+            );
         }
     }
 

--- a/crates/spk-exec/src/exec_test.rs
+++ b/crates/spk-exec/src/exec_test.rs
@@ -5,16 +5,33 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use futures::StreamExt;
 use rstest::{fixture, rstest};
+use spfs::prelude::*;
 use spfstest::spfstest;
 use spk_cmd_build::build_package;
 use spk_schema::foundation::build_ident;
 use spk_schema::foundation::fixtures::*;
-use spk_solve::{DecisionFormatterBuilder, SolverExt, SolverMut, StepSolver};
+use spk_schema::foundation::ident_component::Component;
+use spk_schema::spec;
+use spk_solve::{DecisionFormatterBuilder, RepositoryHandle, SolverExt, SolverMut, StepSolver};
 use spk_solve_macros::pinned_request;
+use spk_storage::IndexedRepository;
 use spk_storage::fixtures::*;
+use tokio::pin;
 
-use crate::solution_to_resolved_runtime_layers;
+use super::{ResolvedLayer, ResolvedLayers};
+use crate::{Error, solution_to_resolved_runtime_layers};
+
+/// Build a single-layer [`ResolvedLayers`] pointing at the given repository.
+fn resolved_layers_for(repo: Arc<RepositoryHandle>, digest: spfs::Digest) -> ResolvedLayers {
+    ResolvedLayers(vec![ResolvedLayer {
+        digest,
+        spec: Arc::new(spec!({"pkg": "my-pkg/1.0.0/3I42H3S6"})),
+        component: Component::Run,
+        repo,
+    }])
+}
 
 #[fixture]
 fn solver() -> StepSolver {
@@ -90,4 +107,93 @@ build:
 
     assert!(environment.get_path("subdir/one.txt").is_some());
     assert!(environment.get_path("subdir/two.txt").is_some());
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_iter_entries_rejects_layers_without_spfs_storage() {
+    let repo = make_repo(RepoKind::Mem).await;
+    let layers = resolved_layers_for(Arc::clone(&repo.repo), empty_layer_digest());
+
+    let entries = layers.iter_entries();
+    pin!(entries);
+
+    assert!(
+        matches!(
+            entries.next().await,
+            Some(Err(Error::NonSpfsLayerInResolvedLayers))
+        ),
+        "a layer from a repository with no spfs storage cannot be read"
+    );
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_iter_entries_reads_through_an_indexed_repo() {
+    // An indexed repository wraps the spfs repository it indexes. Reading the
+    // layer must follow through to that storage instead of treating the layer
+    // as if it were not backed by spfs at all.
+    let repo = make_repo(RepoKind::Spfs).await;
+    let RepositoryHandle::SPFS(spfs_repo) = &*repo.repo else {
+        panic!("the spfs test fixture should produce an spfs repository");
+    };
+
+    let mut contents = spfs::tracking::Manifest::<()>::default();
+    contents.mkdirs("subdir").unwrap();
+    contents.mkfile("subdir/file.txt").unwrap();
+    let manifest = contents.to_graph_manifest();
+    let layer = spfs::graph::Layer::new(manifest.digest().unwrap());
+    spfs_repo.write_object(&manifest).await.unwrap();
+    spfs_repo.write_object(&layer).await.unwrap();
+
+    let indexed = RepositoryHandle::Indexed(
+        IndexedRepository::generate_from_repo(Arc::clone(&repo.repo))
+            .await
+            .unwrap(),
+    );
+
+    let layers = resolved_layers_for(Arc::new(indexed), layer.digest().unwrap());
+
+    let entries = layers.iter_entries();
+    pin!(entries);
+
+    let mut paths = Vec::new();
+    while let Some(entry) = entries.next().await {
+        let (path, _entry, _layer) =
+            entry.expect("entries of an indexed repository should be readable");
+        paths.push(path.to_string());
+    }
+
+    assert!(
+        paths.iter().any(|path| path.ends_with("subdir/file.txt")),
+        "the layer's files should be reachable through the index, got: {paths:?}"
+    );
+}
+
+#[spfstest]
+#[rstest]
+#[tokio::test]
+async fn test_pull_resolved_runtime_layers_warns_for_layers_without_spfs_storage() {
+    let _rt = spfs_runtime().await;
+
+    // A digest that is not in the isolated local repository, so pulling it is
+    // actually attempted.
+    let missing_digest = spfs::Digest::from_bytes(&[0xab; spfs::encoding::DIGEST_SIZE]).unwrap();
+
+    let repo = make_repo(RepoKind::Mem).await;
+    let layers = resolved_layers_for(Arc::clone(&repo.repo), missing_digest);
+
+    // The layer cannot be localized, but that is reported as a warning rather
+    // than failing the whole operation.
+    let stack = crate::pull_resolved_runtime_layers(&layers)
+        .await
+        .expect("layers that cannot be localized should not fail the pull");
+
+    assert_eq!(stack, vec![missing_digest]);
+
+    let local_repo = spk_storage::local_repository().await.unwrap();
+    assert!(
+        !local_repo.has_object(missing_digest).await,
+        "nothing should have been synced from a repository with no spfs storage"
+    );
 }

--- a/crates/spk-storage/src/storage/handle.rs
+++ b/crates/spk-storage/src/storage/handle.rs
@@ -46,6 +46,28 @@ impl RepositoryHandle {
         }
     }
 
+    /// Return the spfs repository that backs this handle, if there is one.
+    ///
+    /// Wrapper repositories, such as [`super::IndexedRepository`], are
+    /// unwrapped so that callers needing spfs-level access (syncing objects,
+    /// rendering, exporting, ...) still find the underlying spfs storage.
+    /// Callers should always prefer this over matching on
+    /// [`RepositoryHandle::SPFS`] directly, otherwise their behavior silently
+    /// changes depending on whether repository indexes happen to be enabled.
+    ///
+    /// Returns `None` for handles with no spfs storage behind them, such as
+    /// in-memory and runtime repositories.
+    pub fn try_as_spfs(&self) -> Option<&super::SpfsRepository> {
+        let mut handle = self;
+        loop {
+            match handle {
+                Self::SPFS(repo) => return Some(repo),
+                Self::Indexed(repo) => handle = repo.underlying_repo_ref(),
+                Self::Mem(_) | Self::Runtime(_) => return None,
+            }
+        }
+    }
+
     pub async fn index_location_path(&self) -> Result<PathBuf> {
         match self {
             Self::SPFS(spfs_repo) => spfs_repo.get_or_create_index_path().await,

--- a/crates/spk-storage/src/storage/handle.rs
+++ b/crates/spk-storage/src/storage/handle.rs
@@ -12,6 +12,10 @@ use super::Repository;
 use super::messaging::listen_to_index_status_until_updated;
 use crate::{Error, Result};
 
+#[cfg(test)]
+#[path = "./handle_test.rs"]
+mod handle_test;
+
 type Handle = dyn Repository<Recipe = SpecRecipe, Package = Spec>;
 
 #[derive(Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Clone, Variantly)]

--- a/crates/spk-storage/src/storage/handle_test.rs
+++ b/crates/spk-storage/src/storage/handle_test.rs
@@ -1,0 +1,89 @@
+// Copyright (c) Contributors to the SPK project.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/spkenv/spk
+
+use std::sync::Arc;
+
+use rstest::rstest;
+
+use super::RepositoryHandle;
+use crate::fixtures::*;
+use crate::{IndexedRepository, Repository};
+
+/// Wrap the given handle in an index, as the repository flags do when index
+/// use is enabled for a repository.
+async fn indexed(repo: Arc<RepositoryHandle>) -> RepositoryHandle {
+    RepositoryHandle::Indexed(
+        IndexedRepository::generate_from_repo(repo)
+            .await
+            .expect("failed to generate an index for the test repository"),
+    )
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_try_as_spfs_returns_spfs_repo() {
+    let repo = make_repo(RepoKind::Spfs).await;
+
+    let spfs_repo = repo
+        .try_as_spfs()
+        .expect("an spfs repository should expose its spfs storage");
+
+    assert_eq!(spfs_repo.address(), repo.address());
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_try_as_spfs_unwraps_indexed_repo() {
+    // An indexed repository wraps another repository, and callers that need
+    // spfs-level access must still be able to reach it. Otherwise operations
+    // like rendering and exporting silently change behavior depending on
+    // whether indexes happen to be enabled.
+    let repo = make_repo(RepoKind::Spfs).await;
+    let expected_address = repo.address().clone();
+
+    let indexed_handle = indexed(Arc::clone(&repo.repo)).await;
+
+    let spfs_repo = indexed_handle
+        .try_as_spfs()
+        .expect("an indexed spfs repository should expose the spfs storage it wraps");
+
+    assert_eq!(*spfs_repo.address(), expected_address);
+}
+
+#[rstest]
+#[case::mem(RepoKind::Mem)]
+#[case::indexed_mem(RepoKind::IndexedMem)]
+#[tokio::test]
+async fn test_try_as_spfs_is_none_without_spfs_storage(#[case] kind: RepoKind) {
+    let repo = make_repo(kind).await;
+
+    assert!(
+        repo.try_as_spfs().is_none(),
+        "{kind:?} has no spfs storage behind it"
+    );
+}
+
+#[rstest]
+fn test_try_as_spfs_is_none_for_runtime_repo() {
+    assert!(
+        RepositoryHandle::new_runtime().try_as_spfs().is_none(),
+        "a runtime repository has no spfs storage behind it"
+    );
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_underlying_repo_ref_borrows_wrapped_handle() {
+    let repo = make_repo(RepoKind::Mem).await;
+    let expected_address = repo.address().clone();
+
+    let RepositoryHandle::Indexed(indexed_repo) = indexed(Arc::clone(&repo.repo)).await else {
+        panic!("expected an indexed repository handle");
+    };
+
+    assert_eq!(
+        *indexed_repo.underlying_repo_ref().address(),
+        expected_address
+    );
+}

--- a/crates/spk-storage/src/storage/indexed.rs
+++ b/crates/spk-storage/src/storage/indexed.rs
@@ -74,6 +74,14 @@ impl IndexedRepository {
         self.wrapped_repo.clone()
     }
 
+    /// Borrow the underlying repo handle this index wraps.
+    ///
+    /// This is a non-cloning counterpart to [`Self::underlying_repo`] for
+    /// callers that only need to inspect the wrapped repository.
+    pub fn underlying_repo_ref(&self) -> &RepositoryHandle {
+        &self.wrapped_repo
+    }
+
     /// Set whether to update the internal index after any publish or
     /// write operation on this repository. This is meant for use by
     /// automated testing. Updating the index continuously may be costly.

--- a/crates/spk-storage/src/walker.rs
+++ b/crates/spk-storage/src/walker.rs
@@ -621,7 +621,7 @@ impl RepoWalker<'_> {
             }
 
             // This only stream only operates on spfs repos
-            let storage::RepositoryHandle::SPFS(spfs_repo) = repo else {
+            let Some(spfs_repo) = repo.try_as_spfs() else {
                 return;
             };
 


### PR DESCRIPTION
`spk render` fails with a bare `Unknown Object` error whenever it runs against
a repository that has indexes enabled and the resolved layers are not already
present in the local repository. This is what our CI hits on every python
feedstock build, since CI enables index use and mounts /spfs with FUSE, so the
CI-isolated local repo starts out effectively empty.

```
$ spk render --index-use enabled python/3.10 /tmp/out
 INFO Rendering into dir: "/tmp/out"
ERROR   × Unknown Object: XV4C3IUYLWLM5I6R3ESWT3DCLRCTYGLOIGVCVPMJOY3ZKB7PKVXQ====

$ spk render --index-use disabled python/3.10 /tmp/out
 INFO collecting 1 of 2 python/3.10.10+r.1/V3Z7WJ3G
 INFO collecting 2 of 2 stdfs/1.1.0/PF6B6TLF
 INFO Render completed: "/tmp/out"
```

When a repository is configured to use an index, the solver hands back a
`RepositoryHandle::Indexed` wrapping the spfs repository rather than a
`RepositoryHandle::SPFS`. Several code paths matched on the `SPFS` variant
directly and so silently did nothing for the wrapped form. In the render case
two of them combine: `pull_resolved_runtime_layers` skips localizing every
layer (note the missing `collecting N of M` lines above), and the render
command filters the remote out of its fallback list, leaving the renderer with
no way to reach the objects at all.

The same oversight also disabled `spk debug` layer syncing, environment
filesystem collection during builds, file walking in `spk ls`/`spk du`, and
made `spk export` reject indexed repositories outright.

## Changes

- Add `RepositoryHandle::try_as_spfs`, which unwraps wrapper repositories to
  reach the underlying spfs storage, and document that callers should prefer
  it over matching `RepositoryHandle::SPFS` so behavior does not silently
  change based on whether indexes are enabled.
- Add `IndexedRepository::underlying_repo_ref` as a non-cloning accessor for
  the wrapped handle.
- Use `try_as_spfs` in `spk render`, `spk debug`, `spk export`, the build-time
  environment filesystem collection, and the storage walker.
- Layers that genuinely cannot be localized now log a warning naming the
  package and repository instead of being dropped without a trace.

