### PR TITLE
Keep solver options in resolvo solutions

### DIFF
--- a/crates/spk-solve/src/solvers/resolvo/mod.rs
+++ b/crates/spk-solve/src/solvers/resolvo/mod.rs
@@ -231,7 +231,13 @@ impl Solver {
         .await
         .map_err(|err| Error::String(format!("Tokio panicked? {err}")))??;
 
-        let mut solution_options = OptionMap::default();
+        // Start from the options the caller configured on this solver (host
+        // options, `--opt` values, the variant being built or tested, ...).
+        // These are not recoverable from the solved packages alone, and the
+        // step solver carries them into its solution, so dropping them here
+        // would make `Solution::to_environment` emit a different set of
+        // `SPK_OPT_*` variables depending on which solver ran.
+        let mut solution_options = self.options.clone();
         for request in &self.requests {
             if let RequestWithOptions::Var(var_req) = request {
                 solution_options.insert(var_req.var.clone(), var_req.value.to_string());

--- a/crates/spk-solve/src/solvers/solver_test.rs
+++ b/crates/spk-solve/src/solvers/solver_test.rs
@@ -380,6 +380,65 @@ async fn test_solver_single_package_no_deps(
 #[case::step(step_solver())]
 #[case::resolvo(resolvo_solver())]
 #[tokio::test]
+async fn test_solver_solution_preserves_solver_options(
+    #[case] mut solver: SolverImpl,
+    #[values(true, false)] use_index: bool,
+) {
+    // Options given to the solver must survive into the solution, because
+    // that is what `Solution::to_environment` turns into the `SPK_OPT_*`
+    // variables that build and test scripts read. A package that declares the
+    // same option as a strong-inheritance var also contributes a namespaced
+    // copy of it, which must not displace the un-namespaced one.
+    let options = option_map! {"abi" => "cp39"};
+    let repo = make_repo!(
+        [
+            {
+                "pkg": "my-pkg/1.0.0",
+                "build": {
+                    "options": [
+                        {
+                            "var": "abi",
+                            "default": "cp39",
+                            "inheritance": "Strong",
+                            "description": "The ABI flavor to use.",
+                        },
+                    ],
+                },
+            },
+        ],
+        options = options.clone()
+    );
+    let repo = wrap_repo_for_test(repo, use_index).await;
+
+    solver.update_options(options);
+    solver.add_repository(Arc::new(repo));
+    solver.add_request(pinned_request!("my-pkg"));
+
+    let solution = run_and_print_resolve_for_tests(&mut solver).await.unwrap();
+
+    assert_eq!(
+        solution.options().get(opt_name!("abi")).map(String::as_str),
+        Some("cp39"),
+        "solver options must be preserved in the solution"
+    );
+
+    let env = solution.to_environment::<std::collections::HashMap<String, String>>(None);
+    assert_eq!(
+        env.get("SPK_OPT_abi").map(String::as_str),
+        Some("cp39"),
+        "solver options must reach the environment as SPK_OPT_*"
+    );
+    assert_eq!(
+        env.get("SPK_PKG_my_pkg_OPT_abi").map(String::as_str),
+        Some("cp39"),
+        "strong inheritance vars must also reach the environment namespaced"
+    );
+}
+
+#[rstest]
+#[case::step(step_solver())]
+#[case::resolvo(resolvo_solver())]
+#[tokio::test]
 async fn test_solver_single_package_simple_deps(
     #[case] mut solver: SolverImpl,
     #[values(true, false)] use_index: bool,


### PR DESCRIPTION
The resolvo solver builds its `Solution`'s option map from scratch, filling it in from the var requests and from the options recorded on each solved package. The options handed to the solver itself are dropped, so host options, `--opt` values, and the variant currently being built or tested never make it into the solution.

That map is what `Solution::to_environment` turns into the `SPK_OPT_*` variables that build and test scripts read, so the same recipe sees a different environment depending on which solver ran.

A package declaring a strong-inheritance `abi` var, built and then tested at `abi: cp99`:

```
$ spk build pkg.spk.yaml
+ echo build SPK_OPT_abi=[cp99]
build SPK_OPT_abi=[cp99]

$ spk test --solver-to-run cli pkg.spk.yaml@install
+ echo test SPK_OPT_abi=[cp99]
test SPK_OPT_abi=[cp99]

$ spk test --solver-to-run resolvo pkg.spk.yaml@install
+ echo test SPK_OPT_abi=[]
test SPK_OPT_abi=[]
```

The build script and the step solver both supply the value, but under resolvo the install test gets an empty string, even though `abi` is listed in the variant being tested. Any test that compares a built artifact against the option it was built with then fails with an empty expected value.

Seed the map with the solver's own options and let the var requests and resolved packages layer on top, matching the order in which the step solver applies them to its state.

A regression test in the shared solver suite asserts that a caller-supplied option survives into the solution and reaches the environment, and runs against both solvers. It fails on the resolvo cases without the fix.

